### PR TITLE
Separate budget reset from edit behavior

### DIFF
--- a/src/lib/clara-budget-cycle-reset.js
+++ b/src/lib/clara-budget-cycle-reset.js
@@ -1,0 +1,119 @@
+function normalizeString(value) {
+  return String(value || "").trim();
+}
+
+function normalizeLower(value) {
+  return normalizeString(value).toLowerCase();
+}
+
+function isBudgetHeader(row = {}) {
+  return (
+    row?.is_plan_header === true ||
+    row?.plan_type === "monthly_budget" ||
+    normalizeLower(row?.category) === "__monthly_budget__" ||
+    normalizeLower(row?.budget_category) === "__monthly_budget__" ||
+    normalizeLower(row?.type) === "monthly_budget"
+  );
+}
+
+function isInactive(row = {}) {
+  const status = normalizeLower(row?.status);
+  return row?.is_active === false || row?.active === false || ["inactive", "archived", "deleted", "closed"].includes(status);
+}
+
+function sameCycle(row = {}, header = {}) {
+  if (!header) return false;
+  const headerMonth = normalizeString(header.month || header.month_key || header.budget_month);
+  const rowMonth = normalizeString(row.month || row.month_key || row.budget_month);
+  const headerCycleStart = normalizeString(header.cycle_start || header.period_start || header.budget_cycle_start);
+  const rowCycleStart = normalizeString(row.cycle_start || row.period_start || row.budget_cycle_start);
+
+  if (headerCycleStart && rowCycleStart && headerCycleStart === rowCycleStart) return true;
+  if (headerMonth && rowMonth && headerMonth === rowMonth) return true;
+  return false;
+}
+
+function archivePatch(now) {
+  return {
+    is_active: false,
+    active: false,
+    status: "archived",
+    archived_at: now,
+    closed_at: now,
+    updated_at: now,
+  };
+}
+
+export async function resetMonthlyBudgetCycle({
+  budgets = [],
+  headerPayload,
+  categoryPayloads = [],
+  addBudget,
+  updateBudget,
+} = {}) {
+  if (typeof addBudget !== "function") {
+    throw new Error("addBudget is required to reset the budget cycle.");
+  }
+
+  if (typeof updateBudget !== "function") {
+    throw new Error("updateBudget is required to archive the old budget cycle.");
+  }
+
+  if (!headerPayload || typeof headerPayload !== "object") {
+    throw new Error("A new budget header payload is required.");
+  }
+
+  const now = new Date().toISOString();
+  const activeHeader = (Array.isArray(budgets) ? budgets : []).find(
+    (budget) => isBudgetHeader(budget) && !isInactive(budget)
+  );
+
+  const activeCategories = (Array.isArray(budgets) ? budgets : []).filter(
+    (budget) => !isBudgetHeader(budget) && !isInactive(budget) && (!activeHeader || sameCycle(budget, activeHeader))
+  );
+
+  if (activeHeader?.id) {
+    await updateBudget(activeHeader.id, archivePatch(now));
+  }
+
+  for (const category of activeCategories) {
+    if (category?.id) {
+      await updateBudget(category.id, archivePatch(now));
+    }
+  }
+
+  const newHeader = await addBudget({
+    ...headerPayload,
+    is_active: true,
+    active: true,
+    status: headerPayload.status || "draft",
+    reset_from_budget_id: activeHeader?.id || null,
+    reset_at: now,
+    created_at: headerPayload.created_at || now,
+    updated_at: now,
+  });
+
+  const newCategories = [];
+  for (const payload of Array.isArray(categoryPayloads) ? categoryPayloads : []) {
+    if (!payload) continue;
+    newCategories.push(
+      await addBudget({
+        ...payload,
+        is_active: true,
+        active: true,
+        status: payload.status || "active",
+        reset_from_budget_id: activeHeader?.id || null,
+        reset_at: now,
+        created_at: payload.created_at || now,
+        updated_at: now,
+      })
+    );
+  }
+
+  return {
+    archivedHeaderId: activeHeader?.id || null,
+    archivedCategoryIds: activeCategories.map((category) => category.id).filter(Boolean),
+    newHeader,
+    newCategories,
+  };
+}

