### PR TITLE
Fix Income Hub subtitle copy

### DIFF
--- a/src/components/financial-carousel/cards/investment/logic/useInvestmentCardLogic.js
+++ b/src/components/financial-carousel/cards/investment/logic/useInvestmentCardLogic.js
@@ -225,7 +225,7 @@ export default function useInvestmentCardLogic({
 
   const tone = getIncomeToneClasses();
   const title = data.title || "Income Hub";
-  const subtitle = data.subtitle || "Where your money comes from";
+  const subtitle = "Where your money comes";
   const readiness = useMemo(() => buildIncomeSummary(incomeSources), [incomeSources]);
   const statusMeta = getStatusMeta(readiness.sourceCount);
   const amountStatus = readiness.sourceCount > 0


### PR DESCRIPTION
## Summary
- Force the Income Hub card header subtitle to the shorter premium copy: `Where your money comes`
- Prevent the longer carousel-provided subtitle from squeezing under the `Set up` pill on mobile

## Notes
- No income source logic changed
- No setup state logic changed
- No card sizing or redesign changed