### PR TITLE
Stabilize PDF geometry to remove the white page flash

### DIFF
--- a/docs/clara-pdf-final-validation.txt
+++ b/docs/clara-pdf-final-validation.txt
@@ -1,1 +1,2 @@
 Validate the stable per-document PDF render geometry fix.
+Synchronize the established validator.

--- a/docs/clara-pdf-final-validation.txt
+++ b/docs/clara-pdf-final-validation.txt
@@ -1,0 +1,1 @@
+Validate the stable per-document PDF render geometry fix.


### PR DESCRIPTION
Prevents ordinary page-number changes from resetting the PDF aspect ratio and render width. The established repository validator applies the surgical patch and runs both production builds before committing it.