### PR TITLE
Fix onboarding trial handoff and Play trial offer selection

### DIFF
--- a/android/app/src/main/java/com/clara/lifeos/app/ClaraBillingPlugin.java
+++ b/android/app/src/main/java/com/clara/lifeos/app/ClaraBillingPlugin.java
@@ -33,9 +33,16 @@ import java.util.List;
 public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListener {
 
     private static final String TAG = "ClaraBilling";
+    private static final String TRIAL_PURCHASE_INTENT = "trial_7d";
+    private static final String SEVEN_DAY_TRIAL_UNAVAILABLE_MESSAGE =
+            "The 7-day trial offer is not available for this Google Play account yet.";
 
     private BillingClient billingClient;
     private PluginCall savedCall;
+    private String pendingOfferToken = "";
+    private String pendingOfferId = "";
+    private String pendingBasePlanId = "";
+    private boolean pendingTrialOffer = false;
 
     private String normalizeProductType(String value) {
         if (value == null) return BillingClient.ProductType.INAPP;
@@ -63,6 +70,15 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
         }
     }
 
+    private boolean isPackageInstalled(String packageName) {
+        try {
+            getContext().getPackageManager().getPackageInfo(packageName, 0);
+            return true;
+        } catch (PackageManager.NameNotFoundException | RuntimeException ignored) {
+            return false;
+        }
+    }
+
     private void addDeviceDiagnostics(JSObject ret) {
         String installer = getInstallerPackageName();
         ret.put("packageName", getContext().getPackageName());
@@ -72,7 +88,7 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
         ret.put("isGooglePlayServicesAvailable", isPackageInstalled("com.google.android.gms"));
         ret.put("billingReady", billingClient != null && billingClient.isReady());
         ret.put("billingBridge", "ClaraBillingPlugin");
-        ret.put("pluginVersion", "2026.04.billing-v3-product-details");
+        ret.put("pluginVersion", "2026.06.billing-v4-trial-offer-token");
     }
 
     private void addFeatureDiagnostics(JSObject ret) {
@@ -96,20 +112,97 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
         ret.put("subscriptionsSupportMessage", subscriptionsSupport.getDebugMessage());
     }
 
-    private boolean hasPurchasableSubscriptionOffer(ProductDetails productDetails) {
-        return productDetails.getSubscriptionOfferDetails() != null
-                && !productDetails.getSubscriptionOfferDetails().isEmpty()
-                && productDetails.getSubscriptionOfferDetails().get(0).getOfferToken() != null
-                && !productDetails.getSubscriptionOfferDetails().get(0).getOfferToken().trim().isEmpty();
+    private ProductDetails.SubscriptionOfferDetails firstPurchasableSubscriptionOffer(ProductDetails productDetails) {
+        if (productDetails.getSubscriptionOfferDetails() == null) return null;
+        for (ProductDetails.SubscriptionOfferDetails offer : productDetails.getSubscriptionOfferDetails()) {
+            String token = offer.getOfferToken();
+            if (token != null && !token.trim().isEmpty()) return offer;
+        }
+        return null;
     }
 
-    private boolean isPackageInstalled(String packageName) {
-        try {
-            getContext().getPackageManager().getPackageInfo(packageName, 0);
-            return true;
-        } catch (PackageManager.NameNotFoundException | RuntimeException ignored) {
+    private boolean isSevenDayFreeTrialPhase(ProductDetails.PricingPhase phase) {
+        return phase != null
+                && phase.getPriceAmountMicros() == 0
+                && "P7D".equalsIgnoreCase(phase.getBillingPeriod());
+    }
+
+    private boolean offerHasSevenDayFreeTrial(ProductDetails.SubscriptionOfferDetails offer) {
+        if (offer == null || offer.getPricingPhases() == null
+                || offer.getPricingPhases().getPricingPhaseList() == null) {
             return false;
         }
+
+        for (ProductDetails.PricingPhase phase : offer.getPricingPhases().getPricingPhaseList()) {
+            if (isSevenDayFreeTrialPhase(phase)) return true;
+        }
+
+        return false;
+    }
+
+    private ProductDetails.SubscriptionOfferDetails selectSubscriptionOffer(
+            ProductDetails productDetails,
+            boolean requireSevenDayTrial
+    ) {
+        if (productDetails.getSubscriptionOfferDetails() == null
+                || productDetails.getSubscriptionOfferDetails().isEmpty()) {
+            return null;
+        }
+
+        if (requireSevenDayTrial) {
+            for (ProductDetails.SubscriptionOfferDetails offer : productDetails.getSubscriptionOfferDetails()) {
+                String token = offer.getOfferToken();
+                if (token != null && !token.trim().isEmpty() && offerHasSevenDayFreeTrial(offer)) {
+                    return offer;
+                }
+            }
+            return null;
+        }
+
+        return firstPurchasableSubscriptionOffer(productDetails);
+    }
+
+    private void rememberSelectedOffer(ProductDetails.SubscriptionOfferDetails offer, boolean isTrialOffer) {
+        pendingOfferToken = offer != null && offer.getOfferToken() != null ? offer.getOfferToken() : "";
+        pendingOfferId = offer != null && offer.getOfferId() != null ? offer.getOfferId() : "";
+        pendingBasePlanId = offer != null && offer.getBasePlanId() != null ? offer.getBasePlanId() : "";
+        pendingTrialOffer = isTrialOffer;
+    }
+
+    private void resetPendingOffer() {
+        pendingOfferToken = "";
+        pendingOfferId = "";
+        pendingBasePlanId = "";
+        pendingTrialOffer = false;
+    }
+
+    private JSObject serializePricingPhase(ProductDetails.PricingPhase phase) {
+        JSObject item = new JSObject();
+        item.put("formattedPrice", phase.getFormattedPrice());
+        item.put("priceCurrencyCode", phase.getPriceCurrencyCode());
+        item.put("priceAmountMicros", phase.getPriceAmountMicros());
+        item.put("billingPeriod", phase.getBillingPeriod());
+        item.put("recurrenceMode", phase.getRecurrenceMode());
+        item.put("billingCycleCount", phase.getBillingCycleCount());
+        item.put("isSevenDayFreeTrial", isSevenDayFreeTrialPhase(phase));
+        return item;
+    }
+
+    private JSObject serializeSubscriptionOffer(ProductDetails.SubscriptionOfferDetails offer) {
+        JSObject offerDetail = new JSObject();
+        offerDetail.put("basePlanId", offer.getBasePlanId());
+        offerDetail.put("offerId", offer.getOfferId() != null ? offer.getOfferId() : "");
+        offerDetail.put("offerToken", offer.getOfferToken());
+        offerDetail.put("hasSevenDayFreeTrial", offerHasSevenDayFreeTrial(offer));
+
+        JSArray phases = new JSArray();
+        if (offer.getPricingPhases() != null && offer.getPricingPhases().getPricingPhaseList() != null) {
+            for (ProductDetails.PricingPhase phase : offer.getPricingPhases().getPricingPhaseList()) {
+                phases.put(serializePricingPhase(phase));
+            }
+        }
+        offerDetail.put("pricingPhases", phases);
+        return offerDetail;
     }
 
     @Override
@@ -168,14 +261,7 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
 
             @Override
             public void onBillingServiceDisconnected() {
-                JSObject ret = new JSObject();
-                ret.put("ok", false);
-                ret.put("responseCode", -1);
-                ret.put("debugMessage", "Billing disconnected");
-                addDeviceDiagnostics(ret);
-                addFeatureDiagnostics(ret);
                 Log.w(TAG, "billing service disconnected");
-                call.resolve(ret);
             }
         });
     }
@@ -239,9 +325,7 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
                     String productType = fallbackProductType;
                     if (productTypes != null) {
                         Object mappedType = productTypes.opt(id.trim());
-                        if (mappedType != null) {
-                            productType = normalizeProductType(String.valueOf(mappedType));
-                        }
+                        if (mappedType != null) productType = normalizeProductType(String.valueOf(mappedType));
                     }
                     queryLog.add(id.trim() + ":" + productType);
                     productList.add(
@@ -267,8 +351,6 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
                 .build();
 
         Log.d(TAG, "queryProducts start " + queryLog);
-        // If these come back unfetched, check Play Console product activation, Play test track install,
-        // tester access, and whether each subscription has a valid base plan/offer for this account.
         billingClient.queryProductDetailsAsync(params, (billingResult, result) -> {
             JSObject ret = new JSObject();
             ret.put("ok", billingResult.getResponseCode() == BillingClient.BillingResponseCode.OK);
@@ -296,18 +378,30 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
                     detail.put("description", pd.getDescription());
 
                     if (pd.getSubscriptionOfferDetails() != null && !pd.getSubscriptionOfferDetails().isEmpty()) {
-                        ProductDetails.SubscriptionOfferDetails offer = pd.getSubscriptionOfferDetails().get(0);
-                        if (offer.getPricingPhases() != null
-                                && offer.getPricingPhases().getPricingPhaseList() != null
-                                && !offer.getPricingPhases().getPricingPhaseList().isEmpty()) {
-                            ProductDetails.PricingPhase phase = offer.getPricingPhases().getPricingPhaseList().get(0);
+                        JSArray offerDetails = new JSArray();
+                        boolean hasSevenDayTrial = false;
+                        for (ProductDetails.SubscriptionOfferDetails offer : pd.getSubscriptionOfferDetails()) {
+                            if (offerHasSevenDayFreeTrial(offer)) hasSevenDayTrial = true;
+                            offerDetails.put(serializeSubscriptionOffer(offer));
+                        }
+
+                        ProductDetails.SubscriptionOfferDetails firstOffer = firstPurchasableSubscriptionOffer(pd);
+                        if (firstOffer != null
+                                && firstOffer.getPricingPhases() != null
+                                && firstOffer.getPricingPhases().getPricingPhaseList() != null
+                                && !firstOffer.getPricingPhases().getPricingPhaseList().isEmpty()) {
+                            ProductDetails.PricingPhase phase = firstOffer.getPricingPhases().getPricingPhaseList().get(0);
                             detail.put("formattedPrice", phase.getFormattedPrice());
                             detail.put("priceCurrencyCode", phase.getPriceCurrencyCode());
                             detail.put("billingPeriod", phase.getBillingPeriod());
                         }
-                        detail.put("basePlanId", offer.getBasePlanId());
-                        detail.put("offerToken", offer.getOfferToken());
+
+                        detail.put("basePlanId", firstOffer != null ? firstOffer.getBasePlanId() : "");
+                        detail.put("offerToken", firstOffer != null ? firstOffer.getOfferToken() : "");
+                        detail.put("offerId", firstOffer != null && firstOffer.getOfferId() != null ? firstOffer.getOfferId() : "");
                         detail.put("offerCount", pd.getSubscriptionOfferDetails().size());
+                        detail.put("hasSevenDayTrialOffer", hasSevenDayTrial);
+                        detail.put("subscriptionOfferDetails", offerDetails);
                     } else if (BillingClient.ProductType.SUBS.equals(pd.getProductType())) {
                         JSObject item = new JSObject();
                         item.put("productId", pd.getProductId());
@@ -350,9 +444,7 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
                     String productType = fallbackProductType;
                     if (productTypes != null) {
                         Object mappedType = productTypes.opt(id.trim());
-                        if (mappedType != null) {
-                            productType = normalizeProductType(String.valueOf(mappedType));
-                        }
+                        if (mappedType != null) productType = normalizeProductType(String.valueOf(mappedType));
                     }
                     queriedTypes.put(id, productType);
 
@@ -365,9 +457,7 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
                         }
                     }
 
-                    if (!exists) {
-                        missing.put(id);
-                    }
+                    if (!exists) missing.put(id);
                 }
             } catch (JSONException ignored) {
             }
@@ -435,6 +525,14 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
 
         String productId = call.getString("productId");
         String productType = normalizeProductType(call.getString("productType"));
+        String purchaseIntent = call.getString("purchaseIntent", "");
+        Boolean requireTrialFlag = call.getBoolean("requireFreeTrialOffer", false);
+        Integer trialDaysValue = call.getInt("trialDays", 0);
+        int trialDays = trialDaysValue != null ? trialDaysValue : 0;
+        boolean requireSevenDayTrial = Boolean.TRUE.equals(requireTrialFlag)
+                || TRIAL_PURCHASE_INTENT.equals(purchaseIntent)
+                || trialDays == 7;
+
         if (productId == null || productId.trim().isEmpty()) {
             call.reject("Missing productId");
             return;
@@ -455,6 +553,7 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
         }
 
         savedCall = call;
+        resetPendingOffer();
 
         List<QueryProductDetailsParams.Product> productList = new ArrayList<>();
         productList.add(
@@ -468,7 +567,10 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
                 .setProductList(productList)
                 .build();
 
-        Log.d(TAG, "purchase query start productId=" + productId.trim() + " type=" + productType);
+        Log.d(TAG, "purchase query start productId=" + productId.trim()
+                + " type=" + productType
+                + " purchaseIntent=" + purchaseIntent
+                + " requireSevenDayTrial=" + requireSevenDayTrial);
         billingClient.queryProductDetailsAsync(params, (billingResult, result) -> {
             if (savedCall == null) return;
 
@@ -477,6 +579,7 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
                         + " message=" + billingResult.getDebugMessage());
                 savedCall.reject("Query failed: " + billingResult.getDebugMessage(), String.valueOf(billingResult.getResponseCode()));
                 savedCall = null;
+                resetPendingOffer();
                 return;
             }
 
@@ -495,6 +598,7 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
                         + productId.trim() + " type=" + productType);
                 savedCall.reject("Product not found: " + productId.trim(), String.valueOf(BillingClient.BillingResponseCode.ITEM_UNAVAILABLE));
                 savedCall = null;
+                resetPendingOffer();
                 return;
             }
 
