### PR TITLE
Refine Daily Money Tip voice, layout, and daily rotation

### DIFF
--- a/src/components/DailyTipCard.jsx
+++ b/src/components/DailyTipCard.jsx
@@ -86,10 +86,9 @@ export default function DailyTipCard({ user, isAdmin }) {
   };
 
   const teaserText = useMemo(() => buildTipTeaser(tipState.tip), [tipState.tip]);
-  const helperText = tipState.usingFallback
-    ? "Today's CLARA fallback tip is live while admin tips are inactive."
-    : "Today's tip is coming from the admin panel.";
-  const badgeText = tipState.loading ? "Checking live tip" : tipState.usingFallback ? "Daily rotation" : "Admin live";
+  const fallbackDay = tipState.usingFallback
+    ? (Number.isInteger(tipState.tip?.rotation_index) ? tipState.tip.rotation_index : 0) + 1
+    : null;
   const suggestionEnabled = Boolean(user && !(isAdmin || user?.role === "admin"));
 
   return (
@@ -127,11 +126,8 @@ export default function DailyTipCard({ user, isAdmin }) {
                     <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-white/60">
                       Daily Money Tip
                     </p>
-                    <p className="mt-2 max-w-[16rem] text-2xl font-semibold leading-tight text-white">
+                    <p className="mt-3 max-w-[16rem] text-xl font-semibold leading-snug text-white">
                       {teaserText}
-                    </p>
-                    <p className="mt-3 max-w-[18rem] text-sm leading-relaxed text-white/70">
-                      {helperText}
                     </p>
                   </div>
 
@@ -145,12 +141,9 @@ export default function DailyTipCard({ user, isAdmin }) {
                 </div>
 
                 <div className="mt-auto flex items-end justify-between gap-3 pt-6">
-                  <p className="max-w-[16rem] text-sm leading-relaxed text-white/75">
+                  <p className="max-w-[16rem] text-sm leading-normal text-white/75">
                     Tap to flip and read today's full insight.
                   </p>
-                  <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[11px] font-medium text-white/65">
-                    {badgeText}
-                  </span>
                 </div>
               </div>
             </div>
@@ -167,9 +160,9 @@ export default function DailyTipCard({ user, isAdmin }) {
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
                     <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-emerald-300/80">
-                      {tipState.usingFallback ? "Today's rotation" : "Today's admin tip"}
+                      Daily Money Tip
                     </p>
-                    <p className="mt-2 text-lg font-semibold leading-relaxed text-white">
+                    <p className="mt-3 text-lg font-semibold leading-snug text-white">
                       {tipState.tip?.text}
                     </p>
                   </div>
@@ -193,14 +186,18 @@ export default function DailyTipCard({ user, isAdmin }) {
                       Suggest a money tip
                     </button>
                   ) : (
-                    <p className="text-xs text-white/45">
-                      {tipState.usingFallback ? "Fallback rotation stays active until admin selects a live tip." : "Updated from the admin panel"}
-                    </p>
+                    <div />
                   )}
 
-                  <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[11px] font-medium text-white/65">
-                    Tap to flip back
-                  </span>
+                  {fallbackDay ? (
+                    <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[11px] font-medium text-white/65">
+                      Day {fallbackDay} of 30
+                    </span>
+                  ) : (
+                    <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[11px] font-medium text-white/65">
+                      Tap to flip back
+                    </span>
+                  )}
                 </div>
               </div>
             </div>

--- a/src/lib/daily-tip-utils.js
+++ b/src/lib/daily-tip-utils.js
@@ -1,158 +1,40 @@
 const normalizeString = (value) => String(value ?? "").trim();
 
 export const FALLBACK_MONEY_TIPS = [
-  {
-    id: "fallback-01",
-    title: "Pay yourself first",
-    text: "Move a small amount into savings the moment money comes in. What gets protected first is more likely to grow.",
-  },
-  {
-    id: "fallback-02",
-    title: "Name every peso",
-    text: "A simple spending plan gives each peso a job before the week begins. Clarity usually reduces impulse spending faster than willpower alone.",
-  },
-  {
-    id: "fallback-03",
-    title: "Delay the urge",
-    text: "When you want to buy something unplanned, wait 24 hours. Most urgent purchases get quieter when you give them time.",
-  },
-  {
-    id: "fallback-04",
-    title: "Track the tiny leaks",
-    text: "Small repeat expenses shape your month more than one big splurge. Review subscriptions, snacks, delivery fees, and convenience purchases regularly.",
-  },
-  {
-    id: "fallback-05",
-    title: "Savings is a bill",
-    text: "Treat savings like a required payment, not leftover money. If it sits last in line, it rarely gets funded.",
-  },
-  {
-    id: "fallback-06",
-    title: "Emergency beats perfect",
-    text: "Your first goal is not a perfect portfolio. It is breathing room for emergencies so one bad week does not become a financial setback.",
-  },
-  {
-    id: "fallback-07",
-    title: "Budget with your real life",
-    text: "A budget should match your actual habits, not your ideal self. Honest numbers lead to useful plans.",
-  },
-  {
-    id: "fallback-08",
-    title: "Automate what matters",
-    text: "Automation protects good intentions from busy days. Even a small scheduled transfer can build a strong habit over time.",
-  },
-  {
-    id: "fallback-09",
-    title: "Separate your goals",
-    text: "Keep savings goals in different buckets if you can. Emergency money, tuition, and travel feel more real when each one has its own purpose.",
-  },
-  {
-    id: "fallback-10",
-    title: "Income needs a plan",
-    text: "A raise or side income helps most when you decide in advance where it goes. Extra money disappears quickly without direction.",
-  },
-  {
-    id: "fallback-11",
-    title: "Watch your defaults",
-    text: "Most money habits happen on autopilot. Make the cheapest, healthiest choice the easiest one to repeat.",
-  },
-  {
-    id: "fallback-12",
-    title: "One strong habit wins",
-    text: "You do not need ten money changes at once. One habit done consistently can reshape your month more than a perfect reset.",
-  },
-  {
-    id: "fallback-13",
-    title: "Review before payday",
-    text: "Check your balances and spending before new money arrives. It helps you respond with intention instead of relief-driven spending.",
-  },
-  {
-    id: "fallback-14",
-    title: "Progress loves visibility",
-    text: "Goals feel easier to continue when you can see them moving. Track wins where you will actually notice them.",
-  },
-  {
-    id: "fallback-15",
-    title: "Reduce friction for saving",
-    text: "Make saving one tap away and spending a little slower. Small friction changes can protect you from emotional purchases.",
-  },
-  {
-    id: "fallback-16",
-    title: "Know your floor",
-    text: "Your monthly essentials number is a power metric. Once you know your true baseline, better decisions come faster.",
-  },
-  {
-    id: "fallback-17",
-    title: "Borrow less from tomorrow",
-    text: "Every impulsive purchase steals flexibility from future you. A wise pause today often feels like relief later.",
-  },
-  {
-    id: "fallback-18",
-    title: "Cash flow tells the truth",
-    text: "Income matters, but cash flow decides daily stress. Focus on the gap between what comes in and what goes out.",
-  },
-  {
-    id: "fallback-19",
-    title: "Spend on purpose",
-    text: "Cutting everything is not the goal. Spend intentionally on what matters and protect yourself from the rest.",
-  },
-  {
-    id: "fallback-20",
-    title: "Prepare for irregular costs",
-    text: "Annual fees, school needs, and family events are not surprises if they happen every year. Break them into monthly mini-savings.",
-  },
-  {
-    id: "fallback-21",
-    title: "Debt needs a rhythm",
-    text: "Debt feels lighter when you follow a steady plan. Consistency reduces mental load even before the balance is gone.",
-  },
-  {
-    id: "fallback-22",
-    title: "Build a reset routine",
-    text: "A weekly money check-in prevents chaos from piling up. Ten calm minutes now can save you from stressed decisions later.",
-  },
-  {
-    id: "fallback-23",
-    title: "Protect your calm",
-    text: "Financial peace is built through small repeated boundaries. Saying no to one careless expense is saying yes to stability.",
-  },
-  {
-    id: "fallback-24",
-    title: "Use goals that pull you",
-    text: "Saving is easier when the goal is emotionally clear. Attach each target to a real reason, not just a number.",
-  },
-  {
-    id: "fallback-25",
-    title: "Notice your triggers",
-    text: "Stress, boredom, and celebration all affect spending. When you know your triggers, you can design around them.",
-  },
-  {
-    id: "fallback-26",
-    title: "A plan beats guilt",
-    text: "Guilt may make you pause once, but structure helps you improve for good. Replace self-judgment with a repeatable system.",
-  },
-  {
-    id: "fallback-27",
-    title: "Keep a small buffer",
-    text: "Even a modest wallet buffer can stop short-term emergencies from turning into debt. Stability grows from margins.",
-  },
-  {
-    id: "fallback-28",
-    title: "Make growth visible",
-    text: "Celebrate steady progress, not dramatic moments. Real money confidence usually grows quietly.",
-  },
-  {
-    id: "fallback-29",
-    title: "Good systems feel boring",
-    text: "If your finances feel a little boring, that can be a good sign. Calm, repeatable systems usually beat dramatic rescue cycles.",
-  },
-  {
-    id: "fallback-30",
-    title: "Consistency compounds",
-    text: "A small amount saved or tracked every day can change your future. Tiny disciplined actions become trust in yourself.",
-  },
-].map((tip, index) => ({
-  ...tip,
+  "If you don’t track it, you will lose it.",
+  "Income is important, but behavior is everything.",
+  "You don’t need more money. You need more control.",
+  "Small leaks sink big ships. Watch your daily spending.",
+  "Discipline beats motivation every time.",
+  "What you repeat daily becomes your financial identity.",
+  "Budgeting is not restriction. It’s direction.",
+  "Every peso has a job. Give it one.",
+  "Being broke is temporary. Staying broke is behavioral.",
+  "Your habits decide your future, not your salary.",
+  "Save first. Spend what’s left. Not the other way around.",
+  "If it’s not planned, it’s probably wasted.",
+  "Comfort spending is the silent killer of progress.",
+  "You can’t fix money problems with more spending.",
+  "Awareness is the first step to control.",
+  "Control leads to confidence. Confidence builds wealth.",
+  "Stop guessing. Start tracking.",
+  "Financial freedom starts with honest numbers.",
+  "You don’t rise by chance. You rise by discipline.",
+  "The goal is not to look rich. It’s to be stable.",
+  "Your future self is watching your decisions today.",
+  "Delayed gratification is a financial superpower.",
+  "Most people earn. Few people manage. Be different.",
+  "You don’t need perfection. You need consistency.",
+  "A budget tells your money where to go.",
+  "Spending is easy. Controlling is power.",
+  "The more you ignore your money, the more it controls you.",
+  "Progress starts when excuses stop.",
+  "Track. Adjust. Repeat. That’s the system.",
+  "Control your money or it will control you.",
+].map((text, index) => ({
+  id: `fallback-${String(index + 1).padStart(2, "0")}`,
+  title: "",
+  text,
   audience: "all",
   category: "money",
   source: "fallback",
@@ -220,7 +102,12 @@ export function buildTipTeaser(tip) {
 }
 
 export function getFallbackTipForDate(date = new Date()) {
-  const index = (getDayOfYear(date) - 1 + FALLBACK_MONEY_TIPS.length) % FALLBACK_MONEY_TIPS.length;
+  const dayNumber = Math.floor(
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) / 86400000
+  );
+  const index =
+    ((dayNumber % FALLBACK_MONEY_TIPS.length) + FALLBACK_MONEY_TIPS.length) %
+    FALLBACK_MONEY_TIPS.length;
   return normalizeTip(FALLBACK_MONEY_TIPS[index]);
 }
 


### PR DESCRIPTION
### Motivation
- Make Daily Money Tip feel like a short, premium CLARA punch rather than a backend/system message. 
- Ensure fallback tips are consistent, concise, and follow a predictable daily rotation (no randomness). 
- Standardize front/back card content, sizing, and spacing so tips read in 2–3 lines and feel cohesive across states.

### Description
- Replaced the existing fallback tip set with the exact 30 predefined tip lines (verbatim) and preserved the app's tip object shape by mapping each line into a fallback tip entry in `src/lib/daily-tip-utils.js`.
- Implemented a stable daily rotation in `getFallbackTipForDate` using a deterministic UTC day-based index so Day 1→tip1, Day 2→tip2, … Day 30→tip30 then loop.
- Updated `src/components/DailyTipCard.jsx` to remove system/backend phrasing and weak helper/badge text, tightened typography and spacing (teaser and body sizes), and standardized the card structure so the front shows the label and concise teaser and the back shows the full tip plus an optional `Day X of 30` when the fallback rotation is active.
- Kept suggestion flow intact but removed clutter and replaced technical badges with minimal, premium labels; preserved caching/resolve logic so admin live tips still override fallback when present.

### Testing
- Ran `npx eslint src/components/DailyTipCard.jsx src/lib/daily-tip-utils.js` and the two modified files passed lint checks.
- Ran full `npm run lint` (project-wide) and it failed due to pre-existing lint issues outside this change in `src/pages/Wallets.jsx` and a warning in `src/context/AuthContext.jsx`, which are unrelated to the Daily Tip changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de4e2b3e88832ca2e2e9357d6ffcf2)