### PR TITLE
Clean budget data during reset

### DIFF
--- a/src/pages/MonthlyBudgetPlan.jsx
+++ b/src/pages/MonthlyBudgetPlan.jsx
@@ -142,15 +142,18 @@ export default function MonthlyBudgetPlan() {
     const amount = firstValidNumber(declaredInput, declaredMonthlyBudgetAmount);
     if (amount <= 0) return setNotice("Please enter your new budget amount first.");
     if (typeof window !== "undefined") {
-      const ok = window.confirm("Reset budget cycle? Old expenses stay in Transaction Hub, but the Budget Card, Watch Zone, and categories start clean from this exact moment.");
+      const ok = window.confirm("Reset budget cycle? Transaction history stays, but the Budget Card, Watch Zone, and categories start clean from this exact moment.");
       if (!ok) return;
     }
     try {
       setSaving(true);
       setNotice("");
       const resetCycleWindow = getResetCycleWindow(cycleType, cycleEnd);
+      for (const row of budgets.filter((item) => item?.id)) {
+        await deleteBudget(row.id);
+      }
       await resetMonthlyBudgetCycle({
-        budgets,
+        budgets: [],
         headerPayload: headerPayload({ amount, done: false, user, cycle: resetCycleWindow }),
         categoryPayloads: [],
         addBudget,
@@ -162,7 +165,7 @@ export default function MonthlyBudgetPlan() {
       setCategoryName("");
       setCategoryAmount("");
       navigate("/budget-plan", { replace: true });
-      setNotice("Budget cycle reset. Old spending stayed in Transaction Hub, and the Budget Card, Watch Zone, and categories now start clean.");
+      setNotice("Budget cycle reset. Transaction history stayed, and the Budget Card, Watch Zone, and categories now start clean.");
     } catch (e) {
       setNotice(e?.message || "CLARA could not reset this budget cycle yet.");
     } finally {
@@ -190,7 +193,7 @@ export default function MonthlyBudgetPlan() {
         <p className={`${hint} mt-2.5 ${isActiveBudget ? "border-emerald-300/20 bg-emerald-400/10 text-emerald-50" : ""}`}>{helper}</p>
       </section>
 
-      {isActiveBudget ? <section className={`${card} border-amber-300/14 bg-amber-400/[0.055]`}><div className="flex items-start justify-between gap-3"><div><p className="text-sm font-bold text-amber-50">Reset cycle</p><p className="mt-1 text-xs font-semibold leading-5 text-amber-50/60">Starts a fresh budget from now. Old expenses stay in Transaction Hub, but Watch Zone and categories reset.</p></div><button type="button" onClick={resetCycle} disabled={busy} className="shrink-0 rounded-2xl border border-amber-300/25 bg-amber-400/12 px-3 py-2 text-xs font-black text-amber-50">Reset</button></div></section> : null}
+      {isActiveBudget ? <section className={`${card} border-amber-300/14 bg-amber-400/[0.055]`}><div className="flex items-start justify-between gap-3"><div><p className="text-sm font-bold text-amber-50">Reset cycle</p><p className="mt-1 text-xs font-semibold leading-5 text-amber-50/60">Starts a fresh budget from now. Transaction history stays, but Watch Zone and categories reset.</p></div><button type="button" onClick={resetCycle} disabled={busy} className="shrink-0 rounded-2xl border border-amber-300/25 bg-amber-400/12 px-3 py-2 text-xs font-black text-amber-50">Reset</button></div></section> : null}
 
       <section className={card}>
         <div className="flex items-center justify-between gap-3">


### PR DESCRIPTION
Updates the Budget Reset flow so existing budget rows are cleared before the fresh budget header is created. Transaction history, wallet data, and emergency fund remain unchanged.