### PR TITLE
Add universal device notifications

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="com.android.vending.BILLING" />
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
 

--- a/android/app/src/main/java/com/clara/lifeos/app/MainActivity.java
+++ b/android/app/src/main/java/com/clara/lifeos/app/MainActivity.java
@@ -1,14 +1,37 @@
 package com.clara.lifeos.app;
 
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.os.Build;
 import android.os.Bundle;
 import com.getcapacitor.BridgeActivity;
 import com.clara.lifeos.app.ClaraBillingPlugin;
 
 public class MainActivity extends BridgeActivity {
+    private static final String CLARA_REMINDERS_CHANNEL_ID = "clara_reminders";
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        createClaraReminderChannel();
         registerPlugin(ClaraBillingPlugin.class);
         super.onCreate(savedInstanceState);
+    }
+
+    private void createClaraReminderChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return;
+        }
+
+        NotificationChannel channel = new NotificationChannel(
+            CLARA_REMINDERS_CHANNEL_ID,
+            "CLARA Reminders",
+            NotificationManager.IMPORTANCE_HIGH
+        );
+        channel.setDescription("Money reminders and important CLARA updates.");
+
+        NotificationManager manager = getSystemService(NotificationManager.class);
+        if (manager != null) {
+            manager.createNotificationChannel(channel);
+        }
     }
 }

--- a/docs/native-notifications-setup.md
+++ b/docs/native-notifications-setup.md
@@ -1,0 +1,144 @@
+# CLARA native notifications setup
+
+CLARA uses a universal notification bridge:
+
+- Supported web browser or installed PWA: Web Push through the existing service worker.
+- Android installed app through Capacitor: native push through Capacitor Push Notifications and Firebase Cloud Messaging.
+- iOS installed app through Capacitor: native push scaffold through Capacitor Push Notifications.
+- Unsupported browser or WebView: in-app notifications remain available.
+
+## 1. Install and sync Capacitor notification plugins
+
+```bash
+npm install @capacitor/push-notifications @capacitor/local-notifications
+npx cap sync
+```
+
+Run `npx cap sync android` before opening Android Studio after dependency changes.
+
+## 2. Firebase Console setup for Android
+
+1. Create or open the Firebase project for CLARA.
+2. Add an Android app using the CLARA package id:
+
+   ```text
+   com.clara.lifeos.app
+   ```
+
+3. Download `google-services.json`.
+4. Place it at:
+
+   ```text
+   android/app/google-services.json
+   ```
+
+Do not commit a production `google-services.json` unless the project policy explicitly allows it. Use a placeholder or keep it in local/CI secrets when possible.
+
+## 3. Android native requirements
+
+The Android app must include:
+
+- Android 13+ permission:
+
+  ```xml
+  android.permission.POST_NOTIFICATIONS
+  ```
+
+- Notification channel id:
+
+  ```text
+  clara_reminders
+  ```
+
+- Channel name:
+
+  ```text
+  CLARA Reminders
+  ```
+
+- Importance:
+
+  ```text
+  High
+  ```
+
+- Description:
+
+  ```text
+  Money reminders and important CLARA updates.
+  ```
+
+This branch creates the channel in `MainActivity.java` and adds the permission in `AndroidManifest.xml`.
+
+## 4. Supabase schema
+
+Run the universal notification device migration:
+
+```sql
+supabase/universal_notification_devices.sql
+```
+
+This creates `public.user_notification_devices` for native FCM/APNs tokens and mirrored web-push subscriptions. The old `public.user_push_subscriptions` table remains for backward compatibility.
+
+## 5. Supabase edge function secrets
+
+Web Push still needs:
+
+```bash
+supabase secrets set VAPID_PUBLIC_KEY=...
+supabase secrets set VAPID_PRIVATE_KEY=...
+supabase secrets set VAPID_SUBJECT="mailto:support@clara.app"
+```
+
+Android FCM needs:
+
+```bash
+supabase secrets set FIREBASE_PROJECT_ID=...
+supabase secrets set FIREBASE_CLIENT_EMAIL=...
+supabase secrets set FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+```
+
+Keep the private key quoted so newline escapes are preserved.
+
+## 6. Build and open Android
+
+```bash
+npm install
+npx cap sync android
+npm run build:android
+npx cap open android
+```
+
+In Android Studio, build and install the app on a real device. Push notification behavior should be tested on a physical device, not only an emulator.
+
+## 7. Testing checklist
+
+### Desktop browser
+
+- Settings → Notifications shows browser/web app wording.
+- Enable device notifications uses Web Push when VAPID is configured.
+- Test notification works.
+- Existing service worker still handles notification taps.
+
+### Unsupported browser or WebView
+
+- Settings → Notifications says browser notifications are unavailable.
+- The app does not crash.
+- In-app notifications still work.
+- Notification category toggles remain usable.
+
+### Android Capacitor installed app
+
+- Settings → Notifications does not say “This browser cannot receive device notifications.”
+- It shows phone/native notification copy.
+- Enable phone notifications requests Android permission.
+- A token is saved to `user_notification_devices` with channel `fcm` and platform `android`.
+- Notification taps open the CLARA route from the payload data.
+- Test notification works through local notifications.
+- `send-task-reminders` can send to the FCM token after Firebase secrets are configured.
+
+### Supabase
+
+- `user_notification_devices` migration runs cleanly.
+- Existing `user_push_subscriptions` rows still work as fallback.
+- Invalid FCM or Web Push targets are deactivated without failing the whole function.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
+    <link rel="manifest" href="./manifest.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>CLARA</title>
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "@capacitor/android": "^8.3.0",
     "@capacitor/cli": "^8.3.0",
     "@capacitor/core": "^8.3.0",
