### PR TITLE
Add CLARA schedule and calendar notifications

### DIFF
--- a/src/clara-schedule-notification-runtime-bridge.js
+++ b/src/clara-schedule-notification-runtime-bridge.js
@@ -1,0 +1,218 @@
+const SCHEDULE_STORAGE_PREFIX = "clara_schedule_events_v2_";
+const SCHEDULE_UPDATE_EVENT = "clara:schedule-events-updated";
+const FINANCE_UPDATE_EVENT = "clara:finance-data-updated";
+const INSTALLED_FLAG = "__claraScheduleNotificationRuntimeBridgeInstalled";
+const MONEY_KEYWORDS = /\b(bill|rent|payment|payday|salary|due|fee|tuition)\b/i;
+
+let notifyRuntimeTimer = null;
+
+function safeParseEvents(raw) {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function cleanString(value) {
+  return String(value || "").replace(/\s+/g, " ").trim();
+}
+
+function cleanMoney(value) {
+  const parsed = Number(cleanString(value).replace(/[₱,\s]/g, ""));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function isScheduleKey(key) {
+  return typeof key === "string" && key.startsWith(SCHEDULE_STORAGE_PREFIX);
+}
+
+function userIdFromScheduleKey(key) {
+  return cleanString(key).slice(SCHEDULE_STORAGE_PREFIX.length) || "guest";
+}
+
+function isSampleEvent(event) {
+  const id = cleanString(event?.id).toLowerCase();
+  const title = cleanString(event?.title).toLowerCase();
+  return id.startsWith("sample-") || title.includes("lifeos check-in");
+}
+
+function isMoneyEvent(event) {
+  const type = cleanString(event?.type).toLowerCase();
+  const text = `${event?.title || ""} ${event?.note || ""}`;
+
+  return Boolean(
+    cleanMoney(event?.amount) > 0 ||
+      type === "bill" ||
+      type === "payday" ||
+      MONEY_KEYWORDS.test(text)
+  );
+}
+
+function eventSignature(event) {
+  return JSON.stringify({
+    id: cleanString(event?.id),
+    title: cleanString(event?.title),
+    date: cleanString(event?.date),
+    time: cleanString(event?.time),
+    type: cleanString(event?.type),
+    amount: cleanString(event?.amount),
+    note: cleanString(event?.note),
+  });
+}
+
+function findChangedEvents(previousEvents, nextEvents) {
+  const previousById = new Map();
+  previousEvents.forEach((event) => {
+    const id = cleanString(event?.id);
+    if (id) previousById.set(id, eventSignature(event));
+  });
+
+  return nextEvents.filter((event) => {
+    const id = cleanString(event?.id);
+    if (!id || !cleanString(event?.title) || !cleanString(event?.date) || isSampleEvent(event)) return false;
+    return previousById.get(id) !== eventSignature(event);
+  });
+}
+
+function dispatchScheduleUpdated(key, events) {
+  if (typeof window === "undefined") return;
+
+  window.dispatchEvent(
+    new CustomEvent(SCHEDULE_UPDATE_EVENT, {
+      detail: {
+        userId: userIdFromScheduleKey(key),
+        count: events.length,
+      },
+    })
+  );
+}
+
+function notifyExistingRuntime(reason = "schedule") {
+  if (typeof window === "undefined") return;
+
+  if (notifyRuntimeTimer) window.clearTimeout(notifyRuntimeTimer);
+  notifyRuntimeTimer = window.setTimeout(() => {
+    notifyRuntimeTimer = null;
+    window.dispatchEvent(
+      new CustomEvent(FINANCE_UPDATE_EVENT, {
+        detail: { source: reason },
+      })
+    );
+  }, 250);
+}
+
+function parseScheduleDateTime(dateKey, time = "09:00", dayOffset = 0) {
+  const [year, month, day] = cleanString(dateKey).split("-").map(Number);
+  const [hour = 9, minute = 0] = cleanString(time || "09:00").split(":").map(Number);
+
+  if (!year || !month || !day) return null;
+  if (!Number.isFinite(hour) || !Number.isFinite(minute)) return null;
+
+  const date = new Date(year, month - 1, day + dayOffset, hour, minute, 0, 0);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function scheduleFutureDate({ event, at, title, body, tag, eventType }) {
+  if (!at || at <= new Date()) return;
+
+  import("@/lib/notifications/deviceNotifications")
+    .then(({ scheduleNativeCalendarNotification }) => {
+      if (typeof scheduleNativeCalendarNotification !== "function") return null;
+      return scheduleNativeCalendarNotification({
+        id: `${event.id}:${tag}`,
+        title,
+        body,
+        at,
+        url: "#/dashboard",
+        tag,
+        eventType,
+      });
+    })
+    .catch((error) => {
+      console.warn("CLARA schedule native reminder scheduling failed:", error);
+    });
+}
+
+function scheduleNativeRemindersForEvent(event) {
+  const id = cleanString(event?.id);
+  const title = cleanString(event?.title);
+  const date = cleanString(event?.date);
+  const time = cleanString(event?.time);
+
+  if (!id || !title || !date || isSampleEvent(event)) return;
+
+  if (time) {
+    const eventTime = parseScheduleDateTime(date, time, 0);
+    if (eventTime) {
+      scheduleFutureDate({
+        event: { ...event, id },
+        at: new Date(eventTime.getTime() - 60 * 60 * 1000),
+        title: "Upcoming schedule soon",
+        body: `${title} starts in about 1 hour.`,
+        tag: `schedule:${id}:${date}:1hour`,
+        eventType: "schedule_event_upcoming",
+      });
+      scheduleFutureDate({
+        event: { ...event, id },
+        at: eventTime,
+        title: "Schedule now",
+        body: `${title} is on your calendar now.`,
+        tag: `schedule:${id}:${date}:time`,
+        eventType: "schedule_event_today",
+      });
+    }
+  } else {
+    scheduleFutureDate({
+      event: { ...event, id },
+      at: parseScheduleDateTime(date, "09:00", 0),
+      title: "Schedule today",
+      body: `${title} is on your calendar today.`,
+      tag: `schedule:${id}:${date}:0900`,
+      eventType: "schedule_event_today",
+    });
+  }
+
+  if (isMoneyEvent(event)) {
+    scheduleFutureDate({
+      event: { ...event, id },
+      at: parseScheduleDateTime(date, "09:00", -1),
+      title: "Money-impact schedule coming",
+      body: cleanMoney(event.amount) > 0
+        ? `₱${cleanMoney(event.amount).toLocaleString()} may be involved for ${title}. Prepare before optional spending.`
+        : `${title} may affect your money. Prepare before optional spending.`,
+      tag: `schedule:${id}:${date}:money`,
+      eventType: "schedule_money_event_due",
+    });
+  }
+}
+
+function installScheduleStorageBridge() {
+  if (typeof window === "undefined" || !window.localStorage) return;
+  if (window[INSTALLED_FLAG]) return;
+
+  window[INSTALLED_FLAG] = true;
+
+  const originalSetItem = window.localStorage.setItem.bind(window.localStorage);
+
+  window.localStorage.setItem = (key, value) => {
+    const scheduleKey = isScheduleKey(key);
+    const previousEvents = scheduleKey ? safeParseEvents(window.localStorage.getItem(key)) : [];
+
+    originalSetItem(key, value);
+
+    if (!scheduleKey) return;
+
+    const nextEvents = safeParseEvents(value);
+    dispatchScheduleUpdated(key, nextEvents);
+    notifyExistingRuntime("schedule");
+
+    findChangedEvents(previousEvents, nextEvents).forEach(scheduleNativeRemindersForEvent);
+  };
+
+  window.addEventListener(SCHEDULE_UPDATE_EVENT, () => notifyExistingRuntime("schedule-event"));
+}
+
+installScheduleStorageBridge();

--- a/src/lib/notifications/deviceNotifications.js
+++ b/src/lib/notifications/deviceNotifications.js
@@ -105,6 +105,19 @@ async function requestLocalNotificationPermission(LocalNotifications) {
   return normalizePermission(requested?.display || requested?.receive);
 }
 
+function deterministicNotificationId(value) {
+  const source = String(value || "").trim();
+  if (!source) return Math.floor(Date.now() % 2147483647);
+
+  let hash = 0;
+  for (let index = 0; index < source.length; index += 1) {
+    hash = ((hash << 5) - hash + source.charCodeAt(index)) | 0;
+  }
+
+  const positive = Math.abs(hash);
+  return positive > 0 ? positive % 2147483647 : Math.floor(Date.now() % 2147483647);
+}
+
 async function scheduleNativeRuntimeNotification({
   title,
   body,
@@ -149,6 +162,60 @@ async function scheduleNativeRuntimeNotification({
   });
 
   return { delivered: true, permission, environment };
+}
+
+export async function scheduleNativeCalendarNotification({
+  id,
+  title,
+  body,
+  at,
+  url = "#/dashboard",
+  tag = "",
+  eventType = "schedule_event_today",
+} = {}) {
+  const environment = getNotificationEnvironment();
+  const scheduledAt = at instanceof Date ? at : new Date(at);
+
+  if (!(scheduledAt instanceof Date) || Number.isNaN(scheduledAt.getTime()) || scheduledAt <= new Date()) {
+    return { delivered: false, permission: "skipped", environment, reason: "invalid_or_past_schedule" };
+  }
+
+  const LocalNotifications = await loadLocalNotificationsPlugin();
+  if (!LocalNotifications) {
+    return { delivered: false, permission: "unsupported", environment, reason: IN_APP_FALLBACK_MESSAGE };
+  }
+
+  const permission = await requestLocalNotificationPermission(LocalNotifications);
+  if (permission !== "granted") {
+    if (permission === "denied") {
+      console.warn("CLARA calendar notification skipped because device permission is denied.");
+    }
+    return { delivered: false, permission, environment };
+  }
+
+  installLocalNotificationTapListener(LocalNotifications);
+
+  const safeUrl = normalizeRuntimeNotificationUrl(url || "#/dashboard");
+  const stableKey = `${id || tag || eventType}:${scheduledAt.toISOString()}`;
+
+  await LocalNotifications.schedule({
+    notifications: [
+      {
+        id: deterministicNotificationId(stableKey),
+        title: title || "CLARA schedule reminder",
+        body: body || "You have a schedule reminder from CLARA.",
+        schedule: { at: scheduledAt },
+        extra: {
+          url: safeUrl,
+          tag: tag || "",
+          eventType: eventType || "schedule_event_today",
+        },
+        channelId: environment?.platform === "android" ? "clara_reminders" : undefined,
+      },
+    ],
+  });
+
+  return { delivered: true, permission, environment, scheduledAt: scheduledAt.toISOString() };
 }
 
 export function getDeviceNotificationEnvironment() {

--- a/src/lib/notifications/financialNotificationEvaluator.js
+++ b/src/lib/notifications/financialNotificationEvaluator.js
@@ -11,10 +11,9 @@ import {
   createNotification,
   getNotificationByDedupeKey,
 } from "@/lib/notifications/localNotificationRepository";
+import { evaluateScheduleNotifications } from "@/lib/notifications/scheduleNotificationEvaluator";
 
 const SAVINGS_MILESTONES = [25, 50, 75, 100];
-const WEEKLY_REVIEW_EVENT_TYPE = "weekly_review_ready";
-const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
 function numberFrom(value) {
   if (typeof value === "number") return Number.isFinite(value) ? value : 0;
@@ -165,216 +164,6 @@ async function createSavingsNotifications({ userId, preferences, savingsGoals })
   return created;
 }
 
-function safeTimezone(value) {
-  const timezone = String(value || "").trim() || "UTC";
-  try {
-    Intl.DateTimeFormat("en-US", { timeZone: timezone }).format(new Date());
-    return timezone;
-  } catch {
-    return "UTC";
-  }
-}
-
-function weeklyDateParts(timezone, date = new Date()) {
-  const safeZone = safeTimezone(timezone);
-  const formatter = new Intl.DateTimeFormat("en-CA", {
-    timeZone: safeZone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    hourCycle: "h23",
-  });
-  const parts = Object.fromEntries(
-    formatter.formatToParts(date).map((part) => [part.type, part.value])
-  );
-  const weekday = new Intl.DateTimeFormat("en-US", {
-    timeZone: safeZone,
-    weekday: "short",
-  }).format(date);
-
-  return {
-    dateKey: `${parts.year}-${parts.month}-${parts.day}`,
-    minutes: Number(parts.hour) * 60 + Number(parts.minute),
-    dayIndex: Math.max(WEEKDAY_LABELS.indexOf(weekday), 0),
-  };
-}
-
-function addDays(dateKey, amount) {
-  const [year, month, day] = String(dateKey || "").split("-").map(Number);
-  if (!year || !month || !day) return "";
-  const date = new Date(Date.UTC(year, month - 1, day + amount));
-  return date.toISOString().slice(0, 10);
-}
-
-function weeklyRange(dateKey, dayIndex) {
-  const daysSinceMonday = dayIndex === 0 ? 6 : dayIndex - 1;
-  const weekStartKey = addDays(dateKey, -daysSinceMonday);
-  const weekEndKey = addDays(weekStartKey, 6);
-  return { weekStartKey, weekEndKey };
-}
-
-function reviewDay(value) {
-  const day = Number(value);
-  return Number.isInteger(day) && day >= 0 && day <= 6 ? day : 0;
-}
-
-function reviewTimeMinutes(value) {
-  const match = String(value || "20:00").match(/^(\d{1,2}):(\d{2})$/);
-  if (!match) return 20 * 60;
-  const hours = Number(match[1]);
-  const minutes = Number(match[2]);
-  if (!Number.isInteger(hours) || !Number.isInteger(minutes)) return 20 * 60;
-  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return 20 * 60;
-  return hours * 60 + minutes;
-}
-
-function weeklyExpenseDateKey(expense, timezone) {
-  const value = expense?.date
-    || expense?.created_at
-    || expense?.createdAt
-    || expense?.spent_at
-    || expense?.logged_at
-    || expense?.transaction_date
-    || expense?.transactionDate;
-  const raw = String(value || "").trim();
-  if (!raw) return null;
-  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return raw;
-  const parsed = value instanceof Date ? value : new Date(value);
-  if (Number.isNaN(parsed.getTime())) return null;
-  return weeklyDateParts(timezone, parsed).dateKey;
-}
-
-function weeklyExpenseAmount(expense) {
-  return numberFrom(
-    expense?.amount
-    ?? expense?.total
-    ?? expense?.value
-    ?? expense?.expense_amount
-    ?? expense?.spent_amount
-    ?? expense?.price
-  );
-}
-
-function weeklyExpenseCategory(expense) {
-  return String(
-    expense?.budget_category
-    || expense?.expense_category
-    || expense?.category
-    || expense?.budgetCategory
-    || expense?.category_name
-    || expense?.type
-    || "Uncategorized"
-  ).trim() || "Uncategorized";
-}
-
-function weeklyExpenseStatus(expense) {
-  return String(
-    expense?.planning_status
-    || expense?.budget_status
-    || expense?.plan_status
-    || expense?.budgetStatus
-    || expense?.status
-    || weeklyExpenseCategory(expense)
-    || ""
-  ).toLowerCase();
-}
-
-function weeklyBudgetStatus(budgets, expenses) {
-  try {
-    const snapshot = buildClaraBudgetSnapshot({ budgets, expenses });
-    if (!snapshot?.hasDeclaredBudget) return "no_declared_budget";
-    const categories = Array.isArray(snapshot.categories) ? snapshot.categories : [];
-    return {
-      hasDeclaredBudget: true,
-      categoryCount: categories.length,
-      exceededCount: categories.filter((item) => numberFrom(item.spent) > numberFrom(item.allocated)).length,
-    };
-  } catch {
-    return "unavailable";
-  }
-}
-
-export async function evaluateWeeklyMoneyReviewNotification({
-  userId,
-  preferences,
-  budgets = [],
-  expenses = [],
-  savingsGoals = [],
-  walletTransactions = [],
-  emergencyFund = null,
-} = {}) {
-  if (!userId) return [];
-  if (preferences?.weeklyMoneyReview === false) return [];
-  if (!isNotificationEventAllowed(WEEKLY_REVIEW_EVENT_TYPE, preferences)) return [];
-
-  const timezone = safeTimezone(preferences?.timezone);
-  const today = weeklyDateParts(timezone);
-  if (today.dayIndex !== reviewDay(preferences?.weeklyMoneyReviewDay)) return [];
-  if (today.minutes < reviewTimeMinutes(preferences?.weeklyMoneyReviewTime)) return [];
-
-  const { weekStartKey, weekEndKey } = weeklyRange(today.dateKey, today.dayIndex);
-  if (!weekStartKey || !weekEndKey) return [];
-
-  const totalsByCategory = new Map();
-  let totalSpentThisWeek = 0;
-  let unplannedOrUndocumentedSpent = 0;
-
-  (Array.isArray(expenses) ? expenses : []).forEach((expense) => {
-    if (!expense || typeof expense !== "object") return;
-    if (expense.deletedAt || expense.deleted_at) return;
-    const dateKey = weeklyExpenseDateKey(expense, timezone);
-    if (!dateKey || dateKey < weekStartKey || dateKey > weekEndKey) return;
-    const amount = weeklyExpenseAmount(expense);
-    if (amount <= 0) return;
-    const category = weeklyExpenseCategory(expense);
-    totalSpentThisWeek += amount;
-    totalsByCategory.set(category, (totalsByCategory.get(category) || 0) + amount);
-    if (/unplanned|undocumented/.test(weeklyExpenseStatus(expense))) {
-      unplannedOrUndocumentedSpent += amount;
-    }
-  });
-
-  const biggestCategory = [...totalsByCategory.entries()].sort((left, right) => right[1] - left[1])[0] || ["None yet", 0];
-  const savingsSummary = (Array.isArray(savingsGoals) ? savingsGoals : []).reduce(
-    (summary, goal) => ({
-      savingsSaved: summary.savingsSaved + getSavingsSaved(goal),
-      savingsTarget: summary.savingsTarget + getSavingsTarget(goal),
-    }),
-    { savingsSaved: 0, savingsTarget: 0 }
-  );
-  const body = unplannedOrUndocumentedSpent > 0
-    ? `You spent ${money(totalSpentThisWeek)} this week, including ${money(unplannedOrUndocumentedSpent)} outside your plan. Review your leaks and next move.`
-    : totalSpentThisWeek > 0
-      ? `You spent ${money(totalSpentThisWeek)} this week. Biggest category: ${biggestCategory[0]}. Review your leaks, progress, and next move.`
-      : "CLARA needs more records, but your weekly money check is ready when you are.";
-
-  const notification = buildNotificationContract({
-    eventType: WEEKLY_REVIEW_EVENT_TYPE,
-    dedupeKey: `${WEEKLY_REVIEW_EVENT_TYPE}:${weekStartKey}:${weekEndKey}`,
-    title: "Your Weekly Money Review is ready",
-    body,
-    userId,
-    destination: "/dashboard",
-    metadata: {
-      weekStartKey,
-      weekEndKey,
-      totalSpentThisWeek,
-      biggestCategoryName: biggestCategory[0],
-      biggestCategoryAmount: biggestCategory[1],
-      unplannedOrUndocumentedSpent,
-      budgetStatus: weeklyBudgetStatus(budgets, expenses),
-      savingsSaved: savingsSummary.savingsSaved,
-      savingsTarget: savingsSummary.savingsTarget,
-      reviewKind: "weekly_money_review",
-    },
-  });
-
-  const result = await createNotification(notification);
-  return result.created ? [result.notification] : [];
-}
-
 export async function evaluateFinancialNotifications({
   userId,
   preferences,
@@ -384,10 +173,11 @@ export async function evaluateFinancialNotifications({
 } = {}) {
   if (!userId) return [];
 
-  const [budgetNotifications, savingsNotifications] = await Promise.all([
+  const [budgetNotifications, savingsNotifications, scheduleNotifications] = await Promise.all([
     createBudgetNotifications({ userId, preferences, budgets, expenses }),
     createSavingsNotifications({ userId, preferences, savingsGoals }),
+    evaluateScheduleNotifications({ userId, preferences }),
   ]);
 
-  return [...budgetNotifications, ...savingsNotifications];
+  return [...budgetNotifications, ...savingsNotifications, ...scheduleNotifications];
 }

--- a/src/lib/notifications/financialNotificationEvaluator.js
+++ b/src/lib/notifications/financialNotificationEvaluator.js
@@ -14,6 +14,8 @@ import {
 import { evaluateScheduleNotifications } from "@/lib/notifications/scheduleNotificationEvaluator";
 
 const SAVINGS_MILESTONES = [25, 50, 75, 100];
+const WEEKLY_REVIEW_EVENT_TYPE = "weekly_review_ready";
+const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
 function numberFrom(value) {
   if (typeof value === "number") return Number.isFinite(value) ? value : 0;
@@ -162,6 +164,216 @@ async function createSavingsNotifications({ userId, preferences, savingsGoals })
   }
 
   return created;
+}
+
+function safeTimezone(value) {
+  const timezone = String(value || "").trim() || "UTC";
+  try {
+    Intl.DateTimeFormat("en-US", { timeZone: timezone }).format(new Date());
+    return timezone;
+  } catch {
+    return "UTC";
+  }
+}
+
+function weeklyDateParts(timezone, date = new Date()) {
+  const safeZone = safeTimezone(timezone);
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: safeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  });
+  const parts = Object.fromEntries(
+    formatter.formatToParts(date).map((part) => [part.type, part.value])
+  );
+  const weekday = new Intl.DateTimeFormat("en-US", {
+    timeZone: safeZone,
+    weekday: "short",
+  }).format(date);
+
+  return {
+    dateKey: `${parts.year}-${parts.month}-${parts.day}`,
+    minutes: Number(parts.hour) * 60 + Number(parts.minute),
+    dayIndex: Math.max(WEEKDAY_LABELS.indexOf(weekday), 0),
+  };
+}
+
+function addDays(dateKey, amount) {
+  const [year, month, day] = String(dateKey || "").split("-").map(Number);
+  if (!year || !month || !day) return "";
+  const date = new Date(Date.UTC(year, month - 1, day + amount));
+  return date.toISOString().slice(0, 10);
+}
+
+function weeklyRange(dateKey, dayIndex) {
+  const daysSinceMonday = dayIndex === 0 ? 6 : dayIndex - 1;
+  const weekStartKey = addDays(dateKey, -daysSinceMonday);
+  const weekEndKey = addDays(weekStartKey, 6);
+  return { weekStartKey, weekEndKey };
+}
+
+function reviewDay(value) {
+  const day = Number(value);
+  return Number.isInteger(day) && day >= 0 && day <= 6 ? day : 0;
+}
+
+function reviewTimeMinutes(value) {
+  const match = String(value || "20:00").match(/^(\d{1,2}):(\d{2})$/);
+  if (!match) return 20 * 60;
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (!Number.isInteger(hours) || !Number.isInteger(minutes)) return 20 * 60;
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return 20 * 60;
+  return hours * 60 + minutes;
+}
+
+function weeklyExpenseDateKey(expense, timezone) {
+  const value = expense?.date
+    || expense?.created_at
+    || expense?.createdAt
+    || expense?.spent_at
+    || expense?.logged_at
+    || expense?.transaction_date
+    || expense?.transactionDate;
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return raw;
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return weeklyDateParts(timezone, parsed).dateKey;
+}
+
+function weeklyExpenseAmount(expense) {
+  return numberFrom(
+    expense?.amount
+    ?? expense?.total
+    ?? expense?.value
+    ?? expense?.expense_amount
+    ?? expense?.spent_amount
+    ?? expense?.price
+  );
+}
+
+function weeklyExpenseCategory(expense) {
+  return String(
+    expense?.budget_category
+    || expense?.expense_category
+    || expense?.category
+    || expense?.budgetCategory
+    || expense?.category_name
+    || expense?.type
+    || "Uncategorized"
+  ).trim() || "Uncategorized";
+}
+
+function weeklyExpenseStatus(expense) {
+  return String(
+    expense?.planning_status
+    || expense?.budget_status
+    || expense?.plan_status
+    || expense?.budgetStatus
+    || expense?.status
+    || weeklyExpenseCategory(expense)
+    || ""
+  ).toLowerCase();
+}
+
+function weeklyBudgetStatus(budgets, expenses) {
+  try {
+    const snapshot = buildClaraBudgetSnapshot({ budgets, expenses });
+    if (!snapshot?.hasDeclaredBudget) return "no_declared_budget";
+    const categories = Array.isArray(snapshot.categories) ? snapshot.categories : [];
+    return {
+      hasDeclaredBudget: true,
+      categoryCount: categories.length,
+      exceededCount: categories.filter((item) => numberFrom(item.spent) > numberFrom(item.allocated)).length,
+    };
+  } catch {
+    return "unavailable";
+  }
+}
+
+export async function evaluateWeeklyMoneyReviewNotification({
+  userId,
+  preferences,
+  budgets = [],
+  expenses = [],
+  savingsGoals = [],
+  walletTransactions = [],
+  emergencyFund = null,
+} = {}) {
+  if (!userId) return [];
+  if (preferences?.weeklyMoneyReview === false) return [];
+  if (!isNotificationEventAllowed(WEEKLY_REVIEW_EVENT_TYPE, preferences)) return [];
+
+  const timezone = safeTimezone(preferences?.timezone);
+  const today = weeklyDateParts(timezone);
+  if (today.dayIndex !== reviewDay(preferences?.weeklyMoneyReviewDay)) return [];
+  if (today.minutes < reviewTimeMinutes(preferences?.weeklyMoneyReviewTime)) return [];
+
+  const { weekStartKey, weekEndKey } = weeklyRange(today.dateKey, today.dayIndex);
+  if (!weekStartKey || !weekEndKey) return [];
+
+  const totalsByCategory = new Map();
+  let totalSpentThisWeek = 0;
+  let unplannedOrUndocumentedSpent = 0;
+
+  (Array.isArray(expenses) ? expenses : []).forEach((expense) => {
+    if (!expense || typeof expense !== "object") return;
+    if (expense.deletedAt || expense.deleted_at) return;
+    const dateKey = weeklyExpenseDateKey(expense, timezone);
+    if (!dateKey || dateKey < weekStartKey || dateKey > weekEndKey) return;
+    const amount = weeklyExpenseAmount(expense);
+    if (amount <= 0) return;
+    const category = weeklyExpenseCategory(expense);
+    totalSpentThisWeek += amount;
+    totalsByCategory.set(category, (totalsByCategory.get(category) || 0) + amount);
+    if (/unplanned|undocumented/.test(weeklyExpenseStatus(expense))) {
+      unplannedOrUndocumentedSpent += amount;
+    }
+  });
+
+  const biggestCategory = [...totalsByCategory.entries()].sort((left, right) => right[1] - left[1])[0] || ["None yet", 0];
+  const savingsSummary = (Array.isArray(savingsGoals) ? savingsGoals : []).reduce(
+    (summary, goal) => ({
+      savingsSaved: summary.savingsSaved + getSavingsSaved(goal),
+      savingsTarget: summary.savingsTarget + getSavingsTarget(goal),
+    }),
+    { savingsSaved: 0, savingsTarget: 0 }
+  );
+  const body = unplannedOrUndocumentedSpent > 0
+    ? `You spent ${money(totalSpentThisWeek)} this week, including ${money(unplannedOrUndocumentedSpent)} outside your plan. Review your leaks and next move.`
+    : totalSpentThisWeek > 0
+      ? `You spent ${money(totalSpentThisWeek)} this week. Biggest category: ${biggestCategory[0]}. Review your leaks, progress, and next move.`
+      : "CLARA needs more records, but your weekly money check is ready when you are.";
+
+  const notification = buildNotificationContract({
+    eventType: WEEKLY_REVIEW_EVENT_TYPE,
+    dedupeKey: `${WEEKLY_REVIEW_EVENT_TYPE}:${weekStartKey}:${weekEndKey}`,
+    title: "Your Weekly Money Review is ready",
+    body,
+    userId,
+    destination: "/dashboard",
+    metadata: {
+      weekStartKey,
+      weekEndKey,
+      totalSpentThisWeek,
+      biggestCategoryName: biggestCategory[0],
+      biggestCategoryAmount: biggestCategory[1],
+      unplannedOrUndocumentedSpent,
+      budgetStatus: weeklyBudgetStatus(budgets, expenses),
+      savingsSaved: savingsSummary.savingsSaved,
+      savingsTarget: savingsSummary.savingsTarget,
+      reviewKind: "weekly_money_review",
+    },
+  });
+
+  const result = await createNotification(notification);
+  return result.created ? [result.notification] : [];
 }
 
 export async function evaluateFinancialNotifications({

--- a/src/lib/notifications/notificationPreferences.js
+++ b/src/lib/notifications/notificationPreferences.js
@@ -22,6 +22,7 @@ export const DEFAULT_NOTIFICATION_PREFERENCES = Object.freeze({
   dailyCheckIn: true,
   goalsAndReviews: true,
   tasksAndCoaching: true,
+  scheduleAndCalendar: true,
   productUpdates: false,
   deliveryMode: "in_app",
   preferredTime: "09:00",
@@ -44,6 +45,7 @@ const BOOLEAN_KEYS = [
   "dailyCheckIn",
   "goalsAndReviews",
   "tasksAndCoaching",
+  "scheduleAndCalendar",
   "productUpdates",
   "expenseLogStopAfterLogged",
   "weeklyMoneyReview",
@@ -128,6 +130,11 @@ function migrateLegacyShape(value = {}) {
     dailyCheckIn: firstBoolean(source.dailyCheckIn, source.dailyReminders),
     goalsAndReviews: firstBoolean(source.goalsAndReviews, source.goalProgressAlerts),
     tasksAndCoaching: firstBoolean(source.tasksAndCoaching, source.coachingAlerts),
+    scheduleAndCalendar: firstBoolean(
+      source.scheduleAndCalendar,
+      source.calendarReminders,
+      source.scheduleReminders
+    ),
     productUpdates: firstBoolean(source.productUpdates),
     deliveryMode: source.deliveryMode,
     preferredTime: source.preferredTime || source.reminderTime,
@@ -278,6 +285,8 @@ export function notificationPreferencesToLegacySettings(preferences = {}) {
     dailyReminders: normalized.dailyCheckIn,
     budgetAlerts: normalized.moneyAlerts,
     coachingAlerts: normalized.tasksAndCoaching,
+    calendarReminders: normalized.scheduleAndCalendar,
+    scheduleReminders: normalized.scheduleAndCalendar,
     decisionNudges: normalized.moneyAlerts,
     goalProgressAlerts: normalized.goalsAndReviews,
   };

--- a/src/lib/notifications/notificationRegistry.js
+++ b/src/lib/notifications/notificationRegistry.js
@@ -3,6 +3,7 @@ export const NOTIFICATION_CATEGORIES = Object.freeze({
   DAILY: "daily_check_in",
   GOALS: "goals_and_reviews",
   TASKS: "tasks_and_coaching",
+  SCHEDULE: "schedule_and_calendar",
   ACCOUNT: "account_and_service",
   PRODUCT: "product_communication",
 });
@@ -38,6 +39,10 @@ export const NOTIFICATION_EVENTS = Object.freeze({
   program_week_unlocked: event({ category: NOTIFICATION_CATEGORIES.TASKS }),
   coaching_session_reminder: event({ category: NOTIFICATION_CATEGORIES.TASKS }),
 
+  schedule_event_upcoming: event({ category: NOTIFICATION_CATEGORIES.SCHEDULE, severity: "info", active: true }),
+  schedule_event_today: event({ category: NOTIFICATION_CATEGORIES.SCHEDULE, severity: "warning", active: true }),
+  schedule_money_event_due: event({ category: NOTIFICATION_CATEGORIES.SCHEDULE, severity: "warning", active: true }),
+
   new_device_login: event({ category: NOTIFICATION_CATEGORIES.ACCOUNT, severity: "critical", optional: false }),
   password_changed: event({ category: NOTIFICATION_CATEGORIES.ACCOUNT, severity: "critical", optional: false }),
   payment_confirmed: event({ category: NOTIFICATION_CATEGORIES.ACCOUNT, severity: "success", optional: false }),
@@ -58,6 +63,7 @@ const CATEGORY_PREFERENCE_KEYS = Object.freeze({
   [NOTIFICATION_CATEGORIES.DAILY]: "dailyCheckIn",
   [NOTIFICATION_CATEGORIES.GOALS]: "goalsAndReviews",
   [NOTIFICATION_CATEGORIES.TASKS]: "tasksAndCoaching",
+  [NOTIFICATION_CATEGORIES.SCHEDULE]: "scheduleAndCalendar",
   [NOTIFICATION_CATEGORIES.PRODUCT]: "productUpdates",
 });
 

--- a/src/lib/notifications/scheduleNotificationEvaluator.js
+++ b/src/lib/notifications/scheduleNotificationEvaluator.js
@@ -1,0 +1,256 @@
+import {
+  buildNotificationContract,
+  isNotificationEventAllowed,
+} from "@/lib/notifications/notificationRegistry";
+import { createNotification } from "@/lib/notifications/localNotificationRepository";
+import { getZonedDateParts } from "@/lib/notifications/notificationPreferences";
+
+const SCHEDULE_STORAGE_PREFIX = "clara_schedule_events_v2";
+const MONEY_KEYWORDS = /\b(bill|rent|payment|payday|salary|due|fee|tuition)\b/i;
+const NINE_AM = 9 * 60;
+
+function cleanUserId(userId, user) {
+  return String(
+    userId ||
+      user?.id ||
+      user?.email ||
+      "guest"
+  ).trim() || "guest";
+}
+
+function scheduleStorageKey(userId) {
+  return `${SCHEDULE_STORAGE_PREFIX}_${cleanUserId(userId)}`;
+}
+
+function safeJsonArray(raw) {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function readLatestScheduleEvents(exactKey) {
+  if (typeof window === "undefined" || !window.localStorage) return [];
+
+  try {
+    let fallback = [];
+
+    for (let index = 0; index < window.localStorage.length; index += 1) {
+      const key = window.localStorage.key(index);
+      if (!key || key === exactKey || !key.startsWith(`${SCHEDULE_STORAGE_PREFIX}_`)) continue;
+
+      const parsed = safeJsonArray(window.localStorage.getItem(key));
+      if (parsed.length) fallback = parsed;
+    }
+
+    return fallback;
+  } catch {
+    return [];
+  }
+}
+
+function readScheduleEvents(userId) {
+  if (typeof window === "undefined" || !window.localStorage) return [];
+
+  const exactKey = scheduleStorageKey(userId);
+
+  try {
+    const exact = safeJsonArray(window.localStorage.getItem(exactKey));
+    if (exact.length) return exact;
+    return readLatestScheduleEvents(exactKey);
+  } catch {
+    return [];
+  }
+}
+
+function cleanString(value) {
+  return String(value || "").replace(/\s+/g, " ").trim();
+}
+
+function normalizeDateKey(value) {
+  const raw = cleanString(value);
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return raw;
+
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return "";
+  return `${parsed.getFullYear()}-${String(parsed.getMonth() + 1).padStart(2, "0")}-${String(parsed.getDate()).padStart(2, "0")}`;
+}
+
+function normalizeTime(value) {
+  const match = cleanString(value).match(/^(\d{1,2}):(\d{2})$/);
+  if (!match) return "";
+
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (!Number.isInteger(hours) || !Number.isInteger(minutes)) return "";
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return "";
+
+  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
+}
+
+function timeToMinutes(value) {
+  const time = normalizeTime(value);
+  if (!time) return null;
+  const [hours, minutes] = time.split(":").map(Number);
+  return hours * 60 + minutes;
+}
+
+function normalizeAmount(value) {
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
+  const parsed = Number(cleanString(value).replace(/[₱,\s]/g, ""));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function money(value) {
+  return new Intl.NumberFormat("en-PH", {
+    style: "currency",
+    currency: "PHP",
+    maximumFractionDigits: 0,
+  }).format(Math.max(normalizeAmount(value), 0));
+}
+
+function isSampleEvent(event) {
+  const id = cleanString(event?.id).toLowerCase();
+  const title = cleanString(event?.title).toLowerCase();
+  return id.startsWith("sample-") || title.includes("lifeos check-in");
+}
+
+function normalizeEvent(event) {
+  if (!event || typeof event !== "object" || isSampleEvent(event)) return null;
+
+  const id = cleanString(event.id);
+  const title = cleanString(event.title);
+  const date = normalizeDateKey(event.date);
+  if (!id || !title || !date) return null;
+
+  return {
+    id,
+    title,
+    date,
+    time: normalizeTime(event.time),
+    type: cleanString(event.type),
+    amount: normalizeAmount(event.amount),
+    note: cleanString(event.note),
+  };
+}
+
+function addDateKeyDays(dateKey, days) {
+  const [year, month, day] = String(dateKey || "").split("-").map(Number);
+  if (!year || !month || !day) return "";
+
+  const date = new Date(Date.UTC(year, month - 1, day + days));
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
+}
+
+function hasMoneyImpact(event) {
+  const type = cleanString(event?.type).toLowerCase();
+  const text = `${event?.title || ""} ${event?.note || ""}`;
+
+  return Boolean(
+    normalizeAmount(event?.amount) > 0 ||
+      type === "bill" ||
+      type === "payday" ||
+      MONEY_KEYWORDS.test(text)
+  );
+}
+
+async function createScheduleNotification({ userId, preferences, eventType, dedupeKey, title, body, event, reminderKind }) {
+  if (!isNotificationEventAllowed(eventType, preferences)) return null;
+
+  const result = await createNotification(
+    buildNotificationContract({
+      eventType,
+      dedupeKey,
+      title,
+      body,
+      userId,
+      destination: "/dashboard",
+      metadata: {
+        eventId: event.id,
+        date: event.date,
+        time: event.time,
+        type: event.type,
+        amount: event.amount || undefined,
+        reminderKind,
+      },
+    })
+  );
+
+  return result.created ? result.notification : null;
+}
+
+export async function evaluateScheduleNotifications({ userId, preferences = {}, user = null } = {}) {
+  const cleanId = cleanUserId(userId, user);
+  if (!cleanId) return [];
+  if (preferences.scheduleAndCalendar === false) return [];
+
+  let zoned;
+  try {
+    zoned = getZonedDateParts(preferences.timezone);
+  } catch {
+    zoned = getZonedDateParts();
+  }
+
+  const todayKey = zoned.dateKey;
+  const tomorrowKey = addDateKeyDays(todayKey, 1);
+  const events = readScheduleEvents(cleanId)
+    .map(normalizeEvent)
+    .filter(Boolean)
+    .filter((event) => event.date >= todayKey)
+    .sort((left, right) => `${left.date} ${left.time || "99:99"}`.localeCompare(`${right.date} ${right.time || "99:99"}`));
+
+  const created = [];
+
+  for (const event of events) {
+    if (event.date === tomorrowKey) {
+      const notification = await createScheduleNotification({
+        userId: cleanId,
+        preferences,
+        eventType: "schedule_event_upcoming",
+        dedupeKey: `schedule_event_upcoming:${event.id}:${event.date}:1day`,
+        title: "Upcoming schedule tomorrow",
+        body: `${event.title} is scheduled tomorrow. Prepare before it affects your plans.`,
+        event,
+        reminderKind: "tomorrow",
+      });
+      if (notification) created.push(notification);
+    }
+
+    const shouldCreateTodayReminder = event.date === todayKey && (!event.time || zoned.minutes >= NINE_AM);
+    if (shouldCreateTodayReminder) {
+      const notification = await createScheduleNotification({
+        userId: cleanId,
+        preferences,
+        eventType: "schedule_event_today",
+        dedupeKey: `schedule_event_today:${event.id}:${event.date}`,
+        title: "Schedule today",
+        body: `${event.title} is on your calendar today.`,
+        event,
+        reminderKind: "today",
+      });
+      if (notification) created.push(notification);
+    }
+
+    if (hasMoneyImpact(event)) {
+      const amountText = event.amount > 0
+        ? `${money(event.amount)} may be involved for ${event.title}. Prepare before optional spending.`
+        : `${event.title} may affect your money. Prepare before optional spending.`;
+      const notification = await createScheduleNotification({
+        userId: cleanId,
+        preferences,
+        eventType: "schedule_money_event_due",
+        dedupeKey: `schedule_money_event_due:${event.id}:${event.date}`,
+        title: "Money-impact schedule coming",
+        body: amountText,
+        event,
+        reminderKind: "money_impact",
+      });
+      if (notification) created.push(notification);
+    }
+  }
+
+  return created;
+}

--- a/src/runtime/installClaraRuntimePatches.js
+++ b/src/runtime/installClaraRuntimePatches.js
@@ -50,6 +50,9 @@ import "../clara-forecast-transition-loader.css";
 // Buy Check runtime controllers
 import "../clara-buy-check-effective-context-guard";
 
+// Schedule notification runtime bridge
+import "../clara-schedule-notification-runtime-bridge";
+
 // WARNING:
 // These patches relabel/replace assistant tabs through DOM selectors.
 // Later they should become real React tab configuration.


### PR DESCRIPTION
## Summary
- Add Schedule notification category, active event types, and `scheduleAndCalendar` preference support.
- Add a defensive Schedule v2 notification evaluator for tomorrow, today, and money-impact reminders using existing notification contracts/repository dedupe.
- Route Schedule evaluation through the existing financial notification runtime path and add a runtime bridge that dispatches `clara:schedule-events-updated` after Schedule v2 localStorage saves.
- Add native future calendar reminder scheduling through the existing Capacitor LocalNotifications helper path.

## Notes
- This keeps billing, Supabase auth, package identity, task reminders, daily check-ins, financial notifications, and weekly money review logic intact.
- I preserved the latest weekly money review evaluator/settings from main while adding Schedule notifications.
- Build was not run from this connector environment; please run `npm run build` before merge.

## Validation checklist
- Search: `schedule_event_upcoming`, `schedule_event_today`, `schedule_money_event_due`, `scheduleAndCalendar`, `clara:schedule-events-updated`.
- Add tomorrow/today/bill-payday schedule events and confirm deduped notifications.
- Disable `scheduleAndCalendar` and confirm no schedule notifications are created.
- Android installed app: confirm future local notifications route to `#/dashboard`.