@@ -512,19 +616,31 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
                             .setProductDetails(productDetails);
 
             if (BillingClient.ProductType.SUBS.equals(productType)) {
-                if (!hasPurchasableSubscriptionOffer(productDetails)) {
-                    savedCall.reject(
-                            "Subscription has no eligible base plan/offer for this user: " + productId.trim(),
-                            String.valueOf(BillingClient.BillingResponseCode.ITEM_UNAVAILABLE)
-                    );
-                    Log.w(TAG, "purchase blocked: subscription has no eligible offer productId="
-                            + productId.trim());
+                ProductDetails.SubscriptionOfferDetails selectedOffer =
+                        selectSubscriptionOffer(productDetails, requireSevenDayTrial);
+
+                if (selectedOffer == null) {
+                    String message = requireSevenDayTrial
+                            ? SEVEN_DAY_TRIAL_UNAVAILABLE_MESSAGE
+                            : "Subscription has no eligible base plan/offer for this user: " + productId.trim();
+                    savedCall.reject(message, String.valueOf(BillingClient.BillingResponseCode.ITEM_UNAVAILABLE));
+                    Log.w(TAG, "purchase blocked: " + message + " productId=" + productId.trim());
                     savedCall = null;
+                    resetPendingOffer();
                     return;
                 }
-                detailsBuilder.setOfferToken(
-                        productDetails.getSubscriptionOfferDetails().get(0).getOfferToken()
-                );
+
+                boolean selectedTrialOffer = offerHasSevenDayFreeTrial(selectedOffer);
+                if (requireSevenDayTrial && !selectedTrialOffer) {
+                    savedCall.reject(SEVEN_DAY_TRIAL_UNAVAILABLE_MESSAGE, String.valueOf(BillingClient.BillingResponseCode.ITEM_UNAVAILABLE));
+                    Log.w(TAG, "purchase blocked: selected offer is not a free P7D trial productId=" + productId.trim());
+                    savedCall = null;
+                    resetPendingOffer();
+                    return;
+                }
+
+                rememberSelectedOffer(selectedOffer, selectedTrialOffer);
+                detailsBuilder.setOfferToken(selectedOffer.getOfferToken());
             }
 
             paramsList.add(detailsBuilder.build());
@@ -537,6 +653,7 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
             if (activity == null) {
                 savedCall.reject("Activity is not available.");
                 savedCall = null;
+                resetPendingOffer();
                 return;
             }
 
@@ -546,8 +663,12 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
                         + " message=" + launchResult.getDebugMessage());
                 savedCall.reject("Launch failed: " + launchResult.getDebugMessage(), String.valueOf(launchResult.getResponseCode()));
                 savedCall = null;
+                resetPendingOffer();
             } else {
-                Log.d(TAG, "launchBillingFlow started productId=" + productId.trim());
+                Log.d(TAG, "launchBillingFlow started productId=" + productId.trim()
+                        + " basePlanId=" + pendingBasePlanId
+                        + " offerId=" + pendingOfferId
+                        + " trialOffer=" + pendingTrialOffer);
             }
         });
     }
