### PR TITLE
Fix runtime device notifications in installed app

### DIFF
--- a/src/hooks/useClaraNotificationRuntime.js
+++ b/src/hooks/useClaraNotificationRuntime.js
@@ -29,9 +29,9 @@ import {
 } from "@/lib/notifications/notificationPreferences";
 import { evaluateFinancialNotifications } from "@/lib/notifications/financialNotificationEvaluator";
 import {
-  getNotificationPermissionState,
-  showDeviceNotification,
-} from "@/lib/push-notifications";
+  getRuntimeDeviceNotificationPermissionState,
+  showRuntimeDeviceNotification,
+} from "@/lib/notifications/deviceNotifications";
 
 const DAILY_COMPLETION_PREFIX = "clara_daily_money_check_in_completed_";
 const EVALUATION_COOLDOWN_MS = 10_000;
@@ -154,6 +154,32 @@ export default function useClaraNotificationRuntime({
       if (typeof latestNavigate === "function") latestNavigate(destination);
     };
 
+    const deliverDeviceNotificationIfAllowed = async (notification, preferences) => {
+      if (preferences.deliveryMode !== "device_and_in_app") return;
+
+      let permission = "unsupported";
+      try {
+        permission = await getRuntimeDeviceNotificationPermissionState();
+      } catch (error) {
+        console.warn("CLARA device notification permission check failed:", error);
+        return;
+      }
+
+      if (permission !== "granted") return;
+
+      try {
+        await showRuntimeDeviceNotification({
+          title: notification.title,
+          body: notification.body,
+          url: notification.destination || "/dashboard",
+          tag: notification.dedupeKey,
+          eventType: notification.eventType,
+        });
+      } catch (error) {
+        console.warn("CLARA device notification delivery failed:", error);
+      }
+    };
+
     const deliverStoredNotification = async (notification, preferences) => {
       if (!notification || notification.deliveredAt || notification.dismissedAt) return;
       if (notification.snoozedUntil && new Date(notification.snoozedUntil) > new Date()) return;
@@ -177,22 +203,7 @@ export default function useClaraNotificationRuntime({
           : undefined,
       });
 
-      if (
-        preferences.deliveryMode === "device_and_in_app" &&
-        getNotificationPermissionState() === "granted"
-      ) {
-        try {
-          await showDeviceNotification({
-            title: notification.title,
-            body: notification.body,
-            url: notification.destination || "/dashboard",
-            tag: notification.dedupeKey,
-            eventType: notification.eventType,
-          });
-        } catch (error) {
-          console.warn("CLARA device notification delivery failed:", error);
-        }
-      }
+      await deliverDeviceNotificationIfAllowed(notification, preferences);
 
       await markNotificationDelivered(userId, notification.id);
     };
@@ -350,6 +361,8 @@ export default function useClaraNotificationRuntime({
           },
         },
       });