+    "@capacitor/local-notifications": "^8.3.0",
+    "@capacitor/push-notifications": "^8.3.0",
     "@hello-pangea/dnd": "^17.0.0",
     "@hookform/resolvers": "^4.1.2",
     "@radix-ui/react-accordion": "^1.2.3",

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,18 @@
+{
+  "name": "CLARA",
+  "short_name": "CLARA",
+  "description": "CLARA personal money coach",
+  "start_url": "./#/dashboard",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#020617",
+  "theme_color": "#020617",
+  "icons": [
+    {
+      "src": "./favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/src/components/TaskReminderSettingsCard.jsx
+++ b/src/components/TaskReminderSettingsCard.jsx
@@ -63,12 +63,12 @@ export default function TaskReminderSettingsCard({
 
   const permissionLabel =
     permissionState === "granted"
-      ? "Browser permission granted"
+      ? "Device permission granted"
       : permissionState === "denied"
-        ? "Browser permission denied"
+        ? "Device permission denied"
         : permissionState === "unsupported"
-          ? "Push not supported on this browser"
-          : "Browser permission not enabled";
+          ? "Device push is unavailable here"
+          : "Device permission not enabled";
 
   return (
     <div className="rounded-[28px] border border-emerald-400/10 bg-[linear-gradient(180deg,rgba(5,17,31,1)_0%,rgba(6,18,29,0.94)_100%)] p-4 shadow-[0_18px_50px_rgba(0,0,0,0.18)]">
@@ -253,8 +253,8 @@ export default function TaskReminderSettingsCard({
           <div className="flex items-start justify-between gap-4">
             <FieldLabel
               icon={Smartphone}
-              title="Browser push notifications"
-              description="Optional. CLARA can prepare your current device for push reminders when your environment supports it."
+              title="Device push notifications"
+              description="Optional. CLARA can prepare this browser, installed web app, or native phone app for reminders when the environment supports it."
             />
             <button
               type="button"
@@ -276,8 +276,8 @@ export default function TaskReminderSettingsCard({
             </p>
             <p className="mt-1 text-xs leading-6 text-white/52">
               {pushSupported
-                ? "Subscriptions are stored in Supabase and can be targeted by the scheduler-ready edge function."
-                : "In-app reminders still work even when browser push is unavailable."}
+                ? "Device connections are stored in Supabase and can be targeted by the scheduler-ready edge function."
+                : "In-app reminders still work even when device push is unavailable."}
             </p>
           </div>
         </div>

--- a/src/components/notifications/NotificationSettingsPanel.jsx
+++ b/src/components/notifications/NotificationSettingsPanel.jsx
@@ -18,11 +18,7 @@ import useNotificationPreferences from "@/hooks/useNotificationPreferences";
 import {
   hasStoredNotificationPreferences,
 } from "@/lib/notifications/notificationPreferences";
-import {
-  getNotificationPermissionState,
-  showTestNotification,
-  supportsPushNotifications,
-} from "@/lib/push-notifications";
+import { showTestDeviceNotification } from "@/lib/notifications/deviceNotifications";
 
 const SNOOZE_OPTIONS = [
   { value: 30, label: "30 minutes" },
@@ -30,34 +26,54 @@ const SNOOZE_OPTIONS = [
   { value: 180, label: "3 hours" },
 ];
 
-function statusCopy({ pushSupported, permissionState, pushConfigured }) {
-  if (!pushSupported) {
+function environmentBody(environment) {
+  if (environment?.preferredChannel === "native_push" && environment.platform === "android") {
+    return "CLARA can send reminders through this installed Android app.";
+  }
+
+  if (environment?.preferredChannel === "native_push" && environment.platform === "ios") {
+    return "CLARA can send reminders through this installed iPhone app once native push is configured.";
+  }
+
+  if (environment?.preferredChannel === "web_push") {
+    return "CLARA can send reminders through this browser or installed web app.";
+  }
+
+  return "This browser cannot receive device notifications. In-app notifications still work.";
+}
+
+function statusCopy({ environment, permissionState, pushConfigured }) {
+  if (environment?.preferredChannel === "in_app_only") {
     return {
-      title: "Not supported",
-      body: "This browser cannot receive device notifications. In-app notifications still work.",
+      title: "Browser notifications unavailable",
+      body: environmentBody(environment),
     };
   }
+
   if (permissionState === "denied") {
     return {
       title: "Permission blocked",
       body: "Enable notifications in your browser or device settings, then return here.",
     };
   }
-  if (permissionState === "granted" && pushConfigured) {
+
+  if (pushConfigured) {
     return {
-      title: "Enabled on this device",
-      body: "This device is connected for supported CLARA reminders.",
+      title: environment?.preferredChannel === "native_push" ? "Enabled on this phone" : "Enabled on this device",
+      body: environmentBody(environment),
     };
   }
+
   if (permissionState === "granted") {
     return {
-      title: "Permission granted, setup incomplete",
+      title: "Setup incomplete",
       body: "Permission is ready, but push delivery still needs to finish connecting.",
     };
   }
+
   return {
     title: "Not enabled",
-    body: "CLARA will keep using in-app notifications until you enable this device.",
+    body: environmentBody(environment),
   };
 }
 
@@ -102,12 +118,25 @@ export default function NotificationSettingsPanel({ userId, embedded = false }) 
   const [error, setError] = useState("");
   const [testing, setTesting] = useState(false);
 
-  const pushSupported = useMemo(() => supportsPushNotifications(), []);
+  const notificationEnvironment = taskReminderSettings.notificationEnvironment;
+  const pushSupported = taskReminderSettings.pushSupported;
   const deviceStatus = statusCopy({
-    pushSupported,
+    environment: notificationEnvironment,
     permissionState: taskReminderSettings.permissionState,
     pushConfigured: taskReminderSettings.pushConfigured,
   });
+
+  const deviceButtonDisabled =
+    notificationEnvironment?.preferredChannel === "in_app_only" ||
+    taskReminderSettings.pushEnabling ||
+    taskReminderSettings.permissionState === "denied";
+
+  const deviceButtonLabel = useMemo(() => {
+    if (taskReminderSettings.pushEnabling) return "Connecting...";
+    if (taskReminderSettings.pushConfigured) return "Refresh device connection";
+    if (notificationEnvironment?.preferredChannel === "native_push") return "Enable phone notifications";
+    return "Enable device notifications";
+  }, [notificationEnvironment?.preferredChannel, taskReminderSettings.pushConfigured, taskReminderSettings.pushEnabling]);
 
   useEffect(() => {
     let mounted = true;
@@ -205,12 +234,16 @@ export default function NotificationSettingsPanel({ userId, embedded = false }) 
 
     try {
       const result = await taskReminderSettings.enablePush();
+      if (result.permission === "unsupported") {
+        setError(result.reason || "Device notifications are unavailable here, but CLARA will still use in-app notifications.");
+        return;
+      }
       if (result.permission === "denied") {
         setError("Notification permission is blocked. Enable it in your browser or device settings.");
         return;
       }
       if (!result.configured) {
-        setError("Permission was granted, but push delivery is not fully configured for this environment.");
+        setError(result.reason || "Permission was granted, but push delivery is not fully configured for this environment.");
         return;
       }
 
@@ -219,7 +252,7 @@ export default function NotificationSettingsPanel({ userId, embedded = false }) 
       setNotice("Device notifications are enabled on this device.");
     } catch (pushError) {
       console.error("Device notification setup failed:", pushError);
-      setError(pushError?.message || "Unable to enable device notifications right now.");
+      setError(pushError?.message || "Device notifications are unavailable here, but CLARA will still use in-app notifications.");
     }
   }, [syncTaskSettings, taskReminderSettings, updatePreference]);
 
@@ -229,7 +262,7 @@ export default function NotificationSettingsPanel({ userId, embedded = false }) 
     setError("");
 
     try {
-      await showTestNotification();
+      await showTestDeviceNotification();
       setNotice("Test notification sent to this device.");
     } catch (testError) {
       setError(testError?.message || "Unable to show a test notification.");
@@ -274,21 +307,17 @@ export default function NotificationSettingsPanel({ userId, embedded = false }) 
           <button
             type="button"
             onClick={enableDeviceNotifications}
-            disabled={!pushSupported || taskReminderSettings.pushEnabling || taskReminderSettings.permissionState === "denied"}
+            disabled={deviceButtonDisabled}
             className="rounded-2xl border border-cyan-300/20 bg-cyan-300/10 px-4 py-2.5 text-xs font-black text-cyan-50 transition hover:bg-cyan-300/15 disabled:cursor-not-allowed disabled:opacity-45"
           >
-            {taskReminderSettings.pushEnabling
-              ? "Connecting..."
-              : taskReminderSettings.pushConfigured
-                ? "Refresh device connection"
-                : "Enable device notifications"}
+            {deviceButtonLabel}
           </button>
 
           {pushSupported ? (
             <button
               type="button"
               onClick={runTestNotification}
-              disabled={testing || getNotificationPermissionState() !== "granted"}
+              disabled={testing || taskReminderSettings.permissionState !== "granted"}
               className="rounded-2xl border border-white/10 bg-white/[0.055] px-4 py-2.5 text-xs font-bold text-white/70 transition hover:bg-white/[0.09] disabled:cursor-not-allowed disabled:opacity-40"
             >
               {testing ? "Sending..." : "Test notification"}

--- a/src/hooks/useTaskReminderSettings.js
+++ b/src/hooks/useTaskReminderSettings.js
@@ -7,11 +7,19 @@ import {
   upsertTaskReminderSettings,
 } from "@/lib/task-reminders";
 import {
-  enableTaskReminderPush,
-  getExistingPushSubscription,
-  getNotificationPermissionState,
-  supportsPushNotifications,
-} from "@/lib/push-notifications";
+  enableDeviceNotifications,
+  getDeviceNotificationEnvironment,
+  getDeviceNotificationPermissionState,
+  getExistingDeviceNotificationConnection,
+} from "@/lib/notifications/deviceNotifications";
+
+function getInitialPermissionState(environment) {
+  if (!environment?.supportsAnyDevicePush) return "unsupported";
+  if (environment.preferredChannel === "web_push" && typeof Notification !== "undefined") {
+    return Notification.permission;
+  }
+  return "default";
+}
 
 export default function useTaskReminderSettings(userId) {
   const [settings, setSettings] = useState(DEFAULT_TASK_REMINDER_SETTINGS);
@@ -19,27 +27,42 @@ export default function useTaskReminderSettings(userId) {
   const [loading, setLoading] = useState(Boolean(userId));
   const [saving, setSaving] = useState(false);
   const [pushEnabling, setPushEnabling] = useState(false);
-  const [permissionState, setPermissionState] = useState(getNotificationPermissionState());
+  const [notificationEnvironment, setNotificationEnvironment] = useState(getDeviceNotificationEnvironment());
+  const [permissionState, setPermissionState] = useState(() =>
+    getInitialPermissionState(getDeviceNotificationEnvironment())
+  );
   const [pushConfigured, setPushConfigured] = useState(false);
 
-  const pushSupported = useMemo(() => supportsPushNotifications(), []);
+  const pushSupported = useMemo(
+    () => notificationEnvironment.supportsAnyDevicePush,
+    [notificationEnvironment.supportsAnyDevicePush]
+  );
 
   const refreshPushStatus = useCallback(async () => {
-    setPermissionState(getNotificationPermissionState());
+    const environment = getDeviceNotificationEnvironment();
+    setNotificationEnvironment(environment);
 
-    if (!pushSupported) {
+    try {
+      const permission = await getDeviceNotificationPermissionState();
+      setPermissionState(permission);
+    } catch (error) {
+      console.error("Failed checking device notification permission:", error);
+      setPermissionState(environment.supportsAnyDevicePush ? "default" : "unsupported");
+    }
+
+    if (!environment.supportsAnyDevicePush) {
       setPushConfigured(false);
       return;
     }
 
     try {
-      const subscription = await getExistingPushSubscription();
-      setPushConfigured(Boolean(subscription));
+      const connection = await getExistingDeviceNotificationConnection({ userId });
+      setPushConfigured(Boolean(connection));
     } catch (error) {
-      console.error("Failed checking push subscription:", error);
+      console.error("Failed checking device notification connection:", error);
       setPushConfigured(false);
     }
-  }, [pushSupported]);
+  }, [userId]);
 
   const loadSettings = useCallback(async () => {
     if (!userId) {
@@ -102,8 +125,9 @@ export default function useTaskReminderSettings(userId) {
 
     try {
       setPushEnabling(true);
-      const result = await enableTaskReminderPush({ userId });
+      const result = await enableDeviceNotifications({ userId });
       setPermissionState(result.permission);
+      if (result.environment) setNotificationEnvironment(result.environment);
       await refreshPushStatus();
       return result;
     } finally {
@@ -124,6 +148,7 @@ export default function useTaskReminderSettings(userId) {
     dirty,
     saveSettings,
     reloadSettings: loadSettings,
+    notificationEnvironment,
     pushSupported,
     permissionState,
     pushConfigured,

--- a/src/lib/notifications/deviceNotifications.js
+++ b/src/lib/notifications/deviceNotifications.js
@@ -1,0 +1,1 @@
+// Unified CLARA device notification API.

--- a/src/lib/notifications/deviceNotifications.js
+++ b/src/lib/notifications/deviceNotifications.js
@@ -1,1 +1,117 @@
-// Unified CLARA device notification API.
+import { supabase } from "@/lib/supabaseClient";
+import {
+  enableTaskReminderPush,
+  getExistingPushSubscription,
+  getNotificationPermissionState as getWebPermissionState,
+  showTestNotification,
+} from "@/lib/push-notifications";
+import {
+  enableNativePushNotifications,
+  getNativeNotificationStatus,
+} from "@/lib/notifications/nativePushNotifications";
+import { getNotificationEnvironment } from "@/lib/notifications/notificationEnvironment";
+
+const IN_APP_FALLBACK_MESSAGE = "Device notifications are unavailable here, but CLARA will still use in-app notifications.";
+
+export function getDeviceNotificationEnvironment() {
+  return getNotificationEnvironment();
+}
+
+export function supportsDeviceNotifications() {
+  return getNotificationEnvironment().supportsAnyDevicePush;
+}
+
+export async function getDeviceNotificationPermissionState() {
+  const environment = getNotificationEnvironment();
+
+  if (environment.preferredChannel === "native_push") {
+    const status = await getNativeNotificationStatus();
+    return status.permission;
+  }
+
+  if (environment.preferredChannel === "web_push") {
+    return getWebPermissionState();
+  }
+
+  return "unsupported";
+}
+
+export async function enableDeviceNotifications({ userId }) {
+  const environment = getNotificationEnvironment();
+
+  if (environment.preferredChannel === "native_push") {
+    return enableNativePushNotifications({ userId });
+  }
+
+  if (environment.preferredChannel === "web_push") {
+    const result = await enableTaskReminderPush({ userId });
+    return { ...result, channel: "web_push", environment };
+  }
+
+  return {
+    permission: "unsupported",
+    configured: false,
+    environment,
+    reason: IN_APP_FALLBACK_MESSAGE,
+  };
+}
+
+export async function getExistingDeviceNotificationConnection({ userId } = {}) {
+  const environment = getNotificationEnvironment();
+
+  if (environment.preferredChannel === "native_push") {
+    if (!userId) return null;
+
+    const channel = environment.platform === "ios" ? "apns" : "fcm";
+    const { data, error } = await supabase
+      .from("user_notification_devices")
+      .select("id,channel,platform,last_seen_at")
+      .eq("user_id", userId)
+      .eq("channel", channel)
+      .eq("platform", environment.platform)
+      .eq("is_active", true)
+      .order("last_seen_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error) {
+      console.warn("Failed checking native notification device:", error);
+      return null;
+    }
+
+    return data || null;
+  }
+
+  if (environment.preferredChannel === "web_push") {
+    return getExistingPushSubscription();
+  }
+
+  return null;
+}
+
+export async function showTestDeviceNotification() {
+  const environment = getNotificationEnvironment();
+
+  if (environment.preferredChannel === "native_push") {
+    const { LocalNotifications } = await import("@capacitor/local-notifications");
+    await LocalNotifications.schedule({
+      notifications: [
+        {
+          id: Math.floor(Date.now() % 2147483647),
+          title: "CLARA notifications are ready",
+          body: "You’ll receive important reminders based on your preferences.",
+          schedule: { at: new Date(Date.now() + 250) },
+          extra: { url: "#/dashboard", eventType: "test_notification" },
+          channelId: environment.platform === "android" ? "clara_reminders" : undefined,
+        },
+      ],
+    });
+    return;
+  }
+
+  if (environment.preferredChannel === "web_push") {
+    return showTestNotification();
+  }
+
+  throw new Error(IN_APP_FALLBACK_MESSAGE);
+}

--- a/src/lib/notifications/nativePushNotifications.js
+++ b/src/lib/notifications/nativePushNotifications.js
@@ -1,0 +1,211 @@
+import { supabase } from "@/lib/supabaseClient";
+import { getNotificationEnvironment } from "@/lib/notifications/notificationEnvironment";
+
+let listenersInstalled = false;
+
+function normalizePermission(value) {
+  if (value === "granted" || value === "denied") return value;
+  if (value === "prompt" || value === "prompt-with-rationale") return "default";
+  return value || "default";
+}
+
+async function loadPushPlugin() {
+  try {
+    const module = await import("@capacitor/push-notifications");
+    return module.PushNotifications;
+  } catch (error) {
+    console.warn("Native push plugin is unavailable:", error);
+    return null;
+  }
+}
+
+function channelForPlatform(platform) {
+  if (platform === "android") return "fcm";
+  if (platform === "ios") return "apns";
+  return "web_push";
+}
+
+function safeRouteFromNotification(data = {}) {
+  const rawUrl = String(data.url || data.route || data.path || "#/dashboard").trim() || "#/dashboard";
+  if (/^https?:\/\//i.test(rawUrl)) {
+    window.location.href = rawUrl;
+    return;
+  }
+
+  if (rawUrl.startsWith("#")) {
+    window.location.hash = rawUrl.replace(/^#/, "");
+    return;
+  }
+
+  if (rawUrl.startsWith("/")) {
+    window.location.hash = rawUrl;
+    return;
+  }
+
+  window.location.hash = `/${rawUrl.replace(/^\/+/, "")}`;
+}
+
+async function saveNativeToken({ userId, token, platform }) {
+  const cleanToken = String(token || "").trim();
+  if (!cleanToken) throw new Error("Native push registration did not return a token.");
+
+  const { error } = await supabase.from("user_notification_devices").upsert(
+    {
+      user_id: userId,
+      channel: channelForPlatform(platform),
+      platform,
+      token: cleanToken,
+      endpoint: null,
+      subscription: null,
+      device_label: platform === "ios" ? "CLARA iPhone app" : "CLARA Android app",
+      user_agent: typeof navigator !== "undefined" ? navigator.userAgent : null,
+      is_active: true,
+      last_seen_at: new Date().toISOString(),
+    },
+    { onConflict: "token" }
+  );
+
+  if (error) throw error;
+}
+
+export async function requestNativeNotificationPermission() {
+  const environment = getNotificationEnvironment();
+  if (!environment.supportsNativePush) {
+    return { permission: "unsupported", configured: false };
+  }
+
+  const PushNotifications = await loadPushPlugin();
+  if (!PushNotifications) {
+    return { permission: "unsupported", configured: false };
+  }
+
+  const current = await PushNotifications.checkPermissions();
+  const currentPermission = normalizePermission(current?.receive);
+  if (currentPermission === "granted" || currentPermission === "denied") {
+    return { permission: currentPermission, configured: currentPermission === "granted" };
+  }
+
+  const requested = await PushNotifications.requestPermissions();
+  const permission = normalizePermission(requested?.receive);
+  return { permission, configured: permission === "granted" };
+}
+
+export async function enableNativePushNotifications({ userId }) {
+  const environment = getNotificationEnvironment();
+  if (!environment.supportsNativePush) {
+    return { permission: "unsupported", configured: false, token: null, environment };
+  }
+
+  if (!userId) {
+    throw new Error("Sign in to enable device notifications.");
+  }
+
+  const PushNotifications = await loadPushPlugin();
+  if (!PushNotifications) {
+    return { permission: "unsupported", configured: false, token: null, environment };
+  }
+
+  const permissionResult = await requestNativeNotificationPermission();
+  if (permissionResult.permission !== "granted") {
+    return { ...permissionResult, token: null, environment };
+  }
+
+  installNativeNotificationListeners();
+
+  const token = await new Promise(async (resolve, reject) => {
+    let settled = false;
+    let registrationHandle = null;
+    let errorHandle = null;
+    let timeoutId = null;
+
+    const cleanup = async () => {
+      window.clearTimeout(timeoutId);
+      try {
+        await registrationHandle?.remove?.();
+        await errorHandle?.remove?.();
+      } catch {
+        // Listener cleanup should never block setup.
+      }
+    };
+
+    const finish = async (callback, value) => {
+      if (settled) return;
+      settled = true;
+      await cleanup();
+      callback(value);
+    };
+
+    try {
+      registrationHandle = await PushNotifications.addListener("registration", (registrationToken) => {
+        finish(resolve, registrationToken?.value || registrationToken?.token || "");
+      });
+
+      errorHandle = await PushNotifications.addListener("registrationError", (registrationError) => {
+        const message = registrationError?.error || registrationError?.message || "Native push registration failed.";
+        finish(reject, new Error(message));
+      });
+
+      timeoutId = window.setTimeout(() => {
+        finish(reject, new Error("Native push registration timed out."));
+      }, 15000);
+
+      await PushNotifications.register();
+    } catch (error) {
+      await finish(reject, error);
+    }
+  });
+
+  await saveNativeToken({ userId, token, platform: environment.platform });
+
+  return {
+    permission: "granted",
+    configured: true,
+    token,
+    channel: channelForPlatform(environment.platform),
+    environment,
+  };
+}
+
+export async function getNativeNotificationStatus() {
+  const environment = getNotificationEnvironment();
+  if (!environment.supportsNativePush) {
+    return { permission: "unsupported", configured: false, environment };
+  }
+
+  const PushNotifications = await loadPushPlugin();
+  if (!PushNotifications) {
+    return { permission: "unsupported", configured: false, environment };
+  }
+
+  const status = await PushNotifications.checkPermissions();
+  const permission = normalizePermission(status?.receive);
+  return { permission, configured: permission === "granted", environment };
+}
+
+export function installNativeNotificationListeners() {
+  const environment = getNotificationEnvironment();
+  if (!environment.supportsNativePush || listenersInstalled) return;
+
+  listenersInstalled = true;
+
+  loadPushPlugin().then((PushNotifications) => {
+    if (!PushNotifications) return;
+
+    PushNotifications.addListener("registrationError", (error) => {
+      console.error("Native push registration error:", error);
+    });
+
+    PushNotifications.addListener("pushNotificationReceived", (notification) => {
+      window.dispatchEvent(new CustomEvent("clara:native-push-received", { detail: notification }));
+    });
+
+    PushNotifications.addListener("pushNotificationActionPerformed", (event) => {
+      try {
+        const data = event?.notification?.data || {};
+        safeRouteFromNotification(data);
+      } catch (error) {
+        console.warn("Unable to route native notification tap:", error);
+      }
+    });
+  });
+}

--- a/src/lib/notifications/notificationEnvironment.js
+++ b/src/lib/notifications/notificationEnvironment.js
@@ -1,0 +1,66 @@
+import { Capacitor } from "@capacitor/core";
+
+const WEB_PLATFORM = "web";
+
+function hasWindow() {
+  return typeof window !== "undefined";
+}
+
+function getSafeCapacitor() {
+  try {
+    return Capacitor || null;
+  } catch (error) {
+    console.warn("Capacitor runtime detection failed:", error);
+    return null;
+  }
+}
+
+export function supportsWebPushNotifications() {
+  return (
+    hasWindow() &&
+    "Notification" in window &&
+    "serviceWorker" in navigator &&
+    "PushManager" in window
+  );
+}
+
+export function getNotificationEnvironment() {
+  const capacitor = getSafeCapacitor();
+
+  let isNativeRuntime = false;
+  let platform = WEB_PLATFORM;
+
+  try {
+    isNativeRuntime = Boolean(capacitor?.isNativePlatform?.());
+    const detectedPlatform = capacitor?.getPlatform?.();
+    if (detectedPlatform === "android" || detectedPlatform === "ios") {
+      platform = detectedPlatform;
+    }
+  } catch (error) {
+    console.warn("Notification platform detection failed:", error);
+    isNativeRuntime = false;
+    platform = WEB_PLATFORM;
+  }
+
+  const supportsWebPush = supportsWebPushNotifications();
+  const supportsNativePush = isNativeRuntime && (platform === "android" || platform === "ios");
+  const preferredChannel = supportsNativePush
+    ? "native_push"
+    : supportsWebPush
+      ? "web_push"
+      : "in_app_only";
+
+  return {
+    runtime: isNativeRuntime ? "native" : "web",
+    isNativeRuntime,
+    platform: isNativeRuntime ? platform : WEB_PLATFORM,
+    supportsWebPush,
+    supportsNativePush,
+    supportsAnyDevicePush: supportsNativePush || supportsWebPush,
+    preferredChannel,
+  };
+}
+
+export function isNativeNotificationRuntime() {
+  return getNotificationEnvironment().supportsNativePush;
+}

--- a/src/lib/push-notifications.js
+++ b/src/lib/push-notifications.js
@@ -56,6 +56,30 @@ export async function requestBrowserNotificationPermission() {
   return Notification.requestPermission();
 }
 
+async function mirrorWebPushToUniversalDeviceTable({ userId, subscription, serializedSubscription }) {
+  try {
+    const { error } = await supabase.from("user_notification_devices").upsert(
+      {
+        user_id: userId,
+        channel: "web_push",
+        platform: "web",
+        token: null,
+        endpoint: subscription.endpoint,
+        subscription: serializedSubscription,
+        device_label: "CLARA web push",
+        user_agent: navigator.userAgent,
+        is_active: true,
+        last_seen_at: new Date().toISOString(),
+      },
+      { onConflict: "endpoint" }
+    );
+
+    if (error) throw error;
+  } catch (error) {
+    console.warn("Web push universal device mirror failed; legacy web push remains active:", error);
+  }
+}
+
 export async function enableTaskReminderPush({ userId }) {
   if (!userId) {
     throw new Error("Missing user context for push notifications.");
@@ -101,6 +125,8 @@ export async function enableTaskReminderPush({ userId }) {
   );
 
   if (error) throw error;
+
+  await mirrorWebPushToUniversalDeviceTable({ userId, subscription, serializedSubscription });
 
   return {
     permission,

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,6 +6,7 @@ import { AuthProvider } from "@/context/AuthContext";
 import { queryClientInstance } from "@/lib/query-client";
 import { ThemeProvider } from "@/theme/ThemeProvider";
 import { installClaraGlobalClickSound } from "@/lib/claraSoundSystem";
+import { installNativeNotificationListeners } from "@/lib/notifications/nativePushNotifications";
 import "./clara-memory-bridge";
 import "./clara-buy-check-budget-aware-prefilter";
 import "./clara-buy-check-report-router";
@@ -108,6 +109,12 @@ try {
   installClaraGlobalClickSound();
 } catch (error) {
   console.warn("CLARA sound system failed to init:", error);
+}
+
+try {
+  installNativeNotificationListeners();
+} catch (error) {
+  console.warn("CLARA native notification listeners failed to init:", error);
 }
 
 const installClaraSupportComposerEnhancer = () => {};

--- a/supabase/functions/send-task-reminders/index.ts
+++ b/supabase/functions/send-task-reminders/index.ts
@@ -7,12 +7,16 @@ const internalSecret = Deno.env.get("TASK_REMINDER_INTERNAL_SECRET") || "";
 const vapidSubject = Deno.env.get("VAPID_SUBJECT") || "mailto:support@clara.app";
 const vapidPublicKey = Deno.env.get("VAPID_PUBLIC_KEY") || "";
 const vapidPrivateKey = Deno.env.get("VAPID_PRIVATE_KEY") || "";
+const firebaseProjectId = Deno.env.get("FIREBASE_PROJECT_ID") || "";
+const firebaseClientEmail = Deno.env.get("FIREBASE_CLIENT_EMAIL") || "";
+const firebasePrivateKey = (Deno.env.get("FIREBASE_PRIVATE_KEY") || "").replace(/\\n/g, "\n");
 
 if (vapidPublicKey && vapidPrivateKey) {
   webpush.setVapidDetails(vapidSubject, vapidPublicKey, vapidPrivateKey);
 }
 
 const supabase = createClient(supabaseUrl, serviceRoleKey);
+let fcmAccessTokenCache: { token: string; expiresAt: number } | null = null;
 
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -27,6 +31,236 @@ function isAuthorized(request: Request) {
   return Boolean(token && (token === serviceRoleKey || token === internalSecret));
 }
 
+function base64UrlFromString(value: string) {
+  return btoa(value).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function base64UrlFromBuffer(value: ArrayBuffer) {
+  const bytes = new Uint8Array(value);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function pemToArrayBuffer(pem: string) {
+  const clean = pem
+    .replace(/-----BEGIN PRIVATE KEY-----/g, "")
+    .replace(/-----END PRIVATE KEY-----/g, "")
+    .replace(/\s/g, "");
+  const binary = atob(clean);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes.buffer;
+}
+
+async function createServiceAccountJwt() {
+  if (!firebaseClientEmail || !firebasePrivateKey) {
+    throw new Error("Firebase service account secrets are not configured.");
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "RS256", typ: "JWT" };
+  const claims = {
+    iss: firebaseClientEmail,
+    scope: "https://www.googleapis.com/auth/firebase.messaging",
+    aud: "https://oauth2.googleapis.com/token",
+    iat: now,
+    exp: now + 3600,
+  };
+  const unsigned = `${base64UrlFromString(JSON.stringify(header))}.${base64UrlFromString(JSON.stringify(claims))}`;
+  const key = await crypto.subtle.importKey(
+    "pkcs8",
+    pemToArrayBuffer(firebasePrivateKey),
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const signature = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    key,
+    new TextEncoder().encode(unsigned)
+  );
+  return `${unsigned}.${base64UrlFromBuffer(signature)}`;
+}
+
+async function getFcmAccessToken() {
+  if (fcmAccessTokenCache && fcmAccessTokenCache.expiresAt > Date.now() + 60000) {
+    return fcmAccessTokenCache.token;
+  }
+
+  const assertion = await createServiceAccountJwt();
+  const response = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion,
+    }),
+  });
+
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data?.error_description || data?.error || "Unable to fetch Firebase access token.");
+  }
+
+  fcmAccessTokenCache = {
+    token: data.access_token,
+    expiresAt: Date.now() + Number(data.expires_in || 3600) * 1000,
+  };
+  return fcmAccessTokenCache.token;
+}
+
+function buildNotificationPayload(payload: Record<string, unknown>) {
+  return {
+    title: String(payload.title || "CLARA").trim(),
+    body: String(payload.body || "Your guided task is ready.").trim(),
+    url: String(payload.url || "#/lifeos").trim(),
+    dedupeKey: String(payload.dedupe_key || payload.dedupeKey || "").trim(),
+    eventType: String(payload.event_type || payload.eventType || "task_still_incomplete").trim(),
+    icon: payload.icon || "favicon.svg",
+    badge: payload.badge || "favicon.svg",
+  };
+}
+
+function isExpiredWebPush(error: unknown) {
+  const statusCode = Number((error as { statusCode?: number })?.statusCode || 0);
+  return [404, 410].includes(statusCode);
+}
+
+function isInvalidFcmResponse(status: number, text: string) {
+  return [400, 404].includes(status) && /UNREGISTERED|NOT_FOUND|INVALID_ARGUMENT/i.test(text);
+}
+
+async function deactivateDevice(id: string) {
+  await supabase
+    .from("user_notification_devices")
+    .update({ is_active: false, updated_at: new Date().toISOString() })
+    .eq("id", id);
+}
+
+async function sendUniversalDevice(device: Record<string, any>, notification: Record<string, unknown>) {
+  if (device.channel === "web_push") {
+    if (!device.subscription) return { sent: 0, webSent: 0, nativeSent: 0, deactivated: 0, skipped: 1 };
+
+    try {
+      await webpush.sendNotification(device.subscription, JSON.stringify(notification));
+      return { sent: 1, webSent: 1, nativeSent: 0, deactivated: 0, skipped: 0 };
+    } catch (error) {
+      if (isExpiredWebPush(error)) {
+        await deactivateDevice(device.id);
+        return { sent: 0, webSent: 0, nativeSent: 0, deactivated: 1, skipped: 0 };
+      }
+      console.error("Universal web push send failed:", device.endpoint, error);
+      return { sent: 0, webSent: 0, nativeSent: 0, deactivated: 0, skipped: 1 };
+    }
+  }
+
+  if (device.channel === "fcm") {
+    if (!firebaseProjectId || !firebaseClientEmail || !firebasePrivateKey) {
+      console.warn("FCM skipped because Firebase secrets are not configured.");
+      return { sent: 0, webSent: 0, nativeSent: 0, deactivated: 0, skipped: 1 };
+    }
+    if (!device.token) return { sent: 0, webSent: 0, nativeSent: 0, deactivated: 0, skipped: 1 };
+
+    try {
+      const accessToken = await getFcmAccessToken();
+      const response = await fetch(
+        `https://fcm.googleapis.com/v1/projects/${firebaseProjectId}/messages:send`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            message: {
+              token: device.token,
+              notification: {
+                title: notification.title,
+                body: notification.body,
+              },
+              data: {
+                url: String(notification.url || "#/lifeos"),
+                dedupeKey: String(notification.dedupeKey || ""),
+                eventType: String(notification.eventType || "task_still_incomplete"),
+              },
+              android: {
+                priority: "HIGH",
+                notification: {
+                  channel_id: "clara_reminders",
+                },
+              },
+            },
+          }),
+        }
+      );
+
+      const text = await response.text();
+      if (!response.ok) {
+        if (isInvalidFcmResponse(response.status, text)) {
+          await deactivateDevice(device.id);
+          return { sent: 0, webSent: 0, nativeSent: 0, deactivated: 1, skipped: 0 };
+        }
+        console.error("FCM send failed:", response.status, text);
+        return { sent: 0, webSent: 0, nativeSent: 0, deactivated: 0, skipped: 1 };
+      }
+
+      return { sent: 1, webSent: 0, nativeSent: 1, deactivated: 0, skipped: 0 };
+    } catch (error) {
+      console.error("FCM send failed:", error);
+      return { sent: 0, webSent: 0, nativeSent: 0, deactivated: 0, skipped: 1 };
+    }
+  }
+
+  if (device.channel === "apns") {
+    console.warn("APNs notification skipped until iOS native push provider is configured.");
+    return { sent: 0, webSent: 0, nativeSent: 0, deactivated: 0, skipped: 1 };
+  }
+
+  return { sent: 0, webSent: 0, nativeSent: 0, deactivated: 0, skipped: 1 };
+}
+
+async function sendLegacyWebPush(userId: string, notification: Record<string, unknown>) {
+  const { data: subscriptions, error } = await supabase
+    .from("user_push_subscriptions")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("is_active", true);
+
+  if (error) throw error;
+
+  let sent = 0;
+  let deactivated = 0;
+  let skipped = 0;
+
+  for (const subscriptionRow of subscriptions || []) {
+    if (!subscriptionRow.subscription) {
+      skipped += 1;
+      continue;
+    }
+
+    try {
+      await webpush.sendNotification(subscriptionRow.subscription, JSON.stringify(notification));
+      sent += 1;
+    } catch (error) {
+      if (isExpiredWebPush(error)) {
+        await supabase
+          .from("user_push_subscriptions")
+          .update({ is_active: false, updated_at: new Date().toISOString() })
+          .eq("id", subscriptionRow.id);
+        deactivated += 1;
+        continue;
+      }
+      console.error("Legacy web push send failed for endpoint:", subscriptionRow.endpoint, error);
+      skipped += 1;
+    }
+  }
+
+  return { sent, webSent: sent, nativeSent: 0, deactivated, skipped };
+}
+
 Deno.serve(async (request) => {
   if (request.method !== "POST") {
     return jsonResponse({ error: "Method not allowed" }, 405);
@@ -38,16 +272,12 @@ Deno.serve(async (request) => {
   try {
     const payload = await request.json();
     const userId = String(payload.user_id || "").trim();
-    const title = String(payload.title || "CLARA").trim();
-    const body = String(payload.body || "Your guided task is ready.").trim();
-    const url = String(payload.url || "#/lifeos").trim();
-    const dedupeKey = String(payload.dedupe_key || payload.dedupeKey || "").trim();
-    const eventType = String(payload.event_type || payload.eventType || "task_still_incomplete").trim();
+    const notification = buildNotificationPayload(payload);
 
     if (!userId) {
       return jsonResponse({ error: "user_id is required" }, 400);
     }
-    if (!dedupeKey) {
+    if (!notification.dedupeKey) {
       return jsonResponse({ error: "dedupe_key is required" }, 400);
     }
 
@@ -66,58 +296,44 @@ Deno.serve(async (request) => {
     ) {
       return jsonResponse({
         sent: 0,
-        skipped: true,
+        webSent: 0,
+        nativeSent: 0,
+        deactivated: 0,
+        skipped: 1,
+        dedupe_key: notification.dedupeKey,
         reason: "User reminder settings do not allow push notifications",
       });
     }
 
-    const { data: subscriptions, error } = await supabase
-      .from("user_push_subscriptions")
+    const universalResult = await supabase
+      .from("user_notification_devices")
       .select("*")
       .eq("user_id", userId)
       .eq("is_active", true);
 
-    if (error) throw error;
-
-    if (!subscriptions?.length) {
-      return jsonResponse({ sent: 0, skipped: true, reason: "No active subscriptions" });
+    const devices = universalResult.error ? [] : universalResult.data || [];
+    if (universalResult.error) {
+      console.warn("Universal notification device lookup failed; falling back to legacy web push:", universalResult.error);
     }
 
-    let sentCount = 0;
-    let deactivatedCount = 0;
+    let totals = { sent: 0, webSent: 0, nativeSent: 0, deactivated: 0, skipped: 0 };
 
-    for (const subscriptionRow of subscriptions) {
-      if (!subscriptionRow.subscription) continue;
-
-      try {
-        await webpush.sendNotification(
-          subscriptionRow.subscription,
-          JSON.stringify({
-            title,
-            body,
-            url,
-            dedupeKey,
-            eventType,
-            icon: payload.icon || "favicon.svg",
-            badge: payload.badge || "favicon.svg",
-          })
-        );
-        sentCount += 1;
-      } catch (sendError) {
-        const statusCode = Number((sendError as { statusCode?: number })?.statusCode || 0);
-        if ([404, 410].includes(statusCode)) {
-          await supabase
-            .from("user_push_subscriptions")
-            .update({ is_active: false, updated_at: new Date().toISOString() })
-            .eq("id", subscriptionRow.id);
-          deactivatedCount += 1;
-          continue;
-        }
-        console.error("Push send failed for endpoint:", subscriptionRow.endpoint, sendError);
+    if (devices.length) {
+      for (const device of devices) {
+        const result = await sendUniversalDevice(device, notification);
+        totals = {
+          sent: totals.sent + result.sent,
+          webSent: totals.webSent + result.webSent,
+          nativeSent: totals.nativeSent + result.nativeSent,
+          deactivated: totals.deactivated + result.deactivated,
+          skipped: totals.skipped + result.skipped,
+        };
       }
+    } else {
+      totals = await sendLegacyWebPush(userId, notification);
     }
 
-    return jsonResponse({ sent: sentCount, deactivated: deactivatedCount, dedupe_key: dedupeKey });
+    return jsonResponse({ ...totals, dedupe_key: notification.dedupeKey });
   } catch (error) {
     console.error("send-task-reminders failed:", error);
     return jsonResponse(

--- a/supabase/universal_notification_devices.sql
+++ b/supabase/universal_notification_devices.sql
@@ -1,0 +1,74 @@
+create table if not exists public.user_notification_devices (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  channel text not null check (channel in ('web_push','fcm','apns')),
+  platform text not null check (platform in ('web','android','ios')),
+  token text,
+  endpoint text,
+  subscription jsonb,
+  device_label text,
+  user_agent text,
+  is_active boolean not null default true,
+  last_seen_at timestamptz not null default timezone('utc', now()),
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists idx_user_notification_devices_user
+  on public.user_notification_devices (user_id, is_active);
+
+create index if not exists idx_user_notification_devices_channel
+  on public.user_notification_devices (channel);
+
+create index if not exists idx_user_notification_devices_platform
+  on public.user_notification_devices (platform);
+
+create index if not exists idx_user_notification_devices_active
+  on public.user_notification_devices (is_active);
+
+create unique index if not exists uq_user_notification_devices_token
+  on public.user_notification_devices (token)
+  where token is not null;
+
+create unique index if not exists uq_user_notification_devices_endpoint
+  on public.user_notification_devices (endpoint)
+  where endpoint is not null;
+
+create unique index if not exists uq_user_notification_devices_active_token
+  on public.user_notification_devices (token)
+  where is_active = true and token is not null;
+
+create unique index if not exists uq_user_notification_devices_active_endpoint
+  on public.user_notification_devices (endpoint)
+  where is_active = true and endpoint is not null;
+
+create or replace function public.set_notification_devices_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$;
+
+drop trigger if exists user_notification_devices_updated_at on public.user_notification_devices;
+create trigger user_notification_devices_updated_at
+before update on public.user_notification_devices
+for each row execute procedure public.set_notification_devices_updated_at();
+
+alter table public.user_notification_devices enable row level security;
+
+drop policy if exists "users manage own notification devices" on public.user_notification_devices;
+create policy "users manage own notification devices"
+on public.user_notification_devices
+for all
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+drop policy if exists "service role manages notification devices" on public.user_notification_devices;
+create policy "service role manages notification devices"
+on public.user_notification_devices
+for all
+using (auth.role() = 'service_role')
+with check (auth.role() = 'service_role');

--- a/supabase/universal_notification_devices.sql
+++ b/supabase/universal_notification_devices.sql
@@ -26,13 +26,15 @@ create index if not exists idx_user_notification_devices_platform
 create index if not exists idx_user_notification_devices_active
   on public.user_notification_devices (is_active);
 
+-- Required for Supabase upsert(..., { onConflict: "token" }).
+-- PostgreSQL unique indexes allow multiple null values, so web rows with null token stay valid.
 create unique index if not exists uq_user_notification_devices_token
-  on public.user_notification_devices (token)
-  where token is not null;
+  on public.user_notification_devices (token);
 
+-- Required for Supabase upsert(..., { onConflict: "endpoint" }).
+-- Native rows with null endpoint stay valid.
 create unique index if not exists uq_user_notification_devices_endpoint
-  on public.user_notification_devices (endpoint)
-  where endpoint is not null;
+  on public.user_notification_devices (endpoint);
 
 create unique index if not exists uq_user_notification_devices_active_token
   on public.user_notification_devices (token)


### PR DESCRIPTION
Implements universal CLARA device notifications:

- Native Capacitor push path for installed Android/iOS app contexts
- Existing Web Push path preserved for browser/PWA
- In-app fallback for unsupported environments
- Universal notification device table migration
- Edge function support for universal devices, FCM, APNs scaffold, and legacy web-push fallback
- Android notification permission and notification channel
- PWA manifest and native notification setup docs

Note: package-lock was not regenerated in this connector session; run `npm install` and `npx cap sync android` locally after merge.