### PR TITLE
Fix financial carousel one-card swipe sensitivity

### DIFF
--- a/src/components/financial-carousel/logic/useAutoMovingHorizontalCarousel.js
+++ b/src/components/financial-carousel/logic/useAutoMovingHorizontalCarousel.js
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
+const SWIPE_THRESHOLD_PX = 42;
+
 const clampIndex = (index, length) => {
   if (!length) return 0;
   return Math.max(0, Math.min(length - 1, Number(index) || 0));
@@ -18,6 +20,11 @@ export default function useAutoMovingHorizontalCarousel({
   const resumeTimerRef = useRef(null);
   const didSetDefaultSlideRef = useRef(false);
   const isUserInteractingRef = useRef(false);
+  const gestureStartXRef = useRef(null);
+  const gestureStartScrollLeftRef = useRef(0);
+  const gestureStartIndexRef = useRef(0);
+  const isGestureTrackingRef = useRef(false);
+  const settleFrameRef = useRef(null);
   const activeIndexRef = useRef(clampIndex(defaultIndex, itemCount));
   const [activeIndex, setActiveIndex] = useState(() =>
     clampIndex(defaultIndex, itemCount)
@@ -46,14 +53,20 @@ export default function useAutoMovingHorizontalCarousel({
     [itemCount]
   );
 
+  const getSlideWidth = useCallback(() => {
+    const container = carouselRef.current;
+    if (!container || itemCount <= 0) return 1;
+
+    return container.clientWidth || container.scrollWidth / itemCount || 1;
+  }, [itemCount]);
+
   const scrollToIndex = useCallback(
     (nextIndex, behavior = "smooth") => {
       const container = carouselRef.current;
       if (!container || itemCount <= 0) return;
 
       const safeIndex = clampIndex(nextIndex, itemCount);
-      const slideWidth =
-        container.clientWidth || container.scrollWidth / itemCount || 1;
+      const slideWidth = getSlideWidth();
 
       container.scrollTo({
         left: slideWidth * safeIndex,
@@ -62,7 +75,7 @@ export default function useAutoMovingHorizontalCarousel({
 
       setSafeActiveIndex(safeIndex);
     },
-    [itemCount, setSafeActiveIndex]
+    [getSlideWidth, itemCount, setSafeActiveIndex]
   );
 
   const startAutoMove = useCallback(() => {
@@ -98,6 +111,120 @@ export default function useAutoMovingHorizontalCarousel({
     }, resumeDelayMs);
   }, [autoMove, clearResumeTimer, itemCount, resumeDelayMs, startAutoMove]);
 
+  const startGesture = useCallback(
+    (clientX) => {
+      const container = carouselRef.current;
+      if (!container || itemCount <= 0) return;
+
+      pauseAutoMove();
+
+      gestureStartXRef.current = clientX;
+      gestureStartScrollLeftRef.current = container.scrollLeft;
+      gestureStartIndexRef.current = activeIndexRef.current;
+      isGestureTrackingRef.current = true;
+    },
+    [itemCount, pauseAutoMove]
+  );
+
+  const endGesture = useCallback(
+    (clientX) => {
+      const container = carouselRef.current;
+
+      if (!container || itemCount <= 0 || !isGestureTrackingRef.current) {
+        resumeAutoMoveSoon();
+        return;
+      }
+
+      const startX = gestureStartXRef.current;
+      const startIndex = gestureStartIndexRef.current;
+
+      gestureStartXRef.current = null;
+      isGestureTrackingRef.current = false;
+
+      if (typeof startX !== "number") {
+        scrollToIndex(startIndex, "smooth");
+        resumeAutoMoveSoon();
+        return;
+      }
+
+      const dragDelta = clientX - startX;
+      let direction = 0;
+
+      if (Math.abs(dragDelta) >= SWIPE_THRESHOLD_PX) {
+        direction = dragDelta < 0 ? 1 : -1;
+      }
+
+      const targetIndex = clampIndex(startIndex + direction, itemCount);
+
+      if (typeof window === "undefined") {
+        scrollToIndex(targetIndex, "smooth");
+        resumeAutoMoveSoon();
+        return;
+      }
+
+      if (settleFrameRef.current) {
+        window.cancelAnimationFrame(settleFrameRef.current);
+      }
+
+      settleFrameRef.current = window.requestAnimationFrame(() => {
+        scrollToIndex(targetIndex, "smooth");
+      });
+
+      resumeAutoMoveSoon();
+    },
+    [itemCount, resumeAutoMoveSoon, scrollToIndex]
+  );
+
+  const handlePointerDown = useCallback(
+    (event) => {
+      startGesture(event.clientX);
+    },
+    [startGesture]
+  );
+
+  const handlePointerUp = useCallback(
+    (event) => {
+      endGesture(event.clientX);
+    },
+    [endGesture]
+  );
+
+  const handlePointerCancel = useCallback(() => {
+    const startIndex = gestureStartIndexRef.current;
+    isGestureTrackingRef.current = false;
+    gestureStartXRef.current = null;
+    scrollToIndex(startIndex, "smooth");
+    resumeAutoMoveSoon();
+  }, [resumeAutoMoveSoon, scrollToIndex]);
+
+  const handleTouchStart = useCallback(
+    (event) => {
+      const touch = event.touches?.[0];
+      if (!touch) return;
+
+      startGesture(touch.clientX);
+    },
+    [startGesture]
+  );
+
+  const handleTouchEnd = useCallback(
+    (event) => {
+      const touch = event.changedTouches?.[0] || event.touches?.[0];
+
+      if (!touch) {
+        const startIndex = gestureStartIndexRef.current;
+        isGestureTrackingRef.current = false;
+        gestureStartXRef.current = null;
+        scrollToIndex(startIndex, "smooth");
+        resumeAutoMoveSoon();
+        return;
+      }
+
+      endGesture(touch.clientX);
+    },
+    [endGesture, resumeAutoMoveSoon, scrollToIndex]
+  );
+
   const handleScroll = useCallback(() => {
     const container = carouselRef.current;
     if (!container || itemCount <= 0 || typeof window === "undefined") return;
@@ -107,20 +234,20 @@ export default function useAutoMovingHorizontalCarousel({
     }
 
     scrollFrameRef.current = window.requestAnimationFrame(() => {
-      const slideWidth =
-        container.scrollWidth / itemCount || container.clientWidth || 1;
+      const slideWidth = getSlideWidth();
       const index = Math.round(container.scrollLeft / slideWidth);
       setSafeActiveIndex(index);
     });
-  }, [itemCount, setSafeActiveIndex]);
+  }, [getSlideWidth, itemCount, setSafeActiveIndex]);
 
   const interactionHandlers = {
-    onPointerDown: pauseAutoMove,
-    onPointerUp: resumeAutoMoveSoon,
-    onPointerCancel: resumeAutoMoveSoon,
-    onPointerLeave: resumeAutoMoveSoon,
-    onTouchStart: pauseAutoMove,
-    onTouchEnd: resumeAutoMoveSoon,
+    onPointerDown: handlePointerDown,
+    onPointerUp: handlePointerUp,
+    onPointerCancel: handlePointerCancel,
+    onPointerLeave: handlePointerCancel,
+    onTouchStart: handleTouchStart,
+    onTouchEnd: handleTouchEnd,
+    onTouchCancel: handlePointerCancel,
     onMouseEnter: pauseAutoMove,
     onMouseLeave: resumeAutoMoveSoon,
     onFocus: pauseAutoMove,
@@ -150,6 +277,9 @@ export default function useAutoMovingHorizontalCarousel({
     return () => {
       if (scrollFrameRef.current && typeof window !== "undefined") {
         window.cancelAnimationFrame(scrollFrameRef.current);
+      }
+      if (settleFrameRef.current && typeof window !== "undefined") {
+        window.cancelAnimationFrame(settleFrameRef.current);
       }
       clearAutoMoveTimer();
       clearResumeTimer();

--- a/src/components/financial-carousel/logic/useAutoMovingHorizontalCarousel.js
+++ b/src/components/financial-carousel/logic/useAutoMovingHorizontalCarousel.js
@@ -190,6 +190,11 @@ export default function useAutoMovingHorizontalCarousel({
   );
 
   const handlePointerCancel = useCallback(() => {
+    if (!isGestureTrackingRef.current) {
+      resumeAutoMoveSoon();
+      return;
+    }
+
     const startIndex = gestureStartIndexRef.current;
     isGestureTrackingRef.current = false;
     gestureStartXRef.current = null;
@@ -212,17 +217,13 @@ export default function useAutoMovingHorizontalCarousel({
       const touch = event.changedTouches?.[0] || event.touches?.[0];
 
       if (!touch) {
-        const startIndex = gestureStartIndexRef.current;
-        isGestureTrackingRef.current = false;
-        gestureStartXRef.current = null;
-        scrollToIndex(startIndex, "smooth");
-        resumeAutoMoveSoon();
+        handlePointerCancel();
         return;
       }
 
       endGesture(touch.clientX);
     },
-    [endGesture, resumeAutoMoveSoon, scrollToIndex]
+    [endGesture, handlePointerCancel]
   );
 
   const handleScroll = useCallback(() => {

--- a/src/components/financial-carousel/ui/CarouselSlideShell.jsx
+++ b/src/components/financial-carousel/ui/CarouselSlideShell.jsx
@@ -27,7 +27,7 @@ export default function CarouselSlideShell({
 
   return (
     <div
-      className="clara-finance-slide-shell relative flex w-full min-w-full shrink-0 snap-center overflow-visible transition-[height] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]"
+      className="clara-finance-slide-shell relative flex w-full min-w-full shrink-0 snap-center snap-always overflow-visible transition-[height] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]"
       style={{ height: slideHeight, minHeight: slideHeight }}
     >
       <div

--- a/src/components/financial-carousel/ui/CarouselViewport.jsx
+++ b/src/components/financial-carousel/ui/CarouselViewport.jsx
@@ -12,7 +12,7 @@ export default function CarouselViewport({
     allowVerticalOverflow
       ? "overflow-x-auto overflow-y-visible touch-pan-x cursor-grab active:cursor-grabbing"
       : "overflow-x-auto overflow-y-hidden touch-pan-x cursor-grab active:cursor-grabbing",
-    "[scrollbar-width:none] [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden",
+    "[scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
     className,
   ].join(" ");
 


### PR DESCRIPTION
## Summary
- Add controlled gesture tracking so each swipe resolves from the gesture's starting card, not momentum-updated active state.
- Enforce a 42px swipe threshold so tiny accidental drags snap back to the current card.
- Remove iOS native momentum helper from the horizontal viewport and add `snap-always` to slide shells.
- Guard pointer cancel/leave handling so normal desktop hover-leave does not reset the carousel.

## Safety / scope
- Only touches the financial carousel hook and slide/viewport wrappers.
- Does not change card order, business logic, locked-card behavior, financial calculations, Supabase schema, dashboard sizing, dots, or card internals.

## Test checklist
- Open dashboard and confirm Budget remains the default selected card.
- Swipe left slowly and hard: moves exactly one card.
- Swipe right slowly and hard: moves exactly one card.
- Tiny drag: snaps back to starting card.
- Tap carousel dots: still jumps to the selected card.
- Expand Budget, Wallet, Emergency Fund, Savings, and Income Hub if available.
- Confirm locked/free/pro states and console remain clean.