+
+      await deliverDeviceNotificationIfAllowed(result.notification, preferences);
 
       await Promise.all([
         markNotificationDelivered(userId, result.notification.id),

--- a/src/lib/notifications/deviceNotifications.js
+++ b/src/lib/notifications/deviceNotifications.js
@@ -3,6 +3,7 @@ import {
   enableTaskReminderPush,
   getExistingPushSubscription,
   getNotificationPermissionState as getWebPermissionState,
+  showDeviceNotification as showWebDeviceNotification,
   showTestNotification,
 } from "@/lib/push-notifications";
 import {
@@ -12,6 +13,143 @@ import {
 import { getNotificationEnvironment } from "@/lib/notifications/notificationEnvironment";
 
 const IN_APP_FALLBACK_MESSAGE = "Device notifications are unavailable here, but CLARA will still use in-app notifications.";
+
+let localNotificationListenersInstalled = false;
+let warnedLocalNotificationsUnavailable = false;
+
+function normalizePermission(value) {
+  if (value === "granted" || value === "denied") return value;
+  if (value === "prompt" || value === "prompt-with-rationale") return "default";
+  return value || "default";
+}
+
+function normalizeRuntimeNotificationUrl(url) {
+  const rawUrl = String(url || "").trim();
+  if (!rawUrl) return "#/dashboard";
+  if (/^https?:\/\//i.test(rawUrl)) return rawUrl;
+  if (rawUrl.startsWith("#")) return rawUrl;
+  if (rawUrl.startsWith("/")) return `#${rawUrl}`;
+  return `#/${rawUrl.replace(/^\/+/, "")}`;
+}
+
+function routeRuntimeNotificationUrl(url) {
+  if (typeof window === "undefined") return;
+
+  const safeUrl = normalizeRuntimeNotificationUrl(url);
+
+  if (/^https?:\/\//i.test(safeUrl)) {
+    window.location.href = safeUrl;
+    return;
+  }
+
+  if (safeUrl.startsWith("#")) {
+    window.location.hash = safeUrl.replace(/^#/, "");
+    return;
+  }
+
+  if (safeUrl.startsWith("/")) {
+    window.location.hash = safeUrl;
+    return;
+  }
+
+  window.location.hash = `/${safeUrl.replace(/^\/+/, "")}`;
+}
+
+async function loadLocalNotificationsPlugin() {
+  try {
+    const module = await import("@capacitor/local-notifications");
+    return module.LocalNotifications;
+  } catch (error) {
+    if (!warnedLocalNotificationsUnavailable) {
+      warnedLocalNotificationsUnavailable = true;
+      console.warn("Native local notifications plugin is unavailable:", error);
+    }
+    return null;
+  }
+}
+
+function installLocalNotificationTapListener(LocalNotifications) {
+  if (localNotificationListenersInstalled || !LocalNotifications?.addListener) return;
+
+  localNotificationListenersInstalled = true;
+
+  LocalNotifications.addListener("localNotificationActionPerformed", (event) => {
+    try {
+      const extra = event?.notification?.extra || {};
+      routeRuntimeNotificationUrl(extra.url);
+    } catch (error) {
+      console.warn("Unable to route local notification tap:", error);
+    }
+  }).catch((error) => {
+    localNotificationListenersInstalled = false;
+    console.warn("Unable to install local notification tap listener:", error);
+  });
+}
+
+async function getLocalNotificationPermissionState(LocalNotifications) {
+  if (!LocalNotifications?.checkPermissions) return "unsupported";
+
+  const status = await LocalNotifications.checkPermissions();
+  return normalizePermission(status?.display || status?.receive);
+}
+
+async function requestLocalNotificationPermission(LocalNotifications) {
+  const currentPermission = await getLocalNotificationPermissionState(LocalNotifications);
+  if (currentPermission === "granted" || currentPermission === "denied") {
+    return currentPermission;
+  }
+
+  if (!LocalNotifications?.requestPermissions) return currentPermission;
+
+  const requested = await LocalNotifications.requestPermissions();
+  return normalizePermission(requested?.display || requested?.receive);
+}
+
+async function scheduleNativeRuntimeNotification({
+  title,
+  body,
+  url,
+  tag,
+  eventType,
+  environment,
+} = {}) {
+  const LocalNotifications = await loadLocalNotificationsPlugin();
+
+  if (!LocalNotifications) {
+    throw new Error(IN_APP_FALLBACK_MESSAGE);
+  }
+
+  const permission = await requestLocalNotificationPermission(LocalNotifications);
+  if (permission !== "granted") {
+    if (permission === "denied") {
+      console.warn("CLARA local notification skipped because device permission is denied.");
+    }
+    return { delivered: false, permission, environment };
+  }
+
+  installLocalNotificationTapListener(LocalNotifications);
+
+  const safeUrl = normalizeRuntimeNotificationUrl(url || "#/dashboard");
+
+  await LocalNotifications.schedule({
+    notifications: [
+      {
+        id: Math.floor(Date.now() % 2147483647),
+        title: title || "CLARA",
+        body: body || "CLARA has an update for you.",
+        schedule: { at: new Date(Date.now() + 250) },
+        extra: {
+          url: safeUrl,
+          tag: tag || "",
+          eventType: eventType || "",
+        },
+        channelId: environment?.platform === "android" ? "clara_reminders" : undefined,
+      },
+    ],
+  });
+
+  return { delivered: true, permission, environment };
+}
 
 export function getDeviceNotificationEnvironment() {
   return getNotificationEnvironment();
@@ -25,6 +163,27 @@ export async function getDeviceNotificationPermissionState() {
   const environment = getNotificationEnvironment();
 
   if (environment.preferredChannel === "native_push") {
+    const status = await getNativeNotificationStatus();
+    return status.permission;
+  }
+
+  if (environment.preferredChannel === "web_push") {
+    return getWebPermissionState();
+  }
+
+  return "unsupported";
+}
+
+export async function getRuntimeDeviceNotificationPermissionState() {
+  const environment = getNotificationEnvironment();
+
+  if (environment.preferredChannel === "native_push") {
+    const LocalNotifications = await loadLocalNotificationsPlugin();
+    if (LocalNotifications) {
+      const permission = await getLocalNotificationPermissionState(LocalNotifications);
+      if (permission !== "unsupported") return permission;
+    }
+
     const status = await getNativeNotificationStatus();
     return status.permission;
   }
@@ -89,24 +248,57 @@ export async function getExistingDeviceNotificationConnection({ userId } = {}) {
   return null;
 }
 
+export async function showRuntimeDeviceNotification({
+  title,
+  body,
+  url = "#/dashboard",
+  tag = "",
+  eventType = "",
+} = {}) {
+  const environment = getNotificationEnvironment();
+
+  if (environment.preferredChannel === "native_push") {
+    return scheduleNativeRuntimeNotification({
+      title,
+      body,
+      url,
+      tag,
+      eventType,
+      environment,
+    });
+  }
+
+  if (environment.preferredChannel === "web_push") {
+    return showWebDeviceNotification({
+      title,
+      body,
+      url: normalizeRuntimeNotificationUrl(url),
+      tag,
+      eventType,
+    });
+  }
+
+  throw new Error(IN_APP_FALLBACK_MESSAGE);
+}
+
 export async function showTestDeviceNotification() {
   const environment = getNotificationEnvironment();
 
   if (environment.preferredChannel === "native_push") {
-    const { LocalNotifications } = await import("@capacitor/local-notifications");
-    await LocalNotifications.schedule({
-      notifications: [
-        {
-          id: Math.floor(Date.now() % 2147483647),
-          title: "CLARA notifications are ready",
-          body: "You’ll receive important reminders based on your preferences.",
-          schedule: { at: new Date(Date.now() + 250) },
-          extra: { url: "#/dashboard", eventType: "test_notification" },
-          channelId: environment.platform === "android" ? "clara_reminders" : undefined,
-        },
-      ],
+    const result = await scheduleNativeRuntimeNotification({
+      title: "CLARA notifications are ready",
+      body: "You’ll receive important reminders based on your preferences.",
+      url: "#/dashboard",
+      tag: `clara-test-${Date.now()}`,
+      eventType: "test_notification",
+      environment,
     });
-    return;
+
+    if (!result.delivered) {
+      throw new Error("Notification permission is not granted on this device.");
+    }
+
+    return result;
   }
 
   if (environment.preferredChannel === "web_push") {


### PR DESCRIPTION
## Summary
- Added a runtime-safe device notification bridge in `deviceNotifications.js`.
- Uses Capacitor Local Notifications for installed native app runtime reminders.
- Keeps browser/PWA delivery on the existing web push helper.
- Keeps unsupported environments on in-app fallback only.
- Adds one guarded local notification tap listener that routes `extra.url` safely.
- Updates `useClaraNotificationRuntime` to use the device-aware permission/delivery helpers instead of direct browser push helpers.
- Also delivers task reminders through the same helper because that runtime path previously showed only the in-app toast before marking the reminder delivered.

## Guardrails kept
- Did not change Google Play billing.
- Did not change Supabase auth.
- Did not change notification settings UI layout.
- Did not rename Android channel `clara_reminders`.
- Did not remove native push token registration.
- Did not remove web push support.
- Did not remove in-app notification fallback.

## Validation notes
I syntax-checked the updated JS files locally with `node --check`. Full app validation still needs the requested device checklist:
1. `npm build`
2. `npm run build:android`
3. `npx cap sync android`
4. Install on a real Android phone
5. Enable phone notifications
6. Send Settings test notification
7. Trigger runtime reminder
8. Confirm notification appears and tap routes correctly