--- a/src/pages/MonthlyBudgetPlan.jsx
+++ b/src/pages/MonthlyBudgetPlan.jsx
@@ -6,6 +6,7 @@ import useFinancialData from "@/hooks/useFinancialData";
 import useDashboardManualExpenseBudgetOptions from "@/components/fresh/main-dashboard/budget/useDashboardManualExpenseBudgetOptions";
 import useDashboardMonthlyBudgetHeader from "@/components/fresh/main-dashboard/budget/useDashboardMonthlyBudgetHeader";
 import useDashboardMonthlyBudgetPlan from "@/components/fresh/main-dashboard/budget/useDashboardMonthlyBudgetPlan";
+import { resetMonthlyBudgetCycle } from "@/lib/clara-budget-cycle-reset";
 import { firstValidNumber, getPHMonthKey, normalizeString } from "@/utils/dashboard/dashboardHelpers";
 
 const fmt = (v = 0) => new Intl.NumberFormat("en-PH", { style: "currency", currency: "PHP", minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(firstValidNumber(v));
@@ -39,6 +40,11 @@ function getCycleWindow(type, start, end) {
   return { start: `${month}-01`, end: "", label: "Monthly" };
 }
 
+function getResetCycleWindow(type, end) {
+  const base = getCycleWindow(type, today(), end);
+  return { ...base, start: today() };
+}
+
 function headerPayload({ amount, done, user, cycle }) {
   const now = new Date().toISOString();
   const title = `${cycle.label} Spending Plan`;
@@ -69,6 +75,16 @@ function categoryPayload({ title, amount, order, user, cycle }) {
   };
 }
 
+function cloneCategoryPayload(item, order, user, cycle) {
+  return categoryPayload({
+    title: item?.title || item?.name || item?.category,
+    amount: firstValidNumber(item?.allocated, item?.allocated_amount, item?.amount),
+    order,
+    user,
+    cycle,
+  });
+}
+
 function Tile({ label, value, accent }) {
   return <div className="rounded-2xl border border-white/8 bg-white/[0.035] px-2 py-2 text-center"><p className={`truncate text-xs font-black ${accent ? "text-emerald-200" : "text-white/82"}`}>{value}</p><p className="mt-1 text-[7px] font-black uppercase tracking-[0.14em] text-white/34">{label}</p></div>;
 }
@@ -80,7 +96,7 @@ export default function MonthlyBudgetPlan() {
   const { budgets = [], expenses = [], addBudget, updateBudget, deleteBudget, refreshData, loading } = useFinancialData(user);
   const { monthlyBudgetHeader, declaredMonthlyBudgetAmount } = useDashboardMonthlyBudgetHeader({ budgets });
   const budgetOptions = useDashboardManualExpenseBudgetOptions({ budgets });
-  const plan = useDashboardMonthlyBudgetPlan({ manualExpenseBudgetOptions: budgetOptions, expenses, declaredMonthlyBudgetAmount });
+  const plan = useDashboardMonthlyBudgetPlan({ manualExpenseBudgetOptions: budgetOptions, expenses, declaredMonthlyBudgetAmount, monthlyBudgetHeader });
   const editId = String(location.state?.editCategoryId || "");
   const editing = useMemo(() => editId ? budgetOptions.find((b) => String(b.id || b.key) === editId) || null : null, [budgetOptions, editId]);
 
@@ -106,7 +122,7 @@ export default function MonthlyBudgetPlan() {
   const canActivate = canFinish && !isActiveBudget;
   const pageBadge = isActiveBudget ? "Active" : canFinish ? "Ready" : "Draft";
   const busy = saving || loading;
-  const helper = isActiveBudget ? "You already have an active budget plan." : canFinish ? "Ready to activate." : declared <= 0 ? "Enter your budget first." : budgetOptions.length === 0 ? "Add at least one category." : `Assign the remaining ${fmt(left)}.`;
+  const helper = isActiveBudget ? "You already have an active budget plan. Editing keeps the same cycle and spending history." : canFinish ? "Ready to activate." : declared <= 0 ? "Enter your budget first." : budgetOptions.length === 0 ? "Add at least one category." : `Assign the remaining ${fmt(left)}.`;
 
   const refresh = async () => { await refreshData?.(); fireBudgetEvents(); };
   const saveHeader = async (done = false) => {
@@ -117,17 +133,46 @@ export default function MonthlyBudgetPlan() {
     return addBudget?.(payload);
   };
 
-  const saveDraft = async () => { try { setSaving(true); setNotice(""); await saveHeader(false); await refresh(); setNotice(isActiveBudget ? "Budget plan updated." : "Budget draft saved."); } catch (e) { setNotice(e?.message || "CLARA could not save this budget yet."); } finally { setSaving(false); } };
+  const saveDraft = async () => { try { setSaving(true); setNotice(""); await saveHeader(false); await refresh(); setNotice(isActiveBudget ? "Budget plan updated. Spending history stayed in this cycle." : "Budget draft saved."); } catch (e) { setNotice(e?.message || "CLARA could not save this budget yet."); } finally { setSaving(false); } };
   const addCategory = async () => {
     const title = normalizeString(categoryName); const amount = firstValidNumber(categoryAmount);
     if (!title) return setNotice("Please enter a category name.");
     if (amount <= 0) return setNotice("Please enter an amount to assign.");
     const current = editing ? Math.max(allocated - firstValidNumber(editing.allocated), 0) : allocated;
     if (declared > 0 && current + amount > declared) return setNotice(`This exceeds your budget. You only have ${fmt(Math.max(declared - current, 0))} left.`);
-    try { setSaving(true); setNotice(""); await saveHeader(false); const payload = categoryPayload({ title, amount, order: editing?.sortOrder ?? budgetOptions.length, user, cycle }); if (editing?.id && typeof updateBudget === "function") await updateBudget(editing.id, payload); else await addBudget?.(payload); setCategoryName(""); setCategoryAmount(""); await refresh(); setNotice(editing ? "Category updated." : "Category added."); if (editing) navigate("/budget-plan", { replace: true }); } catch (e) { setNotice(e?.message || "CLARA could not save this category yet."); } finally { setSaving(false); }
+    try { setSaving(true); setNotice(""); await saveHeader(false); const payload = categoryPayload({ title, amount, order: editing?.sortOrder ?? budgetOptions.length, user, cycle }); if (editing?.id && typeof updateBudget === "function") await updateBudget(editing.id, payload); else await addBudget?.(payload); setCategoryName(""); setCategoryAmount(""); await refresh(); setNotice(editing ? "Category updated. Existing spending stayed counted in this cycle." : "Category added."); if (editing) navigate("/budget-plan", { replace: true }); } catch (e) { setNotice(e?.message || "CLARA could not save this category yet."); } finally { setSaving(false); }
   };
   const removeCategory = async (item) => { if (!item?.id || typeof deleteBudget !== "function") return; try { setSaving(true); await deleteBudget(item.id); await refresh(); setNotice("Category removed."); } catch (e) { setNotice(e?.message || "CLARA could not remove this category yet."); } finally { setSaving(false); } };
-  const finish = async () => { if (isActiveBudget) return setNotice("This budget plan is already active."); if (!canActivate) return setNotice(helper); try { setSaving(true); await saveHeader(true); await refresh(); navigate("/dashboard"); } catch (e) { setNotice(e?.message || "CLARA could not activate this budget yet."); } finally { setSaving(false); } };
+  const finish = async () => { if (isActiveBudget) return setNotice("This budget plan is already active. Use Save Changes to edit, or Reset Cycle to start clean."); if (!canActivate) return setNotice(helper); try { setSaving(true); await saveHeader(true); await refresh(); navigate("/dashboard"); } catch (e) { setNotice(e?.message || "CLARA could not activate this budget yet."); } finally { setSaving(false); } };
+  const resetCycle = async () => {
+    const amount = firstValidNumber(declaredInput, declaredMonthlyBudgetAmount);
+    if (amount <= 0) return setNotice("Please enter your new budget amount first.");
+    if (typeof window !== "undefined") {
+      const ok = window.confirm("Reset budget cycle? Old expenses stay in Transaction Hub, but the Budget Card and Watch Zone start clean from today.");
+      if (!ok) return;
+    }
+    try {
+      setSaving(true);
+      setNotice("");
+      const resetCycleWindow = getResetCycleWindow(cycleType, cycleEnd);
+      const categoryPayloads = budgetOptions.map((item, index) => cloneCategoryPayload(item, index, user, resetCycleWindow));
+      await resetMonthlyBudgetCycle({
+        budgets,
+        headerPayload: headerPayload({ amount, done: categoryPayloads.length > 0, user, cycle: resetCycleWindow }),
+        categoryPayloads,
+        addBudget,
+        updateBudget,
+      });
+      await refresh();
+      setCycleStart(resetCycleWindow.start);
+      setCycleEnd(resetCycleWindow.end || cycleEnd);
+      setNotice("Budget cycle reset. Old spending stayed in Transaction Hub, and the Budget Card now starts clean from today.");
+    } catch (e) {
+      setNotice(e?.message || "CLARA could not reset this budget cycle yet.");
+    } finally {
+      setSaving(false);
+    }
+  };
 
   return <div className="min-h-[100svh] w-full bg-[radial-gradient(circle_at_top_left,rgba(45,212,191,0.18),transparent_30%),radial-gradient(circle_at_bottom_right,rgba(126,34,206,0.24),transparent_38%),linear-gradient(135deg,#04171e,#071430_48%,#170d36)] px-4 pb-[calc(6.5rem+env(safe-area-inset-bottom))] pt-[calc(0.7rem+env(safe-area-inset-top))] text-white">
     <div className="mx-auto flex w-full max-w-[430px] flex-col gap-3">
@@ -140,14 +185,16 @@ export default function MonthlyBudgetPlan() {
             <p className="mt-1 text-sm font-semibold leading-5 text-white/58">Money available this cycle.</p>
           </div>
           <div className="shrink-0 text-right">
-            <p className="text-[10px] font-bold uppercase tracking-[0.14em] text-white/34">Left</p>
+            <p className="text-[10px] font-bold uppercase tracking-[0.14em] text-white/34">Unallocated</p>
             <p className="mt-0.5 text-lg font-black leading-none text-emerald-200">{fmt(left)}</p>
           </div>
         </div>
         <input type="number" min="0" value={declaredInput} onChange={(e)=>setDeclaredInput(e.target.value)} placeholder="25000" className={`${input} mt-3 text-lg font-black tracking-[-0.02em]`}/>
-        <div className="mt-2.5 grid grid-cols-3 gap-1.5"><Tile label="Allocated" value={fmt(allocated)}/><Tile label="Left" value={fmt(left)} accent/><Tile label="Categories" value={budgetOptions.length}/></div>
+        <div className="mt-2.5 grid grid-cols-3 gap-1.5"><Tile label="Allocated" value={fmt(allocated)}/><Tile label="Unallocated" value={fmt(left)} accent/><Tile label="Categories" value={budgetOptions.length}/></div>
         <p className={`${hint} mt-2.5 ${isActiveBudget ? "border-emerald-300/20 bg-emerald-400/10 text-emerald-50" : ""}`}>{helper}</p>
       </section>
+
+      {isActiveBudget ? <section className={`${card} border-amber-300/14 bg-amber-400/[0.055]`}><div className="flex items-start justify-between gap-3"><div><p className="text-sm font-bold text-amber-50">Reset cycle</p><p className="mt-1 text-xs font-semibold leading-5 text-amber-50/60">Starts a fresh budget from today. Old expenses stay in Transaction Hub, but Watch Zone and category spending reset.</p></div><button type="button" onClick={resetCycle} disabled={busy} className="shrink-0 rounded-2xl border border-amber-300/25 bg-amber-400/12 px-3 py-2 text-xs font-black text-amber-50">Reset</button></div></section> : null}
 
       <section className={card}>
         <div className="flex items-center justify-between gap-3">


### PR DESCRIPTION
Adds a dedicated budget cycle reset path. Reset archives the active budget header/categories and creates a new cycle from today while preserving expense, wallet, and emergency fund history. Edit/save keeps the same cycle and spending history.