### PR TITLE
Fix budget reset timestamp boundary

### DIFF
--- a/src/components/fresh/main-dashboard/budget/useDashboardMonthlyBudgetPlan.js
+++ b/src/components/fresh/main-dashboard/budget/useDashboardMonthlyBudgetPlan.js
@@ -9,6 +9,10 @@ import {
   normalizeString,
 } from "@/utils/dashboard/dashboardHelpers";
 
+function hasTime(value) {
+  return /T\d{2}:\d{2}/.test(String(value || ""));
+}
+
 function toDateOnly(value) {
   if (!value) return "";
   const parsed = new Date(value);
@@ -16,26 +20,68 @@ function toDateOnly(value) {
   return parsed.toISOString().slice(0, 10);
 }
 
+function toTime(value) {
+  if (!value) return null;
+  const parsed = new Date(value);
+  const time = parsed.getTime();
+  return Number.isNaN(time) ? null : time;
+}
+
+function getComparableExpenseDate(expense = {}, startValue = "") {
+  if (hasTime(startValue)) {
+    return (
+      expense?.created_at ||
+      expense?.createdAt ||
+      expense?.logged_at ||
+      expense?.spent_at ||
+      expense?.transaction_date ||
+      expense?.transactionDate ||
+      expense?.date ||
+      getTransactionDate(expense)
+    );
+  }
+
+  return getTransactionDate(expense);
+}
+
 function getBudgetCycleRange(monthlyBudgetHeader = null) {
   const fallbackRange = getPHMonthRange();
-  const start = toDateOnly(
+  const rawStart =
+    monthlyBudgetHeader?.reset_start_at ||
     monthlyBudgetHeader?.cycle_start ||
-      monthlyBudgetHeader?.budget_cycle_start ||
-      monthlyBudgetHeader?.period_start ||
-      monthlyBudgetHeader?.range_start ||
-      monthlyBudgetHeader?.tracking_start_date
-  );
-  const end = toDateOnly(
+    monthlyBudgetHeader?.budget_cycle_start ||
+    monthlyBudgetHeader?.period_start ||
+    monthlyBudgetHeader?.range_start ||
+    monthlyBudgetHeader?.tracking_start_date;
+  const rawEnd =
     monthlyBudgetHeader?.cycle_end ||
-      monthlyBudgetHeader?.budget_cycle_end ||
-      monthlyBudgetHeader?.period_end ||
-      monthlyBudgetHeader?.range_end
-  );
+    monthlyBudgetHeader?.budget_cycle_end ||
+    monthlyBudgetHeader?.period_end ||
+    monthlyBudgetHeader?.range_end;
 
   return {
-    start: start || fallbackRange.start,
-    end: end || fallbackRange.end,
+    start: rawStart || fallbackRange.start,
+    end: rawEnd || fallbackRange.end,
+    hasTimestampStart: hasTime(rawStart),
   };
+}
+
+function isInBudgetCycle(expense = {}, monthRange = {}) {
+  if (monthRange.hasTimestampStart) {
+    const startTime = toTime(monthRange.start);
+    const endTime = toTime(monthRange.end);
+    const expenseTime = toTime(getComparableExpenseDate(expense, monthRange.start));
+
+    if (startTime !== null && (expenseTime === null || expenseTime < startTime)) return false;
+    if (endTime !== null && expenseTime !== null && expenseTime > endTime) return false;
+    return true;
+  }
+
+  return isInPHRange(
+    getComparableExpenseDate(expense, monthRange.start),
+    toDateOnly(monthRange.start),
+    toDateOnly(monthRange.end)
+  );
 }
 
 function getExpenseBudgetCategory(expense = {}) {
@@ -88,8 +134,7 @@ export default function useDashboardMonthlyBudgetPlan({
       ? manualExpenseBudgetOptions
       : [];
     const safeExpenses = Array.isArray(expenses) ? expenses : [];
-    const inActiveRange = (expense) =>
-      isInPHRange(getTransactionDate(expense), monthRange.start, monthRange.end);
+    const inActiveRange = (expense) => isInBudgetCycle(expense, monthRange);
 
     const categories = safeBudgetOptions.map((item) => {
       const itemId = normalizeString(item?.id || item?.key || "");

--- a/src/lib/clara-budget-snapshot.js
+++ b/src/lib/clara-budget-snapshot.js
@@ -24,6 +24,10 @@ function lower(value = "") {
   return String(value || "").toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
 }
 
+function hasTime(value) {
+  return /T\d{2}:\d{2}/.test(String(value || ""));
+}
+
 function getPath(source, path) {
   return String(path || "").split(".").reduce((current, key) => current?.[key], source);
 }
@@ -55,38 +59,57 @@ function toDateOnly(value) {
   return parsed.toISOString().slice(0, 10);
 }
 
+function toTime(value) {
+  if (!value) return null;
+  const parsed = new Date(value);
+  const time = parsed.getTime();
+  return Number.isNaN(time) ? null : time;
+}
+
 function currentMonthRange() {
   const now = new Date();
   const year = now.getFullYear();
   const month = now.getMonth();
   const start = new Date(year, month, 1).toISOString().slice(0, 10);
   const end = new Date(year, month + 1, 0).toISOString().slice(0, 10);
-  return { start, end };
+  return { start, end, hasTimestampStart: false };
 }
 
 function getCycleRange(header = {}) {
   const fallback = currentMonthRange();
+  const start = header?.reset_start_at || header?.cycle_start || header?.budget_cycle_start || header?.period_start || header?.range_start || header?.tracking_start_date;
+  const end = header?.cycle_end || header?.budget_cycle_end || header?.period_end || header?.range_end;
   return {
-    start: toDateOnly(header?.cycle_start || header?.budget_cycle_start || header?.period_start || header?.range_start || header?.tracking_start_date) || fallback.start,
-    end: toDateOnly(header?.cycle_end || header?.budget_cycle_end || header?.period_end || header?.range_end) || fallback.end,
+    start: start || fallback.start,
+    end: end || fallback.end,
+    hasTimestampStart: hasTime(start),
   };
 }
 
-function isInRange(dateValue, range) {
+function getExpenseComparableDate(expense = {}, range = {}) {
+  if (range?.hasTimestampStart) {
+    return textFrom(expense.created_at, expense.createdAt, expense.logged_at, expense.spent_at, expense.transaction_date, expense.transactionDate, expense.date);
+  }
+  return textFrom(expense.date, expense.created_at, expense.createdAt, expense.spent_at, expense.logged_at, expense.transaction_date, expense.transactionDate);
+}
+
+function isInRange(expense = {}, range = {}) {
+  const dateValue = getExpenseComparableDate(expense, range);
+
+  if (range?.hasTimestampStart) {
+    const expenseTime = toTime(dateValue);
+    const startTime = toTime(range.start);
+    const endTime = toTime(range.end);
+    if (startTime !== null && (expenseTime === null || expenseTime < startTime)) return false;
+    if (endTime !== null && expenseTime !== null && expenseTime > endTime) return false;
+    return true;
+  }
+
   const date = toDateOnly(dateValue);
   if (!date) return true;
-  if (range?.start && date < range.start) return false;
-  if (range?.end && date > range.end) return false;
+  if (range?.start && date < toDateOnly(range.start)) return false;
+  if (range?.end && date > toDateOnly(range.end)) return false;
   return true;
-}
-
-function isBudgetHeader(row = {}) {
-  const category = String(row?.category || row?.budget_category || "").trim();
-  return row?.is_plan_header === true || row?.plan_type === "monthly_budget" || category === "__monthly_budget__" || lower(row?.type) === "monthly budget" || lower(category) === "monthly budget" || lower(category) === "monthly spending plan";
-}
-
-function isInactive(row = {}) {
-  return row?.is_active === false || row?.active === false || ["inactive", "archived", "deleted", "closed"].includes(lower(row?.status));
 }
 
 function expenseDate(expense = {}) {
@@ -128,6 +151,15 @@ function categoryId(row = {}) {
 
 function categoryAllocated(row = {}) {
   return numberFrom(row.allocated, row.allocated_amount, row.amount, row.limit, row.total, row.total_budget, row.budget_amount, row.budget) ?? 0;
+}
+
+function isBudgetHeader(row = {}) {
+  const category = String(row?.category || row?.budget_category || "").trim();
+  return row?.is_plan_header === true || row?.plan_type === "monthly_budget" || category === "__monthly_budget__" || lower(row?.type) === "monthly budget" || lower(category) === "monthly budget" || lower(category) === "monthly spending plan";
+}
+
+function isInactive(row = {}) {
+  return row?.is_active === false || row?.active === false || ["inactive", "archived", "deleted", "closed"].includes(lower(row?.status));
 }
 
 function normalizeCategory(row = {}, activeExpenses = []) {
@@ -189,7 +221,7 @@ export function buildClaraBudgetSnapshot(context = {}) {
   const plan = source.monthlyBudgetPlan || source.budgetPlan || source.monthly_budget_plan || {};
   const range = plan.monthRange || getCycleRange(getHeader(source));
   const expenses = firstArray(source, ["expenses", "monthlyExpensesList", "recentExpenses", "finance.expenses", "dashboardSnapshot.expenses"]);
-  const activeExpenses = expenses.filter((expense) => isInRange(expenseDate(expense), range));
+  const activeExpenses = expenses.filter((expense) => isInRange(expense, range));
   const categories = getRawCategories(source).filter((row) => row && !isBudgetHeader(row) && !isInactive(row)).map((row) => normalizeCategory(row, activeExpenses));
   const allocatedBudget = firstNumber(plan, ["allocated", "allocated_total", "totalAllocated"]) ?? firstNumber(source, ["budgetAllocated", "totalBudgetAllocated", "budgetSummary.allocatedBudget"]) ?? sum(categories.map((category) => category.allocated));
   const declaredBudget = getDeclaredBudget(source, allocatedBudget);

--- a/src/pages/MonthlyBudgetPlan.jsx
+++ b/src/pages/MonthlyBudgetPlan.jsx
@@ -11,7 +11,8 @@ import { firstValidNumber, getPHMonthKey, normalizeString } from "@/utils/dashbo
 
 const fmt = (v = 0) => new Intl.NumberFormat("en-PH", { style: "currency", currency: "PHP", minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(firstValidNumber(v));
 const today = () => new Date().toISOString().slice(0, 10);
-const addDays = (date, days) => { const d = new Date(`${date}T00:00:00`); d.setDate(d.getDate() + days); return d.toISOString().slice(0, 10); };
+const nowIso = () => new Date().toISOString();
+const addDays = (date, days) => { const d = new Date(`${String(date || today()).slice(0, 10)}T00:00:00`); d.setDate(d.getDate() + days); return d.toISOString().slice(0, 10); };
 const card = "rounded-[26px] border border-cyan-100/12 bg-white/[0.05] p-3.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.07),0_14px_36px_rgba(0,0,0,0.16)] backdrop-blur-2xl";
 const input = "w-full rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-[15px] font-semibold text-white outline-none placeholder:text-white/35 focus:border-emerald-300/35";
 const btn = "rounded-2xl px-4 py-3 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-50";
@@ -35,14 +36,15 @@ function getCycleWindow(type, start, end) {
   const safeStart = start || today();
   if (safeType === "weekly") return { start: safeStart, end: addDays(safeStart, 6), label: "Weekly" };
   if (safeType === "biweekly") return { start: safeStart, end: addDays(safeStart, 13), label: "Bi-weekly" };
-  if (safeType === "custom") return { start: safeStart, end: end || safeStart, label: "Custom" };
+  if (safeType === "custom") return { start: safeStart, end: end || String(safeStart).slice(0, 10), label: "Custom" };
   const month = getPHMonthKey();
   return { start: `${month}-01`, end: "", label: "Monthly" };
 }
 
 function getResetCycleWindow(type, end) {
+  const resetStart = nowIso();
   const base = getCycleWindow(type, today(), end);
-  return { ...base, start: today() };
+  return { ...base, start: resetStart, reset_start_at: resetStart };
 }
 
 function headerPayload({ amount, done, user, cycle }) {
@@ -54,6 +56,7 @@ function headerPayload({ amount, done, user, cycle }) {
     type: "monthly_budget", plan_type: "monthly_budget", is_plan_header: true,
     budget_cycle: cycle.label.toLowerCase(), cycle_type: cycle.label.toLowerCase(),
     cycle_start: cycle.start, cycle_end: cycle.end, period_start: cycle.start, period_end: cycle.end,
+    reset_start_at: cycle.reset_start_at || null,
     declared_amount: amount, declared_budget: amount, monthly_budget_amount: amount,
     total_declared_budget: amount, total_budget: amount, amount,
     is_complete: Boolean(done), status: done ? "active" : "draft", is_active: true, active: true,
@@ -70,6 +73,7 @@ function categoryPayload({ title, amount, order, user, cycle }) {
     budget_amount: amount, total_budget: amount, amount, sort_order: order, display_order: order, position: order,
     budget_cycle: cycle.label.toLowerCase(), cycle_type: cycle.label.toLowerCase(),
     cycle_start: cycle.start, cycle_end: cycle.end, period_start: cycle.start, period_end: cycle.end,
+    reset_start_at: cycle.reset_start_at || null,
     is_active: true, active: true, status: "active", updated_at: now,
     created_by: user?.email || null, email: user?.email || null, user_id: user?.id || null,
   };
@@ -148,7 +152,7 @@ export default function MonthlyBudgetPlan() {
     const amount = firstValidNumber(declaredInput, declaredMonthlyBudgetAmount);
     if (amount <= 0) return setNotice("Please enter your new budget amount first.");
     if (typeof window !== "undefined") {
-      const ok = window.confirm("Reset budget cycle? Old expenses stay in Transaction Hub, but the Budget Card and Watch Zone start clean from today.");
+      const ok = window.confirm("Reset budget cycle? Old expenses stay in Transaction Hub, but the Budget Card and Watch Zone start clean from this exact moment.");
       if (!ok) return;
     }
     try {
@@ -166,7 +170,7 @@ export default function MonthlyBudgetPlan() {
       await refresh();
       setCycleStart(resetCycleWindow.start);
       setCycleEnd(resetCycleWindow.end || cycleEnd);
-      setNotice("Budget cycle reset. Old spending stayed in Transaction Hub, and the Budget Card now starts clean from today.");
+      setNotice("Budget cycle reset. Old spending stayed in Transaction Hub, and the Budget Card now starts clean from this exact moment.");
     } catch (e) {
       setNotice(e?.message || "CLARA could not reset this budget cycle yet.");
     } finally {
@@ -194,14 +198,14 @@ export default function MonthlyBudgetPlan() {
         <p className={`${hint} mt-2.5 ${isActiveBudget ? "border-emerald-300/20 bg-emerald-400/10 text-emerald-50" : ""}`}>{helper}</p>
       </section>
 
-      {isActiveBudget ? <section className={`${card} border-amber-300/14 bg-amber-400/[0.055]`}><div className="flex items-start justify-between gap-3"><div><p className="text-sm font-bold text-amber-50">Reset cycle</p><p className="mt-1 text-xs font-semibold leading-5 text-amber-50/60">Starts a fresh budget from today. Old expenses stay in Transaction Hub, but Watch Zone and category spending reset.</p></div><button type="button" onClick={resetCycle} disabled={busy} className="shrink-0 rounded-2xl border border-amber-300/25 bg-amber-400/12 px-3 py-2 text-xs font-black text-amber-50">Reset</button></div></section> : null}
+      {isActiveBudget ? <section className={`${card} border-amber-300/14 bg-amber-400/[0.055]`}><div className="flex items-start justify-between gap-3"><div><p className="text-sm font-bold text-amber-50">Reset cycle</p><p className="mt-1 text-xs font-semibold leading-5 text-amber-50/60">Starts a fresh budget from now. Old expenses stay in Transaction Hub, but Watch Zone and category spending reset.</p></div><button type="button" onClick={resetCycle} disabled={busy} className="shrink-0 rounded-2xl border border-amber-300/25 bg-amber-400/12 px-3 py-2 text-xs font-black text-amber-50">Reset</button></div></section> : null}
 
       <section className={card}>
         <div className="flex items-center justify-between gap-3">
           <p className="text-[10px] font-black uppercase tracking-[0.18em] text-cyan-100/50">Cycle</p>
-          <p className="text-[11px] font-semibold text-white/42">{cycle.start}{cycle.end ? ` → ${cycle.end}` : ""}</p>
+          <p className="text-[11px] font-semibold text-white/42">{String(cycle.start || "").slice(0, 10)}{cycle.end ? ` → ${cycle.end}` : ""}</p>
         </div>
-        <div className="mt-3 grid grid-cols-4 gap-1.5">{[["weekly","Weekly"],["biweekly","2 Weeks"],["monthly","Monthly"],["custom","Custom"]].map(([key,label])=><button key={key} type="button" onClick={()=>setCycleType(key)} className={`rounded-2xl border px-2 py-2 text-[11px] font-bold ${cycleType===key?"border-emerald-300/30 bg-emerald-400/15 text-emerald-100":"border-white/8 bg-white/[0.035] text-white/50"}`}>{label}</button>)}</div>{cycleType!=="monthly"?<div className="mt-2.5 grid grid-cols-2 gap-2"><input type="date" value={cycleStart} onChange={(e)=>setCycleStart(e.target.value)} className={input}/>{cycleType==="custom"?<input type="date" value={cycleEnd} onChange={(e)=>setCycleEnd(e.target.value)} className={input}/>:<div className="rounded-2xl border border-white/8 bg-black/12 px-4 py-3 text-sm font-semibold text-white/55">Ends {cycle.end}</div>}</div>:null}</section>
+        <div className="mt-3 grid grid-cols-4 gap-1.5">{[["weekly","Weekly"],["biweekly","2 Weeks"],["monthly","Monthly"],["custom","Custom"]].map(([key,label])=><button key={key} type="button" onClick={()=>setCycleType(key)} className={`rounded-2xl border px-2 py-2 text-[11px] font-bold ${cycleType===key?"border-emerald-300/30 bg-emerald-400/15 text-emerald-100":"border-white/8 bg-white/[0.035] text-white/50"}`}>{label}</button>)}</div>{cycleType!=="monthly"?<div className="mt-2.5 grid grid-cols-2 gap-2"><input type="date" value={String(cycleStart || "").slice(0,10)} onChange={(e)=>setCycleStart(e.target.value)} className={input}/>{cycleType==="custom"?<input type="date" value={cycleEnd} onChange={(e)=>setCycleEnd(e.target.value)} className={input}/>:<div className="rounded-2xl border border-white/8 bg-black/12 px-4 py-3 text-sm font-semibold text-white/55">Ends {cycle.end}</div>}</div>:null}</section>
 
       <section className={card}><div className="mb-3 flex items-start justify-between gap-3"><div><p className="text-sm font-bold">{editing ? "Edit category" : "Add category"}</p><p className="mt-0.5 text-xs leading-5 text-white/48">Food, bills, rent, transport, savings.</p></div>{editing?<button type="button" onClick={()=>navigate("/budget-plan",{replace:true})} className="rounded-full border border-white/8 bg-white/[0.045] px-3 py-1 text-xs font-semibold text-white/58">Cancel</button>:null}</div><div className="space-y-2.5"><input type="text" value={categoryName} onChange={(e)=>{setCategoryName(e.target.value);setNotice("");}} placeholder="Example: Food" className={input}/><input type="number" min="0" value={categoryAmount} onChange={(e)=>{setCategoryAmount(e.target.value);setNotice("");}} placeholder="Amount to assign" className={input}/><button type="button" onClick={addCategory} disabled={busy} className={`${btn} flex w-full items-center justify-center gap-2 border border-emerald-300/25 bg-emerald-500/15 text-emerald-50`}><Plus className="h-4 w-4"/>{editing?"Update Category":"Add Category"}</button></div></section>
       {notice?<div className="rounded-2xl border border-amber-300/20 bg-amber-400/10 px-4 py-3 text-sm font-semibold text-amber-50">{notice}</div>:null}


### PR DESCRIPTION
Fixes reset still counting old same-day spending by saving an exact reset timestamp and making dashboard budget math plus CLARA budget snapshot honor timestamp-based cycle starts.