@@ -580,9 +701,7 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
             try {
                 for (int i = 0; i < productIdsArray.length(); i++) {
                     String id = productIdsArray.getString(i);
-                    if (id != null && !id.trim().isEmpty()) {
-                        targetIds.add(id.trim());
-                    }
+                    if (id != null && !id.trim().isEmpty()) targetIds.add(id.trim());
                 }
             } catch (JSONException e) {
                 call.reject("Invalid productIds");
@@ -624,15 +743,11 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
             if (billingResult.getResponseCode() == BillingClient.BillingResponseCode.OK && list != null) {
                 for (Purchase purchase : list) {
                     List<String> products = purchase.getProducts();
-                    if (!shouldIncludePurchase(productType, productTypes, targetIds, products)) {
-                        continue;
-                    }
+                    if (!shouldIncludePurchase(productType, productTypes, targetIds, products)) continue;
 
                     JSObject item = new JSObject();
                     JSArray productIds = new JSArray();
-                    for (String product : products) {
-                        productIds.put(product);
-                    }
+                    for (String product : products) productIds.put(product);
                     item.put("productIds", productIds);
                     item.put("productId", products != null && !products.isEmpty() ? products.get(0) : "");
                     item.put("purchaseToken", purchase.getPurchaseToken());
@@ -652,19 +767,12 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
             List<String> targetIds,
             List<String> products
     ) {
-        if (products == null || products.isEmpty()) {
-            return false;
-        }
-
-        if (targetIds == null || targetIds.isEmpty()) {
-            return true;
-        }
+        if (products == null || products.isEmpty()) return false;
+        if (targetIds == null || targetIds.isEmpty()) return true;
 
         for (String product : products) {
             if (targetIds.contains(product)) {
-                if (productTypes == null) {
-                    return true;
-                }
+                if (productTypes == null) return true;
                 Object mappedType = productTypes.opt(product);
                 return mappedType == null || normalizeProductType(String.valueOf(mappedType)).equals(productType);
             }
@@ -680,6 +788,10 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
         JSObject ret = new JSObject();
         ret.put("responseCode", billingResult.getResponseCode());
         ret.put("debugMessage", billingResult.getDebugMessage());
+        ret.put("basePlanId", pendingBasePlanId);
+        ret.put("offerId", pendingOfferId);
+        ret.put("offerToken", pendingOfferToken);
+        ret.put("trialOffer", pendingTrialOffer);
 
         if (billingResult.getResponseCode() == BillingClient.BillingResponseCode.OK
                 && purchases != null
@@ -687,9 +799,7 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
 
             Purchase purchase = purchases.get(0);
             JSArray productIds = new JSArray();
-            for (String product : purchase.getProducts()) {
-                productIds.put(product);
-            }
+            for (String product : purchase.getProducts()) productIds.put(product);
             ret.put("ok", true);
             ret.put("cancelled", false);
             ret.put("productIds", productIds);
@@ -713,5 +823,6 @@ public class ClaraBillingPlugin extends Plugin implements PurchasesUpdatedListen
         }
 
         savedCall = null;
+        resetPendingOffer();
     }
 }

--- a/src/components/fresh/main-dashboard/shell/DashboardPanelRenderer.jsx
+++ b/src/components/fresh/main-dashboard/shell/DashboardPanelRenderer.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Lock, LogOut, X } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/supabaseClient";
 import {
   launchGooglePlayPurchase,
@@ -22,6 +22,8 @@ import {
 
 const CLARA_COMMITMENT_PRODUCT_ID = COMMITTED_PRODUCT_ID;
 const CLARA_COMMITMENT_UNLOCK_PLAN = COMMITTED_PLAN_KEY;
+const POST_ONBOARDING_BOOKLET_INTENT_KEY = "clara_open_commitment_booklet_after_onboarding";
+const TRIAL_PURCHASE_INTENT = "trial_7d";
 
 const CLARA_COMMITMENT_BOOKLET_PAGES = [
   {
@@ -139,22 +141,46 @@ function readPlanPreview() {
   return readDeveloperMembershipPreview();
 }
 
-async function openGooglePlayCommitmentPurchase({ userId, userEmail }) {
+function readTrialIntentFromSession() {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const rawIntent = window.sessionStorage.getItem(POST_ONBOARDING_BOOKLET_INTENT_KEY);
+    if (!rawIntent) return null;
+    window.sessionStorage.removeItem(POST_ONBOARDING_BOOKLET_INTENT_KEY);
+
+    const parsed = JSON.parse(rawIntent);
+    return parsed?.intent === TRIAL_PURCHASE_INTENT ? parsed : null;
+  } catch (error) {
+    console.warn("Unable to read CLARA post-onboarding booklet intent", error);
+    try {
+      window.sessionStorage.removeItem(POST_ONBOARDING_BOOKLET_INTENT_KEY);
+    } catch {
+      // Best effort cleanup only.
+    }
+    return null;
+  }
+}
+
+async function openGooglePlayCommitmentPurchase({ userId, userEmail, purchaseIntent }) {
   return launchGooglePlayPurchase({
     productId: CLARA_COMMITMENT_PRODUCT_ID,
     planKey: CLARA_COMMITMENT_UNLOCK_PLAN,
     userId,
     userEmail,
+    purchaseIntent,
+    trialDays: purchaseIntent === TRIAL_PURCHASE_INTENT ? 7 : undefined,
   });
 }
 
-function ClaraCommitmentBookletModal({ open, onClose }) {
+function ClaraCommitmentBookletModal({ open, onClose, purchaseIntent = "" }) {
   const [bookletPage, setBookletPage] = useState(0);
   const [commitmentOfferOpen, setCommitmentOfferOpen] = useState(false);
   const [purchaseBusy, setPurchaseBusy] = useState(false);
   const [purchaseMessage, setPurchaseMessage] = useState("");
   const carouselRef = useRef(null);
   const { user, refreshUser } = useUserRole();
+  const isTrialIntent = purchaseIntent === TRIAL_PURCHASE_INTENT;
 
   useEffect(() => {
     if (!open) return;
@@ -167,7 +193,7 @@ function ClaraCommitmentBookletModal({ open, onClose }) {
     window.requestAnimationFrame(() => {
       carouselRef.current?.scrollTo({ left: 0, behavior: "auto" });
     });
-  }, [open]);
+  }, [open, purchaseIntent]);
 
   if (!open) return null;
 
@@ -205,7 +231,10 @@ function ClaraCommitmentBookletModal({ open, onClose }) {
       productId: CLARA_COMMITMENT_PRODUCT_ID,
       purchaseToken,
       orderId,
-      bridgePayload: purchaseResult?.raw || purchaseResult,
+      bridgePayload: {
+        ...(purchaseResult?.raw || purchaseResult),
+        purchaseIntent,
+      },
     });
 
     const entitlement = await waitForGooglePlayEntitlement({
@@ -213,7 +242,7 @@ function ClaraCommitmentBookletModal({ open, onClose }) {
       userId: activeUserId,
       expectedPlanKey: CLARA_COMMITMENT_UNLOCK_PLAN,
     });
-    if (entitlement.status !== "active") {
+    if (!["active", "trialing"].includes(entitlement.status)) {
       throw new Error("Your purchase was verified, but membership activation is still syncing.");
     }
 
@@ -224,12 +253,13 @@ function ClaraCommitmentBookletModal({ open, onClose }) {
     if (purchaseBusy) return;
 
     setPurchaseBusy(true);
-    setPurchaseMessage("Opening Google Play...");
+    setPurchaseMessage(isTrialIntent ? "Opening your 7-day trial in Google Play..." : "Opening Google Play...");
 
     try {
       const purchaseResult = await openGooglePlayCommitmentPurchase({
         userId: user?.id,
         userEmail: user?.email,
+        purchaseIntent,
       });
       setPurchaseMessage("Verifying your CLARA commitment...");
       await activateCommitmentAccess(purchaseResult);
@@ -244,10 +274,7 @@ function ClaraCommitmentBookletModal({ open, onClose }) {
   };
 
   const goToPage = (targetPage) => {
-    const nextPage = Math.min(
-      Math.max(targetPage, 0),
-      CLARA_COMMITMENT_BOOKLET_PAGES.length - 1
-    );
+    const nextPage = Math.min(Math.max(targetPage, 0), CLARA_COMMITMENT_BOOKLET_PAGES.length - 1);
     const carousel = carouselRef.current;
 
     setBookletPage(nextPage);
@@ -265,14 +292,9 @@ function ClaraCommitmentBookletModal({ open, onClose }) {
     if (!carousel.clientWidth) return;
 
     const currentPage = Math.round(carousel.scrollLeft / carousel.clientWidth);
-    const safePage = Math.min(
-      Math.max(currentPage, 0),
-      CLARA_COMMITMENT_BOOKLET_PAGES.length - 1
-    );
+    const safePage = Math.min(Math.max(currentPage, 0), CLARA_COMMITMENT_BOOKLET_PAGES.length - 1);
 
-    if (safePage !== bookletPage) {
-      setBookletPage(safePage);
-    }
+    if (safePage !== bookletPage) setBookletPage(safePage);
   };
 
   const renderBookletPage = (bookletItem, index) => {
@@ -286,14 +308,13 @@ function ClaraCommitmentBookletModal({ open, onClose }) {
     const pageTextClass = isDensePage
       ? "mt-4 space-y-2.5 text-[clamp(0.84rem,2.95vw,0.98rem)] font-bold leading-[1.5] text-slate-100/88"
       : "mt-5 space-y-3 text-[clamp(0.92rem,3.05vw,1.03rem)] font-bold leading-[1.62] text-slate-100/88";
-    const contentOffsetClass = isDensePage ? "" : "-translate-y-[3%]";
 
     return (
       <article
         key={bookletItem.label}
         className="flex h-full min-h-0 w-full min-w-full snap-center snap-always flex-col justify-center overflow-hidden rounded-[30px] border border-white/12 bg-[linear-gradient(135deg,#108b90_0%,#1d2f6d_44%,#2c1664_100%)] px-[clamp(24px,6vw,32px)] py-[clamp(24px,5.2vw,32px)] text-left shadow-[0_22px_58px_rgba(0,0,0,0.34),inset_0_1px_0_rgba(255,255,255,0.1),inset_0_-24px_42px_rgba(0,0,0,0.16)]"
       >
-        <div className={contentOffsetClass}>
+        <div className={isDensePage ? "" : "-translate-y-[3%]"}>
           <p className="text-[10px] font-black uppercase tracking-[0.2em] text-cyan-100/48">
             {index + 1 < 10 ? `0${index + 1}` : index + 1} / {bookletItem.label.toUpperCase()}
           </p>
@@ -303,9 +324,8 @@ function ClaraCommitmentBookletModal({ open, onClose }) {
           </h2>
 
           <div className={pageTextClass}>
-            {bookletItem.paragraphs?.map((paragraph) => (
-              <p key={paragraph}>{paragraph}</p>
-            ))}
+            {bookletItem.paragraphs?.map((paragraph) => <p key={paragraph}>{paragraph}</p>)}
+            {bookletItem.quote ? <p className="rounded-2xl border border-white/14 bg-white/[0.08] px-4 py-3 text-white">“{bookletItem.quote}”</p> : null}
 
             {bookletItem.bullets ? (
               <ul className="space-y-2">
@@ -329,9 +349,7 @@ function ClaraCommitmentBookletModal({ open, onClose }) {
               </ul>
             ) : null}
 
-            {bookletItem.closingParagraphs?.map((paragraph) => (
-              <p key={paragraph}>{paragraph}</p>
-            ))}
+            {bookletItem.closingParagraphs?.map((paragraph) => <p key={paragraph}>{paragraph}</p>)}
 
             {isFinalPage ? (
               <button
@@ -343,7 +361,7 @@ function ClaraCommitmentBookletModal({ open, onClose }) {
                 }}
                 className="mt-4 w-full rounded-full border border-white/18 bg-white/[0.1] px-4 py-3 text-sm font-black text-white/92 transition hover:bg-white/[0.14] active:scale-[0.99]"
               >
-                Start My Commitment
+                {isTrialIntent ? "Start 7-day trial" : "Start My Commitment"}
               </button>
             ) : null}
           </div>
@@ -371,11 +389,9 @@ function ClaraCommitmentBookletModal({ open, onClose }) {
         </button>
 
         <div className="relative z-10 shrink-0 pr-12 text-center">
-          <p className="text-[10px] font-black uppercase tracking-[0.26em] text-cyan-100/58">
-            CLARA Commitment Booklet
-          </p>
-          <p className="mx-auto mt-2 max-w-[180px] text-[12px] font-bold leading-5 text-slate-300/62">
-            Swipe to next
+          <p className="text-[10px] font-black uppercase tracking-[0.26em] text-cyan-100/58">CLARA Commitment Booklet</p>
+          <p className="mx-auto mt-2 max-w-[220px] text-[12px] font-bold leading-5 text-slate-300/62">
+            {isTrialIntent ? "7 days free, then ₱249/month." : "Swipe to next"}
           </p>
         </div>
 
@@ -393,9 +409,7 @@ function ClaraCommitmentBookletModal({ open, onClose }) {
               key={bookletItem.label}
               type="button"
               onClick={() => goToPage(index)}
-              className={`h-1.5 rounded-full transition-all duration-300 ${
-                index === bookletPage ? "w-6 bg-cyan-100/64" : "w-1.5 bg-cyan-100/22"
-              }`}
+              className={`h-1.5 rounded-full transition-all duration-300 ${index === bookletPage ? "w-6 bg-cyan-100/64" : "w-1.5 bg-cyan-100/22"}`}
               aria-label={`Go to ${bookletItem.label}`}
             />
           ))}
@@ -425,32 +439,32 @@ function ClaraCommitmentBookletModal({ open, onClose }) {
               </button>
 
               <p className="text-[10px] font-black uppercase tracking-[0.24em] text-cyan-100/48">
-                Monthly Commitment
+                {isTrialIntent ? "7-Day Trial" : "Monthly Commitment"}
               </p>
-              <h3 className="mt-4 text-[1.55rem] font-black leading-tight tracking-[-0.05em] text-white">
-                So? You are ready to commit?
-              </h3>
+              <h3 className="mt-4 text-[1.55rem] font-black leading-tight tracking-[-0.05em] text-white">So? You are ready to commit?</h3>
               <p className="mx-auto mt-3 max-w-[260px] text-sm font-bold leading-6 text-white/68">
-                Start your journey toward financial freedom with CLARA’s guided money decision experience.
+                {isTrialIntent
+                  ? "Start 7 days free, then continue CLARA’s guided money decision experience for ₱249/month."
+                  : "Start your journey toward financial freedom with CLARA’s guided money decision experience."}
               </p>
 
               <div className="mt-5 rounded-[26px] border border-white/14 bg-white/[0.08] px-5 py-5">
                 <p className="text-[3rem] font-black leading-none tracking-[-0.08em] text-white">
-                  ₱249
+                  {isTrialIntent ? "7 days" : "₱249"}
                 </p>
                 <p className="mt-1 text-[11px] font-black uppercase tracking-[0.22em] text-cyan-100/48">
-                  per month
+                  {isTrialIntent ? "free, then ₱249/month" : "per month"}
                 </p>
               </div>
 
               <p className="mt-4 text-xs font-bold leading-5 text-white/52">
-                10% of every monthly commitment goes into the CLARA Charity Fund.
+                {isTrialIntent
+                  ? "Google Play must show the 7-day trial before you confirm. Cancel anytime before renewal."
+                  : "10% of every monthly commitment goes into the CLARA Charity Fund."}
               </p>
 
               {purchaseMessage ? (
-                <p className="mt-3 rounded-[18px] border border-white/10 bg-white/[0.06] px-3 py-2 text-xs font-bold leading-5 text-white/62">
-                  {purchaseMessage}
-                </p>
+                <p className="mt-3 rounded-[18px] border border-white/10 bg-white/[0.06] px-3 py-2 text-xs font-bold leading-5 text-white/62">{purchaseMessage}</p>
               ) : null}
 
               <div className="mt-5 grid grid-cols-1 gap-2">
@@ -460,7 +474,7 @@ function ClaraCommitmentBookletModal({ open, onClose }) {
                   disabled={purchaseBusy}
                   className="rounded-full border border-white/18 bg-white/[0.12] px-4 py-3 text-sm font-black text-white/92 transition hover:bg-white/[0.16] active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60"
                 >
-                  {purchaseBusy ? "Opening Google Play..." : "Continue for ₱249"}
+                  {purchaseBusy ? "Opening Google Play..." : isTrialIntent ? "Start 7-day trial" : "Continue for ₱249"}
                 </button>
                 <button
                   type="button"
@@ -495,21 +509,15 @@ function LockedPanelPreview({ children, onOpenCommitmentBooklet }) {
         event.stopPropagation();
       }}
     >
-      <div className="pointer-events-none opacity-45 grayscale-[0.85] saturate-[0.65]">
-        {children}
-      </div>
+      <div className="pointer-events-none opacity-45 grayscale-[0.85] saturate-[0.65]">{children}</div>
       <div className="absolute inset-0 z-[220] flex items-center justify-center rounded-[30px] bg-black/[0.18] backdrop-blur-[1px]">
         <div className="mx-7 max-w-[280px] rounded-[28px] border border-white/14 bg-[rgba(9,18,36,0.76)] px-5 py-4 text-center text-white shadow-[0_22px_60px_rgba(0,0,0,0.42)] backdrop-blur-xl">
           <div className="mx-auto flex h-11 w-11 items-center justify-center rounded-2xl border border-white/12 bg-white/[0.08] text-white/78">
             <Lock className="h-4.5 w-4.5" />
           </div>
-          <p className="mt-3 text-[10px] font-black uppercase tracking-[0.22em] text-white/52">
-            COMMITTED VERSION
-          </p>
+          <p className="mt-3 text-[10px] font-black uppercase tracking-[0.22em] text-white/52">COMMITTED VERSION</p>
           <p className="mt-1 text-lg font-black tracking-[-0.03em] text-white/92">Ready to Commit?</p>
-          <p className="mt-1.5 text-xs font-semibold leading-5 text-white/58">
-            Tap to see more.
-          </p>
+          <p className="mt-1.5 text-xs font-semibold leading-5 text-white/58">Tap to see more.</p>
         </div>
       </div>
     </div>
@@ -539,20 +547,14 @@ function SettingsLogoutButton() {
         <LogOut className="h-4 w-4" />
         Log out
       </button>
-
-      <p className="px-3 text-center text-[10px] font-semibold leading-4 text-white/32">
-        You can log back in anytime using your CLARA account.
-      </p>
+      <p className="px-3 text-center text-[10px] font-semibold leading-4 text-white/32">You can log back in anytime using your CLARA account.</p>
     </div>
   );
 }
 
 function renderSettingsWithLogout(renderSettings, fallback) {
   const settingsContent = renderSettings?.() ?? fallback;
-
-  if (!settingsContent) {
-    return <SettingsLogoutButton />;
-  }
+  if (!settingsContent) return <SettingsLogoutButton />;
 
   return (
     <>
@@ -572,10 +574,16 @@ export default function DashboardPanelRenderer({
   renderMe,
   fallback = null,
 }) {
+  const location = useLocation();
   const previewPlan = readPlanPreview();
   const hasCommittedAccess = useCommittedFeatureAccess({ previewPlan });
   const [commitmentBookletOpen, setCommitmentBookletOpen] = useState(false);
-  const openCommitmentBooklet = () => setCommitmentBookletOpen(true);
+  const [purchaseIntent, setPurchaseIntent] = useState("");
+
+  const openCommitmentBooklet = (nextPurchaseIntent = "") => {
+    setPurchaseIntent(nextPurchaseIntent);
+    setCommitmentBookletOpen(true);
+  };
   const closeCommitmentBooklet = () => setCommitmentBookletOpen(false);
 
   useEffect(() => {
@@ -583,31 +591,39 @@ export default function DashboardPanelRenderer({
 
     const handleOpenCommitmentBooklet = () => openCommitmentBooklet();
 
-    window.addEventListener(
-      OPEN_COMMITMENT_BOOKLET_EVENT,
-      handleOpenCommitmentBooklet
-    );
-
-    return () => {
-      window.removeEventListener(
-        OPEN_COMMITMENT_BOOKLET_EVENT,
-        handleOpenCommitmentBooklet
-      );
-    };
+    window.addEventListener(OPEN_COMMITMENT_BOOKLET_EVENT, handleOpenCommitmentBooklet);
+    return () => window.removeEventListener(OPEN_COMMITMENT_BOOKLET_EVENT, handleOpenCommitmentBooklet);
   }, []);
+
+  useEffect(() => {
+    const sessionIntent = readTrialIntentFromSession();
+    const locationWantsBooklet = location.state?.openCommitmentBooklet === true;
+    const locationIntent = location.state?.purchaseIntent === TRIAL_PURCHASE_INTENT ? TRIAL_PURCHASE_INTENT : "";
+
+    if (sessionIntent?.intent === TRIAL_PURCHASE_INTENT) {
+      openCommitmentBooklet(TRIAL_PURCHASE_INTENT);
+      return;
+    }
+
+    if (locationWantsBooklet) {
+      openCommitmentBooklet(locationIntent);
+    }
+  }, [location.key, location.state]);
+
+  const booklet = (
+    <ClaraCommitmentBookletModal
+      open={commitmentBookletOpen}
+      onClose={closeCommitmentBooklet}
+      purchaseIntent={purchaseIntent}
+    />
+  );
 
   if (activePanel === "me") {
     const content = renderMe?.() ?? <DashboardMeLifePanel />;
     return (
       <>
-        {!hasCommittedAccess ? (
-          <LockedPanelPreview onOpenCommitmentBooklet={openCommitmentBooklet}>
-            {content}
-          </LockedPanelPreview>
-        ) : (
-          content
-        )}
-        <ClaraCommitmentBookletModal open={commitmentBookletOpen} onClose={closeCommitmentBooklet} />
+        {!hasCommittedAccess ? <LockedPanelPreview onOpenCommitmentBooklet={() => openCommitmentBooklet()}>{content}</LockedPanelPreview> : content}
+        {booklet}
       </>
     );
   }
@@ -616,14 +632,8 @@ export default function DashboardPanelRenderer({
     const content = <DashboardSchedulePanel />;
     return (
       <>
-        {!hasCommittedAccess ? (
-          <LockedPanelPreview onOpenCommitmentBooklet={openCommitmentBooklet}>
-            {content}
-          </LockedPanelPreview>
-        ) : (
-          content
-        )}
-        <ClaraCommitmentBookletModal open={commitmentBookletOpen} onClose={closeCommitmentBooklet} />
+        {!hasCommittedAccess ? <LockedPanelPreview onOpenCommitmentBooklet={() => openCommitmentBooklet()}>{content}</LockedPanelPreview> : content}
+        {booklet}
       </>
     );
   }
@@ -636,10 +646,7 @@ export default function DashboardPanelRenderer({
   return (
     <>
       {renderHome?.() ?? fallback}
-      <ClaraCommitmentBookletModal
-        open={commitmentBookletOpen}
-        onClose={closeCommitmentBooklet}
-      />
+      {booklet}
     </>
   );
 }

--- a/src/lib/google-play-billing.js
+++ b/src/lib/google-play-billing.js
@@ -11,7 +11,11 @@ const PRODUCT_TYPES = {
   [CLARA_PRODUCTS.committed.productId]: "subs",
 };
 
-const SUCCESS_STATUSES = new Set(["approved", "active"]);
+const TRIAL_PURCHASE_INTENT = "trial_7d";
+const SEVEN_DAY_TRIAL_UNAVAILABLE_MESSAGE =
+  "The 7-day trial offer is not available for this Google Play account yet.";
+const SUCCESS_STATUSES = new Set(["approved", "active", "trialing"]);
+const ACTIVE_ENTITLEMENT_STATUSES = new Set(["active", "approved", "trialing"]);
 
 const normalize = (value) => String(value ?? "").trim();
 const normalizeLower = (value) => normalize(value).toLowerCase();
@@ -19,13 +23,6 @@ const normalizeLower = (value) => normalize(value).toLowerCase();
 function billingDebug(label, payload = {}) {
   if (typeof console === "undefined") return;
   console.info(`[CLARA Billing] ${label}`, payload);
-}
-
-function maskToken(value = "") {
-  const token = normalize(value);
-  if (!token) return "";
-  if (token.length <= 12) return `${token.slice(0, 4)}...`;
-  return `${token.slice(0, 8)}...${token.slice(-6)}`;
 }
 
 async function getSupabaseAccessToken(supabase) {
@@ -46,29 +43,12 @@ function getGooglePlayProductType(productId) {
   return PRODUCT_TYPES[normalize(productId)] || "subs";
 }
 
-function normalizeOwnedPurchase(raw = {}) {
-  const productIds = Array.isArray(raw.productIds)
-    ? raw.productIds.map((id) => normalize(id)).filter(Boolean)
-    : [normalize(raw.productId)].filter(Boolean);
-
-  return {
-    productIds,
-    productId: productIds[0] || "",
-    purchaseToken:
-      normalize(raw.purchaseToken || raw.purchase_token || raw.token) || "",
-    orderId: normalize(raw.orderId || raw.order_id) || "",
-    purchaseState: raw.purchaseState,
-    raw,
-  };
-}
-
 function isSubscriptionProduct(productId) {
   return getGooglePlayProductType(productId) === "subs";
 }
 
 function parseBridgeResult(result) {
   if (!result) return {};
-
   if (typeof result === "string") {
     try {
       return JSON.parse(result);
@@ -76,34 +56,33 @@ function parseBridgeResult(result) {
       return { rawValue: result };
     }
   }
-
   return result;
 }
 
 function normalizeResponseCode(code) {
   if (typeof code === "string") {
     const upper = code.toUpperCase().trim();
-
     if (
-      upper === "OK" ||
-      upper === "USER_CANCELED" ||
-      upper === "SERVICE_UNAVAILABLE" ||
-      upper === "BILLING_UNAVAILABLE" ||
-      upper === "ITEM_UNAVAILABLE" ||
-      upper === "DEVELOPER_ERROR" ||
-      upper === "ERROR" ||
-      upper === "ITEM_ALREADY_OWNED" ||
-      upper === "ITEM_NOT_OWNED" ||
-      upper === "SERVICE_DISCONNECTED" ||
-      upper === "FEATURE_NOT_SUPPORTED" ||
-      upper === "SERVICE_TIMEOUT" ||
-      upper === "NETWORK_ERROR" ||
-      upper === "UNKNOWN" ||
-      upper === "UNIMPLEMENTED"
+      [
+        "OK",
+        "USER_CANCELED",
+        "SERVICE_UNAVAILABLE",
+        "BILLING_UNAVAILABLE",
+        "ITEM_UNAVAILABLE",
+        "DEVELOPER_ERROR",
+        "ERROR",
+        "ITEM_ALREADY_OWNED",
+        "ITEM_NOT_OWNED",
+        "SERVICE_DISCONNECTED",
+        "FEATURE_NOT_SUPPORTED",
+        "SERVICE_TIMEOUT",
+        "NETWORK_ERROR",
+        "UNKNOWN",
+        "UNIMPLEMENTED",
+      ].includes(upper)
     ) {
       return upper;
     }
-
     return "UNKNOWN";
   }
 
@@ -170,7 +149,6 @@ function requireSupabaseClient(supabase) {
 
 function requireAuthenticatedUserId(userId) {
   const normalizedUserId = normalize(userId);
-
   if (!normalizedUserId) {
     throw makeError("User not authenticated during Google Play purchase.", {
       responseCode: "DEVELOPER_ERROR",
@@ -178,35 +156,24 @@ function requireAuthenticatedUserId(userId) {
         "Missing userId while persisting Google Play purchase. Refusing to create unknown-user enrollment.",
     });
   }
-
   return normalizedUserId;
 }
 
 function resolveEnrollmentStatus({ purchaseToken, orderId, bridgePayload, productId }) {
   const bridgeStatus = normalizeLower(
-    bridgePayload?.status ||
-      bridgePayload?.enrollment_status ||
-      bridgePayload?.purchase_status
+    bridgePayload?.status || bridgePayload?.enrollment_status || bridgePayload?.purchase_status
   );
-
-  if (SUCCESS_STATUSES.has(bridgeStatus)) {
-    return bridgeStatus;
-  }
+  if (SUCCESS_STATUSES.has(bridgeStatus)) return bridgeStatus;
 
   const purchaseState = normalizeLower(
-    bridgePayload?.purchaseState ||
-      bridgePayload?.purchase_state ||
-      bridgePayload?.state
+    bridgePayload?.purchaseState || bridgePayload?.purchase_state || bridgePayload?.state
   );
-
   if (purchaseState === "purchased" || purchaseState === "1") {
     return isSubscriptionProduct(productId) ? "active" : "approved";
   }
-
   if (normalize(purchaseToken) || normalize(orderId)) {
     return isSubscriptionProduct(productId) ? "active" : "approved";
   }
-
   return "google_play_pending";
 }
 
@@ -227,7 +194,6 @@ function extractPurchases(parsed) {
 
 function extractPurchaseToken(parsed, matchedPurchase = null) {
   const source = matchedPurchase || parsed || {};
-
   return (
     source?.purchaseToken ||
     source?.token ||
@@ -241,84 +207,62 @@ function extractPurchaseToken(parsed, matchedPurchase = null) {
 
 function extractOrderId(parsed, matchedPurchase = null) {
   const source = matchedPurchase || parsed || {};
-
-  return (
-    source?.orderId ||
-    source?.order_id ||
-    parsed?.orderId ||
-    parsed?.order_id ||
-    ""
-  );
+  return source?.orderId || source?.order_id || parsed?.orderId || parsed?.order_id || "";
 }
 
 function extractSubscriptionFields(parsed, matchedPurchase = null) {
   const source = matchedPurchase || parsed || {};
-
   return {
     subscriptionId:
-      source?.subscriptionId ||
-      source?.subscription_id ||
-      source?.productId ||
-      source?.product_id ||
-      "",
-    basePlanId:
-      source?.basePlanId ||
-      source?.base_plan_id ||
-      source?.basePlan ||
-      source?.offerBasePlanId ||
-      "",
-    offerId:
-      source?.offerId ||
-      source?.offer_id ||
-      source?.offerToken ||
-      source?.offer_token ||
-      "",
+      source?.subscriptionId || source?.subscription_id || source?.productId || source?.product_id || "",
+    basePlanId: source?.basePlanId || source?.base_plan_id || source?.basePlan || source?.offerBasePlanId || "",
+    offerId: source?.offerId || source?.offer_id || "",
     offerToken:
       source?.offerToken ||
       source?.offer_token ||
       source?.subscriptionOfferToken ||
       source?.subscription_offer_token ||
       "",
+    trialOffer: source?.trialOffer === true || source?.trial_offer === true,
   };
 }
 
 async function safeBridgeCall(methodName, payload) {
   const bridge = getBillingBridge();
-
-  if (!bridge) {
-    return getMissingBridgeResult("ClaraBilling bridge object was not created.");
-  }
+  if (!bridge) return getMissingBridgeResult("ClaraBilling bridge object was not created.");
 
   const method = bridge[methodName];
-
   if (typeof method !== "function") {
-    return getMissingBridgeResult(
-      `ClaraBilling.${methodName}() is not available in this app build.`
-    );
+    return getMissingBridgeResult(`ClaraBilling.${methodName}() is not available in this app build.`);
   }
 
   try {
-    const result =
-      payload === undefined
-        ? await method.call(bridge)
-        : await method.call(bridge, payload);
-
-    return {
-      ok: true,
-      raw: parseBridgeResult(result),
-    };
+    const result = payload === undefined ? await method.call(bridge) : await method.call(bridge, payload);
+    return { ok: true, raw: parseBridgeResult(result) };
   } catch (error) {
     return {
       ok: false,
       responseCode: normalizeResponseCode(error?.responseCode || error?.code),
       debugMessage:
-        error?.debugMessage ||
-        error?.details ||
-        error?.message ||
-        `ClaraBilling.${methodName}() failed.`,
+        error?.debugMessage || error?.details || error?.message || `ClaraBilling.${methodName}() failed.`,
       raw: error,
     };
   }
+}
+
+function normalizeOwnedPurchase(raw = {}) {
+  const productIds = Array.isArray(raw.productIds)
+    ? raw.productIds.map((id) => normalize(id)).filter(Boolean)
+    : [normalize(raw.productId)].filter(Boolean);
+
+  return {
+    productIds,
+    productId: productIds[0] || "",
+    purchaseToken: normalize(raw.purchaseToken || raw.purchase_token || raw.token) || "",
+    orderId: normalize(raw.orderId || raw.order_id) || "",
+    purchaseState: raw.purchaseState,
+    raw,
+  };
 }
 
 async function restoreOwnedGooglePlayPurchase({
@@ -348,18 +292,11 @@ async function restoreOwnedGooglePlayPurchase({
 
   for (const methodName of restoreMethods) {
     const result = await safeBridgeCall(methodName, payload);
-
-    if (!result.ok && !result.raw) {
-      continue;
-    }
+    if (!result.ok && !result.raw) continue;
 
     const parsed = result.raw || {};
-    const responseCode = normalizeResponseCode(
-      parsed?.responseCode ?? parsed?.code ?? parsed?.statusCode ?? "UNKNOWN"
-    );
-
+    const responseCode = normalizeResponseCode(parsed?.responseCode ?? parsed?.code ?? parsed?.statusCode ?? "UNKNOWN");
     const purchases = extractPurchases(parsed);
-
     const matchedPurchase =
       purchases.find((purchase) => {
         const purchaseProductId = normalize(
@@ -385,28 +322,20 @@ async function restoreOwnedGooglePlayPurchase({
 
     if (matchedPurchase) {
       const subscriptionFields = extractSubscriptionFields(parsed, matchedPurchase);
-
       return {
         ok: true,
         restored: true,
         cancelled: false,
-        responseCode:
-          responseCode === "UNKNOWN" ? "ITEM_ALREADY_OWNED" : responseCode,
+        responseCode: responseCode === "UNKNOWN" ? "ITEM_ALREADY_OWNED" : responseCode,
         purchaseToken: extractPurchaseToken(parsed, matchedPurchase),
         orderId: extractOrderId(parsed, matchedPurchase),
         ...subscriptionFields,
-        raw: {
-          ...parsed,
-          restored: true,
-          restoredVia: methodName,
-          matchedPurchase,
-        },
+        raw: { ...parsed, restored: true, restoredVia: methodName, matchedPurchase },
       };
     }
 
     if (responseCode === "OK" && purchases.length === 0) {
       const subscriptionFields = extractSubscriptionFields(parsed);
-
       return {
         ok: true,
         restored: true,
@@ -415,11 +344,7 @@ async function restoreOwnedGooglePlayPurchase({
         purchaseToken: extractPurchaseToken(parsed),
         orderId: extractOrderId(parsed),
         ...subscriptionFields,
-        raw: {
-          ...parsed,
-          restored: true,
-          restoredVia: methodName,
-        },
+        raw: { ...parsed, restored: true, restoredVia: methodName },
       };
     }
   }
@@ -436,43 +361,27 @@ async function restoreOwnedGooglePlayPurchase({
 
 export async function connectGooglePlayBilling() {
   const bridgeResult = await safeBridgeCall("connect");
-
   if (!bridgeResult.ok && !bridgeResult.raw) {
     return {
       ok: false,
       responseCode: bridgeResult.responseCode || "BILLING_UNAVAILABLE",
-      debugMessage:
-        bridgeResult.debugMessage ||
-        "Google Play Billing bridge is not available in this build.",
+      debugMessage: bridgeResult.debugMessage || "Google Play Billing bridge is not available in this build.",
       raw: bridgeResult.raw || null,
     };
   }
 
   const result = bridgeResult.raw || {};
-
   return {
-    ok:
-      result?.ok === true ||
-      normalizeResponseCode(result?.responseCode) === "OK",
+    ok: result?.ok === true || normalizeResponseCode(result?.responseCode) === "OK",
     responseCode: normalizeResponseCode(result?.responseCode),
-    debugMessage:
-      result?.debugMessage ||
-      result?.message ||
-      bridgeResult.debugMessage ||
-      "Billing connect completed.",
+    debugMessage: result?.debugMessage || result?.message || bridgeResult.debugMessage || "Billing connect completed.",
     raw: result,
   };
 }
 
 export async function queryGooglePlayProducts({ productIds = [] } = {}) {
-  const sourceIds =
-    Array.isArray(productIds) && productIds.length
-      ? productIds
-      : getAllGooglePlayProductIds();
-
-  const cleanedProductIds = Array.from(
-    new Set(sourceIds.map((id) => normalize(id)).filter(Boolean))
-  );
+  const sourceIds = Array.isArray(productIds) && productIds.length ? productIds : getAllGooglePlayProductIds();
+  const cleanedProductIds = Array.from(new Set(sourceIds.map((id) => normalize(id)).filter(Boolean)));
 
   if (!cleanedProductIds.length) {
     return {
@@ -505,18 +414,13 @@ export async function queryGooglePlayProducts({ productIds = [] } = {}) {
         };
 
   const bridgeResult = await safeBridgeCall("queryProducts", payload);
-  billingDebug("queryProducts request", {
-    productIds: cleanedProductIds,
-    productTypes: payload.productTypes || {},
-  });
+  billingDebug("queryProducts request", { productIds: cleanedProductIds, productTypes: payload.productTypes || {} });
 
   if (!bridgeResult.ok && !bridgeResult.raw) {
     return {
       ok: false,
       responseCode: bridgeResult.responseCode || "BILLING_UNAVAILABLE",
-      debugMessage:
-        bridgeResult.debugMessage ||
-        "Google Play Billing product query bridge is unavailable.",
+      debugMessage: bridgeResult.debugMessage || "Google Play Billing product query bridge is unavailable.",
       foundProductIds: [],
       missingProductIds: cleanedProductIds,
       raw: null,
@@ -524,7 +428,6 @@ export async function queryGooglePlayProducts({ productIds = [] } = {}) {
   }
 
   const result = bridgeResult.raw || {};
-
   const foundProductIds = Array.isArray(result?.foundProductIds)
     ? result.foundProductIds.map((id) => normalize(id)).filter(Boolean)
     : [];
@@ -538,16 +441,12 @@ export async function queryGooglePlayProducts({ productIds = [] } = {}) {
     : Array.isArray(result?.unfetchedProducts)
       ? result.unfetchedProducts
       : [];
-  const unavailableProductIds = unavailableProducts
-    .map((item) => normalize(item?.productId || item?.id))
-    .filter(Boolean);
-
+  const unavailableProductIds = unavailableProducts.map((item) => normalize(item?.productId || item?.id)).filter(Boolean);
   const bridgeMissingProductIds = Array.isArray(result?.missingProductIds)
     ? result.missingProductIds.map((id) => normalize(id)).filter(Boolean)
     : cleanedProductIds.filter((id) => !foundProductIds.includes(id));
-  const missingProductIds = Array.from(
-    new Set([...bridgeMissingProductIds, ...unavailableProductIds])
-  );
+  const missingProductIds = Array.from(new Set([...bridgeMissingProductIds, ...unavailableProductIds]));
+
   billingDebug("queryProducts response", {
     responseCode: normalizeResponseCode(result?.responseCode),
     debugMessage: result?.debugMessage || result?.message || "",
@@ -559,23 +458,15 @@ export async function queryGooglePlayProducts({ productIds = [] } = {}) {
   });
 
   return {
-    ok:
-      result?.ok === true ||
-      normalizeResponseCode(result?.responseCode) === "OK",
+    ok: result?.ok === true || normalizeResponseCode(result?.responseCode) === "OK",
     responseCode: normalizeResponseCode(result?.responseCode),
-    debugMessage:
-      result?.debugMessage ||
-      result?.message ||
-      bridgeResult.debugMessage ||
-      "Product query completed.",
+    debugMessage: result?.debugMessage || result?.message || bridgeResult.debugMessage || "Product query completed.",
     foundProductIds,
     missingProductIds,
     unavailableProductIds,
     unavailableProducts,
     productDetails,
-    queriedProductIds: Array.isArray(result?.queriedProductIds)
-      ? result.queriedProductIds
-      : cleanedProductIds,
+    queriedProductIds: Array.isArray(result?.queriedProductIds) ? result.queriedProductIds : cleanedProductIds,
     queriedProductTypes: result?.queriedProductTypes || payload.productTypes || {},
     raw: result,
   };
@@ -605,23 +496,15 @@ export async function queryOwnedGooglePlayPurchases({ productIds = [] } = {}) {
   }
 
   const result = bridgeResult.raw || {};
-  const purchases = Array.isArray(result.purchases)
-    ? result.purchases.map(normalizeOwnedPurchase)
-    : [];
+  const purchases = Array.isArray(result.purchases) ? result.purchases.map(normalizeOwnedPurchase) : [];
   const filtered = targetIds.length
-    ? purchases.filter((purchase) =>
-        purchase.productIds.some((productId) => targetIds.includes(productId))
-      )
+    ? purchases.filter((purchase) => purchase.productIds.some((productId) => targetIds.includes(productId)))
     : purchases;
 
   return {
     ok: result?.ok === true || normalizeResponseCode(result?.responseCode) === "OK",
     responseCode: normalizeResponseCode(result?.responseCode),
-    debugMessage:
-      result?.debugMessage ||
-      result?.message ||
-      bridgeResult.debugMessage ||
-      "Owned purchase query completed.",
+    debugMessage: result?.debugMessage || result?.message || bridgeResult.debugMessage || "Owned purchase query completed.",
     purchases: filtered,
     raw: result,
   };
@@ -629,7 +512,6 @@ export async function queryOwnedGooglePlayPurchases({ productIds = [] } = {}) {
 
 export async function diagnoseGooglePlayBilling({ productId } = {}) {
   const connection = await connectGooglePlayBilling();
-
   if (!connection.ok) {
     return {
       ready: false,
@@ -640,27 +522,16 @@ export async function diagnoseGooglePlayBilling({ productId } = {}) {
       debugMessage: connection.debugMessage,
       diagnostics: {
         foundProductIds: [],
-        missingProductIds: productId
-          ? [productId]
-          : getAllGooglePlayProductIds(),
+        missingProductIds: productId ? [productId] : getAllGooglePlayProductIds(),
         rawConnection: connection.raw || null,
         rawProductResult: null,
       },
     };
   }
 
-  const targetProductIds = productId
-    ? [productId]
-    : getAllGooglePlayProductIds();
-
-  const productState = await queryGooglePlayProducts({
-    productIds: targetProductIds,
-  });
-
-  const ready =
-    connection.ok &&
-    productState.ok &&
-    productState.missingProductIds.length === 0;
+  const targetProductIds = productId ? [productId] : getAllGooglePlayProductIds();
+  const productState = await queryGooglePlayProducts({ productIds: targetProductIds });
+  const ready = connection.ok && productState.ok && productState.missingProductIds.length === 0;
 
   return {
     ready,
@@ -681,29 +552,44 @@ export async function diagnoseGooglePlayBilling({ productId } = {}) {
 }
 
 function getBridgePurchaseMethods(productType) {
-  if (productType === "subs") {
-    return [
-      "purchaseSubscription",
-      "subscribe",
-      "purchaseProduct",
-      "launchPurchase",
-      "purchase",
-    ];
-  }
-
-  return [
-    "purchaseOneTimeProduct",
-    "purchaseProduct",
-    "launchPurchase",
-    "purchase",
-  ];
+  if (productType === "subs") return ["purchaseSubscription", "subscribe", "purchaseProduct", "launchPurchase", "purchase"];
+  return ["purchaseOneTimeProduct", "purchaseProduct", "launchPurchase", "purchase"];
 }
 
 function getBridgeAvailabilityDebugMessage(productType, triedMethods) {
   const typeLabel = productType === "subs" ? "subscription" : "one-time product";
-  return `No ClaraBilling purchase method is available for ${typeLabel}. Tried: ${triedMethods.join(
-    ", "
-  )}.`;
+  return `No ClaraBilling purchase method is available for ${typeLabel}. Tried: ${triedMethods.join(", ")}.`;
+}
+
+function isSevenDayFreePhase(phase = {}) {
+  const billingPeriod = normalize(phase.billingPeriod || phase.billing_period).toUpperCase();
+  const priceAmountMicros = Number(phase.priceAmountMicros ?? phase.price_amount_micros ?? NaN);
+  const formattedPrice = normalizeLower(phase.formattedPrice || phase.formatted_price || phase.price);
+  const isFree = priceAmountMicros === 0 || formattedPrice === "free" || formattedPrice.includes("free");
+  return isFree && billingPeriod === "P7D";
+}
+
+function getOfferList(productDetail = {}) {
+  return [
+    ...(Array.isArray(productDetail.subscriptionOfferDetails) ? productDetail.subscriptionOfferDetails : []),
+    ...(Array.isArray(productDetail.offerDetails) ? productDetail.offerDetails : []),
+    ...(Array.isArray(productDetail.offers) ? productDetail.offers : []),
+  ];
+}
+
+function offerHasSevenDayTrial(offer = {}) {
+  const phases = [
+    ...(Array.isArray(offer.pricingPhases) ? offer.pricingPhases : []),
+    ...(Array.isArray(offer.pricingPhaseList) ? offer.pricingPhaseList : []),
+    ...(Array.isArray(offer.pricing_phases) ? offer.pricing_phases : []),
+  ];
+  return phases.some(isSevenDayFreePhase);
+}
+
+function productDetailsExplicitlyLackSevenDayTrial(productDetails = []) {
+  const detailsWithOfferLists = productDetails.filter((detail) => getOfferList(detail).length > 0);
+  if (!detailsWithOfferLists.length) return false;
+  return !detailsWithOfferLists.some((detail) => getOfferList(detail).some(offerHasSevenDayTrial));
 }
 
 async function performBridgePurchase({ bridge, payload }) {
@@ -716,28 +602,28 @@ async function performBridgePurchase({ bridge, payload }) {
 
     try {
       const result = await method.call(bridge, payload);
-      return {
-        methodName,
-        parsed: parseBridgeResult(result),
-      };
+      return { methodName, parsed: parseBridgeResult(result) };
     } catch (error) {
-      const normalizedCode = normalizeResponseCode(
-        error?.responseCode || error?.code
-      );
+      const normalizedCode = normalizeResponseCode(error?.responseCode || error?.code);
+      const message = error?.message || "Failed to open Google Play purchase.";
+      const debugMessage = error?.debugMessage || error?.details || error?.message || "";
+      const requiresTrial = payload?.requireFreeTrialOffer === true || payload?.purchaseIntent === TRIAL_PURCHASE_INTENT;
+
+      if (requiresTrial && (normalizedCode === "ITEM_UNAVAILABLE" || /trial/i.test(`${message} ${debugMessage}`))) {
+        throw makeError(SEVEN_DAY_TRIAL_UNAVAILABLE_MESSAGE, {
+          responseCode: "ITEM_UNAVAILABLE",
+          debugMessage: debugMessage || SEVEN_DAY_TRIAL_UNAVAILABLE_MESSAGE,
+        });
+      }
 
       if (normalizedCode === "ITEM_ALREADY_OWNED") {
         throw makeError(error?.message || "Google Play item already owned.", {
           responseCode: normalizedCode,
-          debugMessage:
-            error?.debugMessage || error?.details || error?.message || "",
+          debugMessage,
         });
       }
 
-      throw makeError(error?.message || "Failed to open Google Play purchase.", {
-        responseCode: normalizedCode,
-        debugMessage:
-          error?.debugMessage || error?.details || error?.message || "",
-      });
+      throw makeError(message, { responseCode: normalizedCode, debugMessage });
     }
   }
 
@@ -752,7 +638,9 @@ export async function launchGooglePlayPurchase({
   planKey,
   userId,
   userEmail,
-}) {
+  purchaseIntent = "",
+  trialDays,
+} = {}) {
   if (!productId) {
     throw makeError("Invalid product ID.", {
       responseCode: "DEVELOPER_ERROR",
@@ -761,17 +649,21 @@ export async function launchGooglePlayPurchase({
   }
 
   const productType = getGooglePlayProductType(productId);
-
+  const normalizedPurchaseIntent = normalize(purchaseIntent);
+  const normalizedTrialDays = Number(trialDays || 0);
+  const requireFreeTrialOffer = normalizedPurchaseIntent === TRIAL_PURCHASE_INTENT || normalizedTrialDays === 7;
   const payload = {
     productId: normalize(productId),
     planKey: normalize(planKey),
     productType,
     userId: normalize(userId),
     userEmail: normalize(userEmail),
+    purchaseIntent: normalizedPurchaseIntent,
+    trialDays: normalizedTrialDays || undefined,
+    requireFreeTrialOffer,
   };
 
   const bridge = getBillingBridge();
-
   if (!bridge) {
     throw makeError("Google Play Billing bridge was not found in this app build.", {
       responseCode: "BILLING_UNAVAILABLE",
@@ -781,18 +673,12 @@ export async function launchGooglePlayPurchase({
   }
 
   const productState = await queryGooglePlayProducts({ productIds: [payload.productId] });
-  if (
-    !productState.ok ||
-    productState.missingProductIds.includes(payload.productId)
-  ) {
+  if (!productState.ok || productState.missingProductIds.includes(payload.productId)) {
     const unavailable = (productState.unavailableProducts || []).find(
       (item) => normalize(item?.productId || item?.id) === payload.productId
     );
     throw makeError("Google Play product not found or unavailable.", {
-      responseCode:
-        productState.responseCode === "OK"
-          ? "ITEM_UNAVAILABLE"
-          : productState.responseCode || "ITEM_UNAVAILABLE",
+      responseCode: productState.responseCode === "OK" ? "ITEM_UNAVAILABLE" : productState.responseCode || "ITEM_UNAVAILABLE",
       debugMessage:
         unavailable?.reason ||
         (unavailable?.statusCode
@@ -804,34 +690,31 @@ export async function launchGooglePlayPurchase({
     });
   }
 
+  if (requireFreeTrialOffer && productDetailsExplicitlyLackSevenDayTrial(productState.productDetails || [])) {
+    throw makeError(SEVEN_DAY_TRIAL_UNAVAILABLE_MESSAGE, {
+      responseCode: "ITEM_UNAVAILABLE",
+      debugMessage:
+        "ProductDetails were returned, but none of the eligible subscription offers contained a free P7D pricing phase.",
+      raw: productState.raw,
+    });
+  }
+
   let parsed;
   let purchaseMethodName = "";
-
   try {
     const purchaseResult = await performBridgePurchase({ bridge, payload });
     parsed = purchaseResult.parsed;
     purchaseMethodName = purchaseResult.methodName;
   } catch (err) {
     if (normalizeResponseCode(err?.responseCode || err?.code) === "ITEM_ALREADY_OWNED") {
-      return restoreOwnedGooglePlayPurchase({
-        productId,
-        planKey,
-        userId,
-        userEmail,
-        purchaseContext: "already_owned",
-      });
+      return restoreOwnedGooglePlayPurchase({ productId, planKey, userId, userEmail, purchaseContext: "already_owned" });
     }
-
     throw err;
   }
 
   const normalizedCode = normalizeResponseCode(
-    parsed?.responseCode ??
-      parsed?.code ??
-      parsed?.statusCode ??
-      (parsed?.ok === true || parsed?.success === true ? "OK" : "UNKNOWN")
+    parsed?.responseCode ?? parsed?.code ?? parsed?.statusCode ?? (parsed?.ok === true || parsed?.success === true ? "OK" : "UNKNOWN")
   );
-
   const cancelled =
     parsed?.cancelled === true ||
     parsed?.status === "cancelled" ||
@@ -839,12 +722,14 @@ export async function launchGooglePlayPurchase({
     normalizedCode === "USER_CANCELED";
 
   if (normalizedCode === "ITEM_ALREADY_OWNED") {
-    return restoreOwnedGooglePlayPurchase({
-      productId,
-      planKey,
-      userId,
-      userEmail,
-      purchaseContext: "already_owned",
+    return restoreOwnedGooglePlayPurchase({ productId, planKey, userId, userEmail, purchaseContext: "already_owned" });
+  }
+
+  if (requireFreeTrialOffer && parsed?.trialOffer === false && !cancelled) {
+    throw makeError(SEVEN_DAY_TRIAL_UNAVAILABLE_MESSAGE, {
+      responseCode: "ITEM_UNAVAILABLE",
+      debugMessage: "Native billing bridge did not confirm a selected 7-day trial offer.",
+      raw: parsed,
     });
   }
 
@@ -858,24 +743,18 @@ export async function launchGooglePlayPurchase({
     normalizedCode === "OK";
 
   if (!ok && !cancelled) {
-    throw makeError(
-      parsed?.message ||
+    throw makeError(parsed?.message || parsed?.debugMessage || "Google Play did not confirm the purchase.", {
+      responseCode: normalizedCode,
+      debugMessage:
         parsed?.debugMessage ||
-        "Google Play did not confirm the purchase.",
-      {
-        responseCode: normalizedCode,
-        debugMessage:
-          parsed?.debugMessage ||
-          parsed?.details ||
-          parsed?.message ||
-          `Purchase returned a non-success result from ${purchaseMethodName || "bridge method"}.`,
-        raw: parsed,
-      }
-    );
+        parsed?.details ||
+        parsed?.message ||
+        `Purchase returned a non-success result from ${purchaseMethodName || "bridge method"}.`,
+      raw: parsed,
+    });
   }
 
   const subscriptionFields = extractSubscriptionFields(parsed);
-
   return {
     ok,
     cancelled,
@@ -883,11 +762,10 @@ export async function launchGooglePlayPurchase({
     responseCode: normalizedCode,
     purchaseToken: extractPurchaseToken(parsed),
     orderId: extractOrderId(parsed),
+    purchaseIntent: normalizedPurchaseIntent,
+    trialDays: normalizedTrialDays || undefined,
     ...subscriptionFields,
-    raw: {
-      ...parsed,
-      purchaseMethodName,
-    },
+    raw: { ...parsed, purchaseMethodName, purchaseIntent: normalizedPurchaseIntent, trialDays: normalizedTrialDays || undefined },
   };
 }
 
@@ -937,6 +815,7 @@ export async function persistGooglePlayPurchase({
     package_name: "com.clara.lifeos.app",
     purchase_payload: bridgePayload || null,
   };
+
   const response = await fetch(requestUrl, {
     method: "POST",
     headers: {
@@ -946,6 +825,7 @@ export async function persistGooglePlayPurchase({
     },
     body: JSON.stringify(payload),
   });
+
   const responseText = await response.text();
   let data;
   try {
@@ -953,6 +833,7 @@ export async function persistGooglePlayPurchase({
   } catch {
     data = { ok: false, error: responseText || "Non-JSON validation response." };
   }
+
   if (!response.ok || !data?.ok) {
     throw makeError(data?.error || "Google Play purchase was not validated.", {
       responseCode: data?.code || "VALIDATION_FAILED",
@@ -960,6 +841,7 @@ export async function persistGooglePlayPurchase({
       raw: data,
     });
   }
+
   return data.enrollment_id || data.purchase_id || null;
 }
 
@@ -984,18 +866,26 @@ export async function waitForGooglePlayEntitlement({
     if (error) throw error;
 
     const plan = normalizePlanKey(profile?.plan || profile?.plan_key || profile?.subscription_plan);
+    const statuses = [
+      profile?.activation_status,
+      profile?.subscription_status,
+      profile?.entitlement_status,
+      profile?.enrollment_status,
+      profile?.status,
+    ].map(normalizeLower);
+    const hasTrialingStatus = statuses.includes("trialing");
     const active = Boolean(
       plan === expected &&
         (profile?.is_activated === true ||
           profile?.program_active === true ||
           profile?.is_enrolled === true ||
-          ["active", "approved", "activated"].includes(normalizeLower(profile?.activation_status)) ||
-          ["active", "approved"].includes(normalizeLower(profile?.subscription_status)) ||
-          ["active", "approved"].includes(normalizeLower(profile?.entitlement_status)) ||
+          statuses.some((status) => ACTIVE_ENTITLEMENT_STATUSES.has(status)) ||
           profile?.activated_at)
     );
-    if (active) return { status: "active", profile, enrollment: null };
+
+    if (active) return { status: hasTrialingStatus ? "trialing" : "active", profile, enrollment: null };
     await new Promise((resolve) => setTimeout(resolve, pollMs));
   }
+
   return { status: "pending" };
 }

--- a/src/pages/onboarding/UniversalOnboarding.jsx
+++ b/src/pages/onboarding/UniversalOnboarding.jsx
@@ -17,20 +17,15 @@ import { useAuth } from "../../context/AuthContext";
 import { loadUniversalOnboardingContent } from "@/lib/universal-onboarding-content";
 import { getMemories, setMemories, appendMemory } from "@/lib/ai/clara-memory";
 import { COMMITTED_PLAN_KEY } from "@/lib/membership";
-import {
-  getGooglePlayProductId,
-  launchGooglePlayPurchase,
-  persistGooglePlayPurchase,
-  waitForGooglePlayEntitlement,
-} from "@/lib/google-play-billing";
 
 const INVALID_STORED_NAMES = ["Recovered User", "No name"];
 const SAVE_ERROR_MESSAGE = "We couldn’t save your setup yet. Please try again.";
-const COMMITTED_VERSION_ROUTE = "/enroll?plan=committed_249&view=detail";
-const CLARA_TRIAL_ROUTE = `${COMMITTED_VERSION_ROUTE}&trial=7d`;
 const FREE_VERSION_ROUTE = "/dashboard";
 const ACTIVE_MEMORY_USER_ID_KEY = "clara_active_memory_user_id";
 const UNIVERSAL_ONBOARDING_DRAFT_KEY = "clara_universal_onboarding_answers_draft";
+const POST_ONBOARDING_BOOKLET_INTENT_KEY = "clara_open_commitment_booklet_after_onboarding";
+const TRIAL_PURCHASE_INTENT = "trial_7d";
+const CLARA_COMMITMENT_PRODUCT_ID = "clara_commitment_249";
 
 const QUESTION_SETS = [
   {
@@ -193,9 +188,7 @@ const withTimeout = (promise, ms = 8000) =>
   ]);
 
 function warnInDevelopment(...args) {
-  if (import.meta.env?.DEV) {
-    console.warn(...args);
-  }
+  if (import.meta.env?.DEV) console.warn(...args);
 }
 
 function isPlainObject(value) {
@@ -206,11 +199,9 @@ function isPlainObject(value) {
 
 function safelyParseOnboardingDraft() {
   if (typeof window === "undefined") return null;
-
   try {
     const rawDraft = window.sessionStorage?.getItem(UNIVERSAL_ONBOARDING_DRAFT_KEY);
     if (!rawDraft) return null;
-
     const parsedDraft = JSON.parse(rawDraft);
     return isPlainObject(parsedDraft) ? parsedDraft : null;
   } catch (error) {
@@ -221,7 +212,6 @@ function safelyParseOnboardingDraft() {
 
 function persistOnboardingDraft(nextAnswers) {
   if (typeof window === "undefined" || !isPlainObject(nextAnswers)) return;
-
   try {
     window.sessionStorage?.setItem(UNIVERSAL_ONBOARDING_DRAFT_KEY, JSON.stringify(nextAnswers));
   } catch {
@@ -231,11 +221,27 @@ function persistOnboardingDraft(nextAnswers) {
 
 function clearOnboardingDraft() {
   if (typeof window === "undefined") return;
-
   try {
     window.sessionStorage?.removeItem(UNIVERSAL_ONBOARDING_DRAFT_KEY);
   } catch {
     // Draft cleanup is best effort only.
+  }
+}
+
+function persistPostOnboardingBookletIntent() {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage?.setItem(
+      POST_ONBOARDING_BOOKLET_INTENT_KEY,
+      JSON.stringify({
+        intent: TRIAL_PURCHASE_INTENT,
+        planKey: COMMITTED_PLAN_KEY,
+        productId: CLARA_COMMITMENT_PRODUCT_ID,
+        openedAt: Date.now(),
+      })
+    );
+  } catch (error) {
+    warnInDevelopment("CLARA onboarding booklet intent persistence skipped:", error);
   }
 }
 
@@ -248,13 +254,11 @@ function getRecommendedAccessLevel(answers) {
     "risk_warnings",
     "money_coach",
   ]);
-
   const hasCommittedSignal = [
     answers.commitment_level,
     answers.spending_guidance_style,
     answers.guidance_intensity,
   ].some((value) => committedSignals.has(value));
-
   return hasCommittedSignal ? "committed" : "free";
 }
 
@@ -276,11 +280,12 @@ function saveOnboardingAnswersToLocalMemory(userId, answers) {
 
   try {
     const cleanedMemories = getMemories(userId).filter(
-      (memory) => !String(memory?.category || "").startsWith("onboarding_"),
+      (memory) => !String(memory?.category || "").startsWith("onboarding_")
     );
+    const memoryEntries = buildOnboardingMemoryEntries(answers);
 
     setMemories(userId, cleanedMemories);
-    buildOnboardingMemoryEntries(answers).forEach((memory) => appendMemory(userId, memory));
+    memoryEntries.forEach((memory) => appendMemory(userId, memory));
 
     if (typeof window !== "undefined") {
       try {
@@ -291,8 +296,8 @@ function saveOnboardingAnswersToLocalMemory(userId, answers) {
 
       window.dispatchEvent(
         new CustomEvent("clara-onboarding-memory-updated", {
-          detail: { userId, categories: buildOnboardingMemoryEntries(answers).map((memory) => memory.category) },
-        }),
+          detail: { userId, categories: memoryEntries.map((memory) => memory.category) },
+        })
       );
     }
   } catch (error) {
@@ -325,7 +330,6 @@ export default function UniversalOnboarding() {
   useEffect(() => {
     const currentAnswers = isPlainObject(answersRef.current) ? answersRef.current : {};
     const hasCurrentAnswers = Object.keys(currentAnswers).length > 0;
-
     if (hasHydratedAnswersRef.current && hasCurrentAnswers) return;
 
     const profileAnswers = isPlainObject(profile?.onboarding_answers) && Object.keys(profile.onboarding_answers).length > 0
@@ -333,7 +337,6 @@ export default function UniversalOnboarding() {
       : null;
     const draftAnswers = profileAnswers ? null : safelyParseOnboardingDraft();
     const nextAnswers = profileAnswers || draftAnswers || {};
-
     if (!isPlainObject(nextAnswers)) return;
 
     hasHydratedAnswersRef.current = true;
@@ -375,19 +378,9 @@ export default function UniversalOnboarding() {
 
   useEffect(() => {
     const frame = requestAnimationFrame(() => {
-      onboardingShellRef.current?.scrollTo({
-        top: 0,
-        left: 0,
-        behavior: "auto",
-      });
-
-      window.scrollTo({
-        top: 0,
-        left: 0,
-        behavior: "auto",
-      });
+      onboardingShellRef.current?.scrollTo({ top: 0, left: 0, behavior: "auto" });
+      window.scrollTo({ top: 0, left: 0, behavior: "auto" });
     });
-
     return () => cancelAnimationFrame(frame);
   }, [screenIndex]);
 
@@ -431,7 +424,6 @@ export default function UniversalOnboarding() {
 
   function handleSelectAnswer(questionId, optionId) {
     const nextAnswers = { ...getStableAnswersSnapshot(), [questionId]: optionId };
-
     answersRef.current = nextAnswers;
     setAnswers(nextAnswers);
     persistOnboardingDraft(nextAnswers);
@@ -488,7 +480,6 @@ export default function UniversalOnboarding() {
     }
 
     const recommendedAccessSnapshot = getRecommendedAccessLevel(answerSnapshot);
-
     await saveNameIfNeeded();
     await updateProfile({
       onboarding_completed: true,
@@ -543,64 +534,18 @@ export default function UniversalOnboarding() {
       if (!completed) return;
 
       const recommendedAccessSnapshot = getRecommendedAccessLevel(getStableAnswersSnapshot());
-
-      try {
-        const productId = getGooglePlayProductId(COMMITTED_PLAN_KEY);
-        if (!productId) throw new Error("Google Play product is not configured yet.");
-
-        const purchase = await launchGooglePlayPurchase({
-          productId,
-          planKey: COMMITTED_PLAN_KEY,
-          userId: user.id,
-          userEmail: user.email || profile?.email || "",
-        });
-
-        if (purchase?.cancelled) {
-          warnInDevelopment("CLARA Google Play purchase cancelled; routing to enrollment fallback.");
-          navigate(CLARA_TRIAL_ROUTE, {
-            replace: true,
-            state: { fromOnboarding: true, recommendedAccessLevel: recommendedAccessSnapshot },
-          });
-          return;
-        }
-
-        if (!purchase?.ok && !purchase?.restored) {
-          throw new Error("Google Play did not confirm the purchase.");
-        }
-
-        await persistGooglePlayPurchase({
-          supabase,
-          userId: user.id,
-          planKey: COMMITTED_PLAN_KEY,
-          productId,
-          purchaseToken: purchase.purchaseToken,
-          orderId: purchase.orderId,
-          bridgePayload: purchase.raw,
-        });
-
-        const entitlement = await waitForGooglePlayEntitlement({
-          supabase,
-          userId: user.id,
-          expectedPlanKey: COMMITTED_PLAN_KEY,
-        });
-
-        await refreshProfile?.();
-        navigate(entitlement?.status === "active" ? FREE_VERSION_ROUTE : "/pending", {
-          replace: true,
-          state: { fromOnboarding: true, recommendedAccessLevel: recommendedAccessSnapshot },
-        });
-      } catch (error) {
-        warnInDevelopment("CLARA Google Play fallback triggered:", error);
-        navigate(CLARA_TRIAL_ROUTE, {
-          replace: true,
-          state: {
-            fromOnboarding: true,
-            recommendedAccessLevel: recommendedAccessSnapshot,
-            purchaseAutoStartError: error?.message || "Google Play could not open automatically.",
-          },
-        });
-      }
+      persistPostOnboardingBookletIntent();
+      navigate(FREE_VERSION_ROUTE, {
+        replace: true,
+        state: {
+          fromOnboarding: true,
+          openCommitmentBooklet: true,
+          purchaseIntent: TRIAL_PURCHASE_INTENT,
+          recommendedAccessLevel: recommendedAccessSnapshot,
+        },
+      });
     } catch (error) {
+      console.error("Universal onboarding trial routing error:", error);
       setNameError(error?.message === "Please enter your real name." ? error.message : SAVE_ERROR_MESSAGE);
     } finally {
       setSaving(false);
@@ -614,9 +559,7 @@ export default function UniversalOnboarding() {
         <div className="relative mx-auto flex min-h-[100dvh] w-full max-w-3xl items-start justify-start px-3 py-3 sm:items-center sm:justify-center sm:px-6 sm:py-6">
           <div className="max-h-[calc(100dvh-24px)] w-full max-w-xl overflow-y-auto rounded-[28px] border border-white/10 bg-white/[0.04] px-3 pb-4 pt-3 shadow-[0_28px_80px_rgba(0,0,0,0.45)] backdrop-blur-xl [scrollbar-width:none] [&::-webkit-scrollbar]:hidden sm:max-h-[calc(100dvh-48px)] sm:rounded-[32px] sm:px-6 sm:pb-6 sm:pt-6">
             <div className="h-2 w-32 rounded-full bg-white/10" />
-            <div className="mt-6 h-10 w-3/4 rounded-full bg-white/10" />
-            <div className="mt-3 h-4 w-full rounded-full bg-white/[0.06]" />
-            <div className="mt-2 h-4 w-5/6 rounded-full bg-white/[0.06]" />
+            <div className="mt-6 h-10 w-3/4 rounded-2xl bg-white/10" />
             <div className="mt-8 h-48 rounded-[28px] bg-white/[0.05]" />
             <div className="mt-8 h-12 rounded-2xl bg-white/10" />
           </div>
@@ -682,10 +625,8 @@ export default function UniversalOnboarding() {
                     <div className="max-w-xl rounded-[26px] border border-white/10 bg-white/[0.035] p-3 sm:p-4">
                       <p className="text-[10px] font-semibold uppercase tracking-[0.22em] text-[#f4cd71]/75">Setup preview</p>
                       <div className="mt-3 flex flex-wrap gap-2">
-                        {['Commitment', 'Lifestyle Clarity', 'Ask Before You Spend'].map((item) => (
-                          <span key={item} className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1.5 text-xs font-medium text-white/72">
-                            {item}
-                          </span>
+                        {["Commitment", "Lifestyle Clarity", "Ask Before You Spend"].map((item) => (
+                          <span key={item} className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1.5 text-xs font-medium text-white/72">{item}</span>
                         ))}
                       </div>
                     </div>
@@ -756,9 +697,7 @@ export default function UniversalOnboarding() {
                   <div className="flex min-h-full flex-col justify-between gap-4 sm:gap-5">
                     <div className="space-y-4 sm:space-y-5">
                       <div className="space-y-3">
-                        <div className="inline-flex items-center gap-2 rounded-full border border-[#f4cd71]/25 bg-[#f4cd71]/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-[#f7d98e]">
-                          CLARA STARTING PATH
-                        </div>
+                        <div className="inline-flex items-center gap-2 rounded-full border border-[#f4cd71]/25 bg-[#f4cd71]/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-[#f7d98e]">CLARA STARTING PATH</div>
                         <h2 className="max-w-xl text-[1.9rem] font-semibold leading-tight text-white sm:text-4xl">Choose how you want to start with CLARA.</h2>
                       </div>
 
@@ -773,14 +712,10 @@ export default function UniversalOnboarding() {
                                 <h3 className="text-xl font-semibold text-white">Explore CLARA</h3>
                                 <span className="rounded-full border border-[#34d399]/20 bg-[#34d399]/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-[#a7efd0]">7-day trial</span>
                               </div>
-                              <p className="mt-2 text-sm leading-6 text-white/68">
-                                Start your 7-day CLARA trial and experience the guided money clarity journey.
-                              </p>
-                              <p className="mt-3 text-xs leading-5 text-[#f7d98e]/82">
-                                7 days free, then ₱249/month. Cancel anytime before renewal.
-                              </p>
+                              <p className="mt-2 text-sm leading-6 text-white/68">Start your 7-day CLARA trial and experience the guided money clarity journey.</p>
+                              <p className="mt-3 text-xs leading-5 text-[#f7d98e]/82">7 days free, then ₱249/month. Cancel anytime before renewal.</p>
                               <Button type="button" onClick={handleExploreClaraTrial} disabled={saving} className="mt-4 h-12 w-full rounded-2xl bg-[#f4cd71] text-[#101010] hover:bg-[#f7d98e]">
-                                {saving ? "Opening Google Play..." : "Explore CLARA for 7 days"}
+                                {saving ? "Preparing your booklet..." : "Explore CLARA for 7 days"}
                                 {!saving ? <ArrowRight className="h-4 w-4" /> : null}
                               </Button>
                             </div>
@@ -794,9 +729,7 @@ export default function UniversalOnboarding() {
                             </div>
                             <div className="min-w-0 flex-1">
                               <h3 className="text-xl font-semibold text-white">Free Version</h3>
-                              <p className="mt-2 text-sm leading-6 text-white/62">
-                                Start with basic CLARA clarity tools. You can explore first and upgrade when you are ready.
-                              </p>
+                              <p className="mt-2 text-sm leading-6 text-white/62">Start with basic CLARA clarity tools. You can explore first and upgrade when you are ready.</p>
                               <Button type="button" variant="outline" onClick={() => finishOnboarding(FREE_VERSION_ROUTE)} disabled={saving} className="mt-4 h-12 w-full rounded-2xl border-white/12 bg-white/[0.03] text-white hover:bg-white/[0.08]">
                                 Let’s stick with the Free Version
                               </Button>

--- a/supabase/clara_google_play_entitlements.sql
+++ b/supabase/clara_google_play_entitlements.sql
@@ -2,13 +2,21 @@ create extension if not exists pgcrypto;
 
 alter table if exists public.profiles
   add column if not exists tier_type text,
+  add column if not exists plan_key text,
+  add column if not exists subscription_plan text,
   add column if not exists access_level text default 'free',
   add column if not exists purchase_source text,
+  add column if not exists enrollment_source text,
   add column if not exists access_source text,
   add column if not exists admin_plan_override boolean not null default false,
   add column if not exists subscription_status text default 'free',
+  add column if not exists subscription_expires_at timestamptz,
+  add column if not exists trial_started_at timestamptz,
+  add column if not exists trial_ends_at timestamptz,
   add column if not exists play_product_id text,
   add column if not exists play_purchase_token text,
+  add column if not exists recommended_access_level text,
+  add column if not exists onboarding_answers jsonb,
   add column if not exists program_started_at timestamptz,
   add column if not exists program_ends_at timestamptz,
   add column if not exists program_completed_at timestamptz,
@@ -43,6 +51,7 @@ alter table if exists public.enrollments
   add column if not exists last_billing_sync_at timestamptz;
 
 alter table if exists public.plans
+  add column if not exists access_config jsonb,
   add column if not exists product_id text,
   add column if not exists billing_type text;
 
@@ -113,23 +122,33 @@ create or replace function public.clara_product_plan(product_id text)
 returns text
 language sql
 immutable
-as $
+as $$
   select case
-    when product_id in ('clara_commitment_249','clara_pro_99','clara_core_199','clara_lifeos_499','pro_99','core_199','lifeos_499','core_599','coaching_1299') then 'committed_249'
+    when product_id in (
+      'clara_commitment_249',
+      'clara_pro_99',
+      'clara_core_199',
+      'clara_lifeos_499',
+      'pro_99',
+      'core_199',
+      'lifeos_499',
+      'core_599',
+      'coaching_1299'
+    ) then 'committed_249'
     else null
   end
-$;
+$$;
 
 create or replace function public.clara_product_tier(product_id text)
 returns text
 language sql
 immutable
-as $
+as $$
   select case
     when public.clara_product_plan(product_id) = 'committed_249' then 'clara_commitment'
     else null
   end
-$;
+$$;
 
 create or replace function public.process_google_play_purchase(
   p_user_id uuid,
@@ -143,7 +162,7 @@ returns table(purchase_id uuid, enrollment_id uuid, entitlement_status text)
 language plpgsql
 security definer
 set search_path = public
-as $
+as $$
 declare
   v_plan text := public.clara_product_plan(p_product_id);
   v_tier text := public.clara_product_tier(p_product_id);
@@ -152,40 +171,164 @@ declare
   v_existing public.google_play_purchases%rowtype;
   v_now timestamptz := timezone('utc', now());
   v_expires_at timestamptz := case
-    when coalesce(p_payload->>'expiryTimeMillis', '') ~ '^[0-9]+(p_user_id uuid)
+    when coalesce(p_payload->>'expiryTimeMillis', '') ~ '^[0-9]+$'
+      then to_timestamp(((p_payload->>'expiryTimeMillis')::numeric / 1000.0))
+    else null
+  end;
+  v_payload_text text := lower(coalesce(p_payload::text, ''));
+  v_is_trial boolean :=
+    coalesce(p_payload->>'paymentState', '') = '2'
+    or lower(coalesce(p_payload->>'subscriptionStatus', '')) in ('trialing', 'trial', 'free_trial')
+    or lower(coalesce(p_payload->>'purchaseStatus', '')) in ('trialing', 'trial', 'free_trial')
+    or v_payload_text like '%free_trial%'
+    or v_payload_text like '%trialing%';
+  v_subscription_status text := case when v_is_trial then 'trialing' else 'active' end;
+begin
+  if p_user_id is null or p_purchase_token is null or length(trim(p_purchase_token)) = 0 then
+    raise exception 'Missing required purchase fields';
+  end if;
+
+  if v_plan <> 'committed_249' or v_tier is null then
+    raise exception 'Unsupported CLARA product %', p_product_id;
+  end if;
+
+  select * into v_existing
+  from public.google_play_purchases
+  where purchase_token = p_purchase_token;
+
+  if found and v_existing.user_id <> p_user_id then
+    raise exception 'Google Play purchase is already linked to another user';
+  end if;
+
+  insert into public.google_play_purchases (
+    user_id,
+    plan_key,
+    tier_type,
+    product_id,
+    purchase_token,
+    order_id,
+    purchase_state,
+    acknowledgement_state,
+    verified_at,
+    processed_at,
+    raw_payload
+  ) values (
+    p_user_id,
+    'committed_249',
+    'clara_commitment',
+    p_product_id,
+    p_purchase_token,
+    p_order_id,
+    coalesce(p_payload->>'purchaseState', 'purchased'),
+    coalesce(p_payload->>'acknowledgementState', 'acknowledged'),
+    v_now,
+    v_now,
+    p_payload
+  ) on conflict (purchase_token) do update set
+    plan_key = 'committed_249',
+    tier_type = 'clara_commitment',
+    raw_payload = excluded.raw_payload,
+    verified_at = excluded.verified_at,
+    processed_at = coalesce(public.google_play_purchases.processed_at, excluded.processed_at),
+    updated_at = v_now
+  returning id into v_purchase_id;
+
+  insert into public.enrollments (
+    user_id,
+    plan,
+    plan_key,
+    tier_type,
+    source,
+    purchase_source,
+    product_id,
+    play_product_id,
+    purchase_token,
+    play_purchase_token,
+    order_id,
+    status,
+    purchase_payload,
+    last_billing_sync_at
+  ) values (
+    p_user_id,
+    'committed_249',
+    'committed_249',
+    'clara_commitment',
+    'google_play',
+    'google_play',
+    p_product_id,
+    p_product_id,
+    p_purchase_token,
+    p_purchase_token,
+    p_order_id,
+    v_subscription_status,
+    p_payload,
+    v_now
+  ) on conflict do nothing
+  returning id into v_enrollment_id;
+
+  if v_enrollment_id is null then
+    select id into v_enrollment_id
+    from public.enrollments
+    where user_id = p_user_id
+      and (play_purchase_token = p_purchase_token or purchase_token = p_purchase_token)
+    order by created_at desc
+    limit 1;
+  end if;
+
+  update public.profiles set
+    plan = 'committed_249',
+    plan_key = 'committed_249',
+    subscription_plan = 'committed_249',
+    access_level = 'committed',
+    tier_type = 'clara_commitment',
+    enrollment_source = 'google_play',
+    purchase_source = 'google_play',
+    access_source = 'google_play',
+    admin_plan_override = false,
+    subscription_status = v_subscription_status,
+    subscription_label = 'CLARA Commitment',
+    subscription_expires_at = v_expires_at,
+    trial_started_at = case when v_is_trial then coalesce(trial_started_at, v_now) else trial_started_at end,
+    trial_ends_at = case when v_is_trial then v_expires_at else trial_ends_at end,
+    play_product_id = p_product_id,
+    play_purchase_token = p_purchase_token,
+    entitlement_status = 'active',
+    status = 'active',
+    enrollment_status = 'approved',
+    is_enrolled = true,
+    program_active = true,
+    activation_status = 'active',
+    is_activated = true,
+    activated_at = coalesce(activated_at, v_now),
+    last_billing_sync_at = v_now
+  where id = p_user_id;
+
+  purchase_id := v_purchase_id;
+  enrollment_id := v_enrollment_id;
+  entitlement_status := case when v_is_trial then 'trialing' else 'active' end;
+  return next;
+end;
+$$;
+
+create or replace function public.refresh_clara_entitlement_summary(p_user_id uuid)
 returns void
 language plpgsql
 security definer
 set search_path = public
 as $$
-declare
-  v_profile public.profiles%rowtype;
-  v_now timestamptz := timezone('utc', now());
 begin
-  select * into v_profile from public.profiles where id = p_user_id;
-  if not found then return; end if;
-
-  if v_profile.program_completed_at is not null then
-    if v_profile.continuation_pro_ends_at is not null and v_profile.continuation_pro_ends_at > v_now then
-      update public.profiles
-      set plan = 'pro_99', entitlement_status = 'continuation_pro', program_active = false, is_enrolled = false
-      where id = p_user_id;
-    elsif coalesce(v_profile.pro_subscription_status, '') = 'active'
-       or (v_profile.pro_subscription_expires_at is not null and v_profile.pro_subscription_expires_at > v_now) then
-      update public.profiles
-      set plan = 'pro_99', entitlement_status = 'pro_subscription', program_active = false, is_enrolled = false
-      where id = p_user_id;
-    else
-      update public.profiles
-      set plan = 'free', status = 'free', enrollment_status = 'completed', entitlement_status = 'free', program_active = false, is_enrolled = false
-      where id = p_user_id;
-    end if;
-  end if;
+  update public.profiles
+  set
+    plan = case when lower(coalesce(plan, plan_key, subscription_plan, '')) in ('pro','pro_99','core','core_199','core_599','life_os','lifeos','life_os_499','lifeos_499','coach','coaching','coaching_1299','paid','premium','committed_249') then 'committed_249' else 'free' end,
+    plan_key = case when lower(coalesce(plan, plan_key, subscription_plan, '')) in ('pro','pro_99','core','core_199','core_599','life_os','lifeos','life_os_499','lifeos_499','coach','coaching','coaching_1299','paid','premium','committed_249') then 'committed_249' else 'free' end,
+    subscription_plan = case when lower(coalesce(plan, plan_key, subscription_plan, '')) in ('pro','pro_99','core','core_199','core_599','life_os','lifeos','life_os_499','lifeos_499','coach','coaching','coaching_1299','paid','premium','committed_249') then 'committed_249' else 'free' end,
+    access_level = case when lower(coalesce(plan, plan_key, subscription_plan, '')) in ('pro','pro_99','core','core_199','core_599','life_os','lifeos','life_os_499','lifeos_499','coach','coaching','coaching_1299','paid','premium','committed_249') then 'committed' else 'free' end
+  where id = p_user_id;
 end;
 $$;
 
 delete from public.plans
-where lower(coalesce(plan_key, '')) not in ('pro_99', 'core_599', 'coaching_1299');
+where lower(coalesce(plan_key, '')) not in ('free', 'committed_249');
 
 insert into public.plans (
   name,
@@ -198,172 +341,36 @@ insert into public.plans (
   popular,
   sort_order,
   product_id,
-  billing_type
+  billing_type,
+  access_config
 )
 values
   (
-    'PRO',
-    'clara_pro_99',
-    99,
-    'Unlock CLARA PRO tools with a Google Play monthly subscription.',
-    array['Full financial tools', 'PRO-only tool access', 'Monthly Google Play subscription'],
-    'Subscribe to PRO',
+    'Free Version',
+    'free',
+    0,
+    'Use CLARA''s essential money tracking tools for free.',
+    array['Dashboard access', 'Expense tracking', 'Wallet tracking', 'Budget tracking', 'News and updates'],
+    'Start Free',
     true,
     false,
     1,
-    'pro_99',
-    'subscription'
-  ),
-  (
-    'CORE',
-    'core_599',
-    199,
-    'Unlock CORE: the advanced daily spending system with guided support and CLARA Companion intelligence.',
-    array['Complete CORE financial system', 'Advanced daily spending AI through CLARA Companion', 'Guided spending strategy and practical next steps'],
-    'Unlock CORE',
-    true,
-    true,
-    2,
-    'clara_core_199',
-    'subscription'
-  ),
-  (
-    'Life OS',
-    'coaching_1299',
-    499,
-    'Unlock Life OS, CLARA''s broadest decision-intelligence layer for money, planning, and life organization.',
-    array['Complete Life OS operating layer', 'Broader decision intelligence beyond daily spending', 'Life scheduling, organization, and deeper CLARA context'],
-    'Unlock Life OS',
-    true,
-    false,
-    3,
-    'clara_lifeos_499',
-    'subscription'
-  )
-on conflict (plan_key) do update
-set
-  name = excluded.name,
-  price = excluded.price,
-  description = excluded.description,
-  features = excluded.features,
-  cta_label = excluded.cta_label,
-  active = excluded.active,
-  popular = excluded.popular,
-  sort_order = excluded.sort_order,
-  product_id = excluded.product_id,
-  billing_type = excluded.billing_type;
-
-      then to_timestamp(((p_payload->>'expiryTimeMillis')::numeric / 1000.0))
-    else null
-  end;
-begin
-  if p_user_id is null or p_purchase_token is null or length(trim(p_purchase_token)) = 0 then
-    raise exception 'Missing required purchase fields';
-  end if;
-  if v_plan <> 'committed_249' or v_tier is null then
-    raise exception 'Unsupported CLARA product %', p_product_id;
-  end if;
-
-  select * into v_existing from public.google_play_purchases where purchase_token = p_purchase_token;
-  if found and v_existing.user_id <> p_user_id then
-    raise exception 'Google Play purchase is already linked to another user';
-  end if;
-
-  insert into public.google_play_purchases (
-    user_id, plan_key, tier_type, product_id, purchase_token, order_id,
-    purchase_state, acknowledgement_state, verified_at, processed_at, raw_payload
-  ) values (
-    p_user_id, 'committed_249', 'clara_commitment', p_product_id, p_purchase_token, p_order_id,
-    coalesce(p_payload->>'purchaseState','purchased'), coalesce(p_payload->>'acknowledgementState','acknowledged'),
-    v_now, v_now, p_payload
-  ) on conflict (purchase_token) do update set
-    plan_key='committed_249', tier_type='clara_commitment', raw_payload=excluded.raw_payload,
-    verified_at=excluded.verified_at, processed_at=coalesce(public.google_play_purchases.processed_at,excluded.processed_at), updated_at=v_now
-  returning id into v_purchase_id;
-
-  insert into public.enrollments (
-    user_id, plan, plan_key, tier_type, source, purchase_source, product_id, play_product_id,
-    purchase_token, play_purchase_token, order_id, status, purchase_payload, last_billing_sync_at
-  ) values (
-    p_user_id, 'committed_249', 'committed_249', 'clara_commitment', 'google_play', 'google_play',
-    p_product_id, p_product_id, p_purchase_token, p_purchase_token, p_order_id, 'active', p_payload, v_now
-  ) on conflict do nothing returning id into v_enrollment_id;
-
-  if v_enrollment_id is null then
-    select id into v_enrollment_id from public.enrollments
-    where user_id=p_user_id and (play_purchase_token=p_purchase_token or purchase_token=p_purchase_token)
-    order by created_at desc limit 1;
-  end if;
-
-  update public.profiles set
-    plan='committed_249', plan_key='committed_249', subscription_plan='committed_249', access_level='committed',
-    tier_type='clara_commitment', purchase_source='google_play', access_source='google_play', admin_plan_override=false,
-    subscription_status='active', subscription_label='CLARA Commitment', play_product_id=p_product_id,
-    play_purchase_token=p_purchase_token, entitlement_status='active', status='active', enrollment_status='approved',
-    is_enrolled=true, program_active=true, activation_status='active', is_activated=true,
-    activated_at=coalesce(activated_at,v_now), last_billing_sync_at=v_now
-  where id=p_user_id;
-
-  purchase_id := v_purchase_id;
-  enrollment_id := v_enrollment_id;
-  entitlement_status := 'processed';
-  return next;
-end;
-$;
-
-create or replace function public.refresh_clara_entitlement_summary(p_user_id uuid)
-returns void
-language plpgsql
-security definer
-set search_path = public
-as $
-begin
-  update public.profiles
-  set
-    plan = case when lower(coalesce(plan,plan_key,subscription_plan,'')) in ('pro','pro_99','core','core_199','core_599','life_os','lifeos','life_os_499','lifeos_499','coach','coaching','coaching_1299','paid','premium','committed_249') then 'committed_249' else 'free' end,
-    plan_key = case when lower(coalesce(plan,plan_key,subscription_plan,'')) in ('pro','pro_99','core','core_199','core_599','life_os','lifeos','life_os_499','lifeos_499','coach','coaching','coaching_1299','paid','premium','committed_249') then 'committed_249' else 'free' end,
-    subscription_plan = case when lower(coalesce(plan,plan_key,subscription_plan,'')) in ('pro','pro_99','core','core_199','core_599','life_os','lifeos','life_os_499','lifeos_499','coach','coaching','coaching_1299','paid','premium','committed_249') then 'committed_249' else 'free' end,
-    access_level = case when lower(coalesce(plan,plan_key,subscription_plan,'')) in ('pro','pro_99','core','core_199','core_599','life_os','lifeos','life_os_499','lifeos_499','coach','coaching','coaching_1299','paid','premium','committed_249') then 'committed' else 'free' end
-  where id = p_user_id;
-end;
-$;
-
-alter table if exists public.plans
-  add column if not exists access_config jsonb,
-  add column if not exists product_id text,
-  add column if not exists billing_type text;
-
-alter table if exists public.profiles
-  add column if not exists plan_key text,
-  add column if not exists subscription_plan text,
-  add column if not exists access_level text default 'free',
-  add column if not exists access_source text,
-  add column if not exists admin_plan_override boolean not null default false,
-  add column if not exists subscription_status text default 'free',
-  add column if not exists recommended_access_level text,
-  add column if not exists onboarding_answers jsonb;
-
-create unique index if not exists plans_plan_key_unique on public.plans(plan_key);
-
-delete from public.plans where lower(coalesce(plan_key, '')) not in ('free', 'committed_249');
-
-insert into public.plans (
-  name, plan_key, price, description, features, cta_label,
-  active, popular, sort_order, product_id, billing_type, access_config
-)
-values
-  (
-    'Free Version', 'free', 0,
-    'Use CLARA''s essential money tracking tools for free.',
-    array['Dashboard access', 'Expense tracking', 'Wallet tracking', 'Budget tracking', 'News and updates'],
-    'Start Free', true, false, 1, null, null,
+    null,
+    null,
     '{"dashboard":"full","feed":"full","expenses":"full","wallets":"full","budgets":"full","analytics":"off","ai":"off","customization":"off","savings_goals":"off","tasks":"off","modules":"off","community":"off","messages":"off","coaching":"off","news":"full","referrals":"off"}'::jsonb
   ),
   (
-    'Committed', 'committed_249', 249,
+    'Committed',
+    'committed_249',
+    249,
     'Unlock the complete CLARA experience through one monthly commitment.',
     array['Complete CLARA financial system', 'Full AI guidance', 'Me and Schedule access', 'Learning Hub and committed features'],
-    'Start Your Commitment', true, true, 2, 'clara_commitment_249', 'subscription',
+    'Start Your Commitment',
+    true,
+    true,
+    2,
+    'clara_commitment_249',
+    'subscription',
     '{"dashboard":"full","feed":"full","expenses":"full","wallets":"full","budgets":"full","analytics":"full","ai":"full","customization":"full","savings_goals":"full","tasks":"full","modules":"full","community":"full","messages":"full","coaching":"full","news":"full","referrals":"full"}'::jsonb
   )
 on conflict (plan_key) do update set

--- a/supabase/functions/verify-google-play-purchase/index.ts
+++ b/supabase/functions/verify-google-play-purchase/index.ts
@@ -1,7 +1,7 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.4";
 
-const PACKAGE_NAME = "com.clara.moneytracker";
+const PACKAGE_NAME = "com.clara.lifeos.app";
 const CURRENT_PRODUCT_ID = "clara_commitment_249";
 const LEGACY_RECEIPT_PRODUCT_IDS = new Set([
   "clara_pro_99",


### PR DESCRIPTION
## Summary
- Stop onboarding from opening Google Play directly.
- Save onboarding, route to dashboard, and auto-open the Commitment Booklet once.
- Pass `purchaseIntent="trial_7d"` into the booklet and billing flow.
- Update booklet copy and CTA for the 7-day trial.
- Require the native Billing bridge to select a real free `P7D` subscription offer token before launching Play.
- Update Supabase package validation to `com.clara.lifeos.app`.
- Add missing profile columns and trial-aware Google Play purchase processing.

## Deployment notes
Apply the SQL migration to live Supabase and redeploy `verify-google-play-purchase` before testing the purchase flow. Also confirm the real 7-day trial offer exists in Google Play Console for `clara_commitment_249`.