### PR TITLE
Validate Supabase Vite env and fail Pages build when missing

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -31,7 +31,29 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Validate Supabase build variables
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+        run: |
+          missing=0
+          if [ -z "$VITE_SUPABASE_URL" ]; then
+            echo "::error::Missing repository secret: VITE_SUPABASE_URL"
+            missing=1
+          fi
+          if [ -z "$VITE_SUPABASE_ANON_KEY" ]; then
+            echo "::error::Missing repository secret: VITE_SUPABASE_ANON_KEY"
+            missing=1
+          fi
+          if [ "$missing" -ne 0 ]; then
+            echo "Configure both secrets in GitHub: Settings -> Secrets and variables -> Actions."
+            exit 1
+          fi
+
       - name: Build
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
         run: npm run build
 
       - name: Setup Pages

--- a/README.md
+++ b/README.md
@@ -11,3 +11,16 @@ A financial behavior and accountability system designed to help users take contr
 git clone https://github.com/YOUR_USERNAME/YOUR_REPO.git
 cd YOUR_REPO
 ```
+
+### 2. Configure environment variables
+Create a `.env` file (for local development) with:
+
+```bash
+VITE_SUPABASE_URL=your_supabase_project_url
+VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+```
+
+For GitHub Pages deployments, set the same keys as **repository secrets**:
+
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_ANON_KEY`


### PR DESCRIPTION
### Motivation
- The production site showed the runtime fallback (`Supabase environment variables are missing`) because Vite build output was produced without `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` available at build time.  
- The goal is to fail fast during CI, prevent a broken `docs/` deploy, and ensure the values are injected into the production build.  

### Description
- Add a pre-build validation step to `.github/workflows/deploy-pages.yml` that checks repository secrets `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` and exits with an error if either is missing.  
- Pass `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` into the `Build` step environment so `npm run build` (Vite) receives those variables during bundling.  
- Update `README.md` to document local `.env` variables and the required GitHub repository secrets `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`.  

### Testing
- Ran `npm run build` locally and the production build completed successfully (Vite output created under `dist/`) with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de70d2ff08832c923ed3fe73e3c9fc)