### PR TITLE
Use popup-only locks for Daily Money Tip and Learning Hub

### DIFF
--- a/src/components/fresh/main-dashboard/daily-tip/ui/DailyTipCard.jsx
+++ b/src/components/fresh/main-dashboard/daily-tip/ui/DailyTipCard.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import useDailyTip from "../logic/useDailyTip";
 import { exitYoungProfessionalCurrentState } from "@/lib/clara-young-professional-current-state";
-import CommittedFeatureLock from "@/components/fresh/main-dashboard/program-access/CommittedFeatureLock";
 
 const ACTIVE_CURRENT_STATE_KEY = "CLARA_ACTIVE_CURRENT_STATE_V1";
 
@@ -42,6 +41,11 @@ export default function DailyTipCard({
   }, []);
 
   const handleFlip = () => {
+    if (!hasCommittedAccess) {
+      onOpenCommitmentBooklet?.();
+      return;
+    }
+
     setIsFlipping(true);
     setFlipped((current) => !current);
     if (!hasSeenToday) markSeenToday();
@@ -97,19 +101,6 @@ export default function DailyTipCard({
             </div>
           </div>
         </div>
-      </div>
-    );
-  }
-
-  if (!hasCommittedAccess) {
-    return (
-      <div className="clara-budget-focus-shift clara-budget-focus-tip px-3 mt-1.5">
-        <CommittedFeatureLock
-          message="Tap to unlock Daily Money Tip"
-          ariaLabel="Open the Committed Version to unlock Daily Money Tip"
-          onClick={onOpenCommitmentBooklet}
-          className="h-[150px]"
-        />
       </div>
     );
   }

--- a/src/components/fresh/main-dashboard/learning-hub/ui/LearningHubCarousel.jsx
+++ b/src/components/fresh/main-dashboard/learning-hub/ui/LearningHubCarousel.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { BookOpen, ChevronDown } from "lucide-react";
 import DailyTipCard from "../../daily-tip";
-import CommittedFeatureLock from "../../program-access/CommittedFeatureLock";
 import LearningMaterialCard from "./LearningMaterialCard";
 
 const AUTO_SCROLL_DELAY = 4200;
@@ -109,23 +108,23 @@ export default function LearningHubCarousel({
     toggleExpanded();
   };
 
-  const handleHeaderTouchStart = (e) => {
+  const handleHeaderTouchStart = (event) => {
     if (isLocked) return;
 
     headerSwipeHandledRef.current = false;
-    setHeaderTouchStartY(e.touches[0].clientY);
+    setHeaderTouchStartY(event.touches[0].clientY);
   };
 
-  const handleHeaderTouchEnd = (e) => {
+  const handleHeaderTouchEnd = (event) => {
     if (isLocked || headerTouchStartY === null) return;
 
-    const diff = e.changedTouches[0].clientY - headerTouchStartY;
+    const diff = event.changedTouches[0].clientY - headerTouchStartY;
     const didSwipe = Math.abs(diff) > SWIPE_THRESHOLD;
 
     if (didSwipe) {
       headerSwipeHandledRef.current = true;
-      e.preventDefault();
-      e.stopPropagation();
+      event.preventDefault();
+      event.stopPropagation();
 
       setIsExpanded(diff > 0);
 
@@ -137,17 +136,17 @@ export default function LearningHubCarousel({
     setHeaderTouchStartY(null);
   };
 
-  const handleTouchStart = (e) => {
+  const handleTouchStart = (event) => {
     if (isLocked) return;
 
     pauseCarousel();
-    setTouchStartX(e.touches[0].clientX);
+    setTouchStartX(event.touches[0].clientX);
   };
 
-  const handleTouchEnd = (e) => {
+  const handleTouchEnd = (event) => {
     if (isLocked || touchStartX === null) return;
 
-    const diff = touchStartX - e.changedTouches[0].clientX;
+    const diff = touchStartX - event.changedTouches[0].clientX;
 
     if (Math.abs(diff) > 50) {
       if (diff > 0) {
@@ -229,86 +228,75 @@ export default function LearningHubCarousel({
         />
       </button>
 
-      {isLocked ? (
-        <div className="mt-3 px-2 pb-1">
-          <CommittedFeatureLock
-            message="Tap to unlock Learning Hub"
-            ariaLabel="Open the Committed Version to unlock Learning Hub"
-            onClick={onOpenCommitmentBooklet}
-            className="h-[116px]"
-          />
-        </div>
-      ) : (
-        <div
-          data-learning-hub-expanded={isExpanded ? "true" : "false"}
-          className="clara-learning-hub-expanded clara-learning-motion grid transition-[grid-template-rows,opacity,margin] duration-500 ease-out"
-          style={{
-            gridTemplateRows: isExpanded ? `${LEARNING_HUB_STAGE_HEIGHT}px` : "0px",
-            opacity: isExpanded ? 1 : 0,
-            marginTop: isExpanded ? "0.75rem" : "0rem",
-          }}
-        >
-          <div className="clara-learning-hub-clip min-h-0 overflow-visible">
-            <div
-              className="clara-learning-hub-stage relative flex w-full items-center justify-center overflow-hidden rounded-[30px] border border-cyan-100/10 bg-[radial-gradient(circle_at_-18%_-28%,rgba(20,184,166,0.22),transparent_48%),radial-gradient(circle_at_78%_118%,rgba(99,102,241,0.18),transparent_58%),linear-gradient(135deg,rgba(6,48,66,0.76),rgba(7,20,48,0.82)_48%,rgba(37,13,74,0.76))]"
-              style={{
-                height: `${LEARNING_HUB_STAGE_HEIGHT}px`,
-                minHeight: `${LEARNING_HUB_STAGE_HEIGHT}px`,
-                perspective: "1300px",
-                transformStyle: "preserve-3d",
-              }}
-              onMouseEnter={pauseCarousel}
-              onMouseLeave={resumeCarouselSoon}
-              onTouchStart={handleTouchStart}
-              onTouchEnd={handleTouchEnd}
-            >
-              <div className="pointer-events-none absolute -left-[112px] -top-[122px] h-[220px] w-[220px] rounded-full bg-cyan-300/[0.08]" />
-              <div className="pointer-events-none absolute bottom-[-150px] left-[39%] h-[250px] w-[250px] rounded-full bg-blue-400/[0.10]" />
-              <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-white/[0.055] via-transparent to-black/24" />
-              <div className="pointer-events-none absolute inset-0 rounded-[30px] ring-1 ring-inset ring-white/10" />
+      <div
+        data-learning-hub-expanded={isExpanded ? "true" : "false"}
+        className="clara-learning-hub-expanded clara-learning-motion grid transition-[grid-template-rows,opacity,margin] duration-500 ease-out"
+        style={{
+          gridTemplateRows: isExpanded ? `${LEARNING_HUB_STAGE_HEIGHT}px` : "0px",
+          opacity: isExpanded ? 1 : 0,
+          marginTop: isExpanded ? "0.75rem" : "0rem",
+        }}
+      >
+        <div className="clara-learning-hub-clip min-h-0 overflow-visible">
+          <div
+            className="clara-learning-hub-stage relative flex w-full items-center justify-center overflow-hidden rounded-[30px] border border-cyan-100/10 bg-[radial-gradient(circle_at_-18%_-28%,rgba(20,184,166,0.22),transparent_48%),radial-gradient(circle_at_78%_118%,rgba(99,102,241,0.18),transparent_58%),linear-gradient(135deg,rgba(6,48,66,0.76),rgba(7,20,48,0.82)_48%,rgba(37,13,74,0.76))]"
+            style={{
+              height: `${LEARNING_HUB_STAGE_HEIGHT}px`,
+              minHeight: `${LEARNING_HUB_STAGE_HEIGHT}px`,
+              perspective: "1300px",
+              transformStyle: "preserve-3d",
+            }}
+            onMouseEnter={pauseCarousel}
+            onMouseLeave={resumeCarouselSoon}
+            onTouchStart={handleTouchStart}
+            onTouchEnd={handleTouchEnd}
+          >
+            <div className="pointer-events-none absolute -left-[112px] -top-[122px] h-[220px] w-[220px] rounded-full bg-cyan-300/[0.08]" />
+            <div className="pointer-events-none absolute bottom-[-150px] left-[39%] h-[250px] w-[250px] rounded-full bg-blue-400/[0.10]" />
+            <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-white/[0.055] via-transparent to-black/24" />
+            <div className="pointer-events-none absolute inset-0 rounded-[30px] ring-1 ring-inset ring-white/10" />
 
-              <div className="pointer-events-none absolute left-0 top-0 z-[88] h-full w-11 bg-gradient-to-r from-[#020617] via-[#020617]/56 to-transparent" />
-              <div className="pointer-events-none absolute right-0 top-0 z-[88] h-full w-11 bg-gradient-to-l from-[#020617] via-[#020617]/56 to-transparent" />
-              <div className="pointer-events-none absolute inset-x-0 top-0 z-[89] h-7 bg-gradient-to-b from-[#020617]/82 to-transparent" />
-              <div className="pointer-events-none absolute inset-x-0 bottom-0 z-[89] h-7 bg-gradient-to-t from-[#020617]/82 to-transparent" />
+            <div className="pointer-events-none absolute left-0 top-0 z-[88] h-full w-11 bg-gradient-to-r from-[#020617] via-[#020617]/56 to-transparent" />
+            <div className="pointer-events-none absolute right-0 top-0 z-[88] h-full w-11 bg-gradient-to-l from-[#020617] via-[#020617]/56 to-transparent" />
+            <div className="pointer-events-none absolute inset-x-0 top-0 z-[89] h-7 bg-gradient-to-b from-[#020617]/82 to-transparent" />
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 z-[89] h-7 bg-gradient-to-t from-[#020617]/82 to-transparent" />
 
-              {safeMaterials.map((item, index) => {
-                const rawOffset = index - activeIndex;
+            {safeMaterials.map((item, index) => {
+              const rawOffset = index - activeIndex;
 
-                const wrappedOffset =
-                  rawOffset > total / 2
-                    ? rawOffset - total
-                    : rawOffset < -total / 2
-                      ? rawOffset + total
-                      : rawOffset;
+              const wrappedOffset =
+                rawOffset > total / 2
+                  ? rawOffset - total
+                  : rawOffset < -total / 2
+                    ? rawOffset + total
+                    : rawOffset;
 
-                const isActive = wrappedOffset === 0;
-                const visible = Math.abs(wrappedOffset) <= 2;
+              const isActive = wrappedOffset === 0;
+              const visible = Math.abs(wrappedOffset) <= 2;
 
-                return (
-                  <LearningMaterialCard
-                    key={item.id || index}
-                    item={item}
-                    isActive={isActive}
-                    offset={wrappedOffset}
-                    visible={visible}
-                    position={index + 1}
-                    total={total}
-                    onClick={() => {
-                      if (isActive) {
-                        onOpenMaterial?.(item);
-                        return;
-                      }
+              return (
+                <LearningMaterialCard
+                  key={item.id || index}
+                  item={item}
+                  isActive={isActive}
+                  offset={wrappedOffset}
+                  visible={visible}
+                  position={index + 1}
+                  total={total}
+                  onClick={() => {
+                    if (isActive) {
+                      onOpenMaterial?.(item);
+                      return;
+                    }
 
-                      moveToIndex(index);
-                    }}
-                  />
-                );
-              })}
-            </div>
+                    moveToIndex(index);
+                  }}
+                />
+              );
+            })}
           </div>
         </div>
-      )}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- removes the two inline COMMITTED VERSION cards from the dashboard
- restores the original Daily Money Tip card appearance
- restores the compact Learning Hub button without an extra locked panel
- intercepts non-committed taps and opens the existing CLARA Commitment Booklet modal
- preserves normal flip, expand, swipe, and lesson behavior for committed users

## Expected behavior
- non-committed Daily Money Tip tap: open commitment popup, do not flip
- non-committed Learning Hub tap: open commitment popup, do not expand
- no additional lock UI or dashboard spacing