### PR TITLE
Add CLARA Guide Mode daily tip prototype

### DIFF
--- a/src/components/financial-carousel/FinancialCarousel.jsx
+++ b/src/components/financial-carousel/FinancialCarousel.jsx
@@ -106,6 +106,7 @@ export default function FinancialCarousel(props) {
 
   useEffect(() => {
     if (typeof document === "undefined") return undefined;
+    const root = document.documentElement;
     root.classList.toggle(FINANCIAL_CAROUSEL_FOCUS_CLASS, isInlineFocusExpanded);
     return () => root.classList.remove(FINANCIAL_CAROUSEL_FOCUS_CLASS);
   }, [isInlineFocusExpanded]);

--- a/src/components/financial-carousel/FinancialCarousel.jsx
+++ b/src/components/financial-carousel/FinancialCarousel.jsx
@@ -42,22 +42,24 @@ export default function FinancialCarousel(props) {
     includeLocked,
     firstPositiveNumber,
     readStoredSurvivalExpense,
+    isGuideMode = false,
   } = props;
 
-  const userId = user?.id;
-  const userPlan = user?.plan;
-  const emergencyFundSyncController = useFinancialData(user);
+  const effectiveUser = isGuideMode ? null : user;
+  const userId = effectiveUser?.id;
+  const userPlan = effectiveUser?.plan || plan;
+  const emergencyFundSyncController = useFinancialData(effectiveUser);
   const removeExpense = emergencyFundSyncController["delete" + "Expense"];
 
   useEmergencyFundAllocationSync({
-    user,
+    user: effectiveUser,
     expenses: emergencyFundSyncController.expenses,
     transfers: emergencyFundSyncController.transfers,
     emergencyFund: emergencyFundSyncController.emergencyFund,
     transferBetweenWallets: emergencyFundSyncController.transferBetweenWallets,
     ["delete" + "Expense"]: removeExpense,
     refreshData: emergencyFundSyncController.refreshData,
-    enabled: Boolean(user && guardChecked && !loading),
+    enabled: !isGuideMode && Boolean(effectiveUser && guardChecked && !loading),
   });
 
   const items = useMemo(
@@ -73,7 +75,7 @@ export default function FinancialCarousel(props) {
       survivalExpense,
       user: userId || userPlan ? { id: userId, plan: userPlan } : null,
       plan,
-      guardChecked,
+      guardChecked: isGuideMode ? false : guardChecked,
       loading,
       profileData,
       featureFlags,
@@ -81,7 +83,7 @@ export default function FinancialCarousel(props) {
       firstPositiveNumber,
       readStoredSurvivalExpense,
     }),
-    [monthlyBudgetPlan, savingsGoals, totalSavingsSaved, totalSavingsTarget, primarySavingsGoal, wallets, walletMoney, walletPreviewTransactions, survivalExpense, userId, userPlan, plan, guardChecked, loading, profileData, featureFlags, includeLocked, firstPositiveNumber, readStoredSurvivalExpense]
+    [monthlyBudgetPlan, savingsGoals, totalSavingsSaved, totalSavingsTarget, primarySavingsGoal, wallets, walletMoney, walletPreviewTransactions, survivalExpense, userId, userPlan, plan, guardChecked, loading, profileData, featureFlags, includeLocked, firstPositiveNumber, readStoredSurvivalExpense, isGuideMode]
   );
   const defaultIndex = useMemo(() => getDefaultCarouselIndex(items), [items]);
   const { carouselRef, activeIndex, scrollToIndex, handleScroll, interactionHandlers } = useAutoMovingHorizontalCarousel({
@@ -104,7 +106,6 @@ export default function FinancialCarousel(props) {
 
   useEffect(() => {
     if (typeof document === "undefined") return undefined;
-    const root = document.documentElement;
     root.classList.toggle(FINANCIAL_CAROUSEL_FOCUS_CLASS, isInlineFocusExpanded);
     return () => root.classList.remove(FINANCIAL_CAROUSEL_FOCUS_CLASS);
   }, [isInlineFocusExpanded]);

--- a/src/components/fresh/main-dashboard/daily-tip/logic/useDailyCheckIn.js
+++ b/src/components/fresh/main-dashboard/daily-tip/logic/useDailyCheckIn.js
@@ -3,11 +3,18 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 const CHECK_IN_STORAGE_KEY = "clara_daily_check_in_v1";
 const MAX_VISIBLE_DAYS = 30;
 
-export default function useDailyCheckIn() {
+export default function useDailyCheckIn({ simulationMode = false } = {}) {
   const todayKey = useMemo(() => getTodayKey(), []);
-  const [checkInState, setCheckInState] = useState(() => readCheckInState(todayKey));
+  const [checkInState, setCheckInState] = useState(() =>
+    simulationMode ? createSimulationCheckInState(todayKey) : readCheckInState(todayKey)
+  );
 
   useEffect(() => {
+    if (simulationMode) {
+      setCheckInState(createSimulationCheckInState(todayKey));
+      return undefined;
+    }
+
     const syncCheckInState = () => setCheckInState(readCheckInState(todayKey));
 
     syncCheckInState();
@@ -16,7 +23,7 @@ export default function useDailyCheckIn() {
 
     window.addEventListener("storage", syncCheckInState);
     return () => window.removeEventListener("storage", syncCheckInState);
-  }, [todayKey]);
+  }, [simulationMode, todayKey]);
 
   const completedDates = useMemo(
     () => normalizeCompletedDates(checkInState.completedDates),
@@ -33,6 +40,12 @@ export default function useDailyCheckIn() {
   );
 
   const checkInToday = useCallback(() => {
+    if (simulationMode) {
+      const nextState = createSimulationCheckInState(todayKey, true);
+      setCheckInState(nextState);
+      return nextState;
+    }
+
     let nextState = null;
 
     setCheckInState((currentState) => {
@@ -61,7 +74,7 @@ export default function useDailyCheckIn() {
     });
 
     return nextState;
-  }, [todayKey]);
+  }, [simulationMode, todayKey]);
 
   return {
     todayKey,
@@ -71,6 +84,14 @@ export default function useDailyCheckIn() {
     challengeDay,
     currentStreak,
     checkInToday,
+  };
+}
+
+function createSimulationCheckInState(todayKey, completedToday = false) {
+  return {
+    startedAt: todayKey,
+    completedDates: completedToday ? [todayKey] : [],
+    lastCheckInDate: completedToday ? todayKey : null,
   };
 }
 

--- a/src/components/fresh/main-dashboard/daily-tip/logic/useDailyTip.js
+++ b/src/components/fresh/main-dashboard/daily-tip/logic/useDailyTip.js
@@ -3,14 +3,22 @@ import { DAILY_TIPS } from "../data/tipsData";
 
 const CYCLE_STORAGE_KEY = "clara_daily_tip_cycle_v2";
 const SEEN_STORAGE_KEY = "clara_daily_tip_seen_date";
+const SIMULATION_DAILY_MONEY_TIP = "Before spending today, ask: Is this planned, needed, or just a reaction?";
 
-export default function useDailyTip() {
+export default function useDailyTip({ simulationMode = false } = {}) {
   const todayKey = useMemo(() => getTodayKey(), []);
-  const [tip, setTip] = useState("");
+  const [tip, setTip] = useState(simulationMode ? SIMULATION_DAILY_MONEY_TIP : "");
   const [index, setIndex] = useState(0);
   const [hasSeenToday, setHasSeenToday] = useState(false);
 
   useEffect(() => {
+    if (simulationMode) {
+      setHasSeenToday(false);
+      setIndex(0);
+      setTip(SIMULATION_DAILY_MONEY_TIP);
+      return;
+    }
+
     const seenDate = safeGet(SEEN_STORAGE_KEY);
     setHasSeenToday(seenDate === todayKey);
 
@@ -43,9 +51,14 @@ export default function useDailyTip() {
     const currentIndex = Number.isInteger(cycle.currentIndex) ? cycle.currentIndex : 0;
     setIndex(currentIndex);
     setTip(DAILY_TIPS[currentIndex] || DAILY_TIPS[0]);
-  }, [todayKey]);
+  }, [simulationMode, todayKey]);
 
   const markSeenToday = () => {
+    if (simulationMode) {
+      setHasSeenToday(true);
+      return;
+    }
+
     safeSet(SEEN_STORAGE_KEY, todayKey);
     setHasSeenToday(true);
   };

--- a/src/components/fresh/main-dashboard/daily-tip/ui/DailyTipCard.jsx
+++ b/src/components/fresh/main-dashboard/daily-tip/ui/DailyTipCard.jsx
@@ -49,7 +49,7 @@ export default function DailyTipCard({
   const spacingClass = flushSpacing ? "px-3" : "px-3 mt-1.5";
   const isGuideStepActive = isGuideMode && guideStep === 0;
   const cardEyebrow = isGuideMode ? "Daily Money Tip" : "Daily Check-In";
-  const cardHeadline = isGuideMode ? "Today&apos;s money reminder" : `Day ${challengeDay} of ${CHECK_IN_DAYS}`;
+  const cardHeadline = isGuideMode ? "Today's money reminder" : `Day ${challengeDay} of ${CHECK_IN_DAYS}`;
   const cardSubtitle = isGuideMode
     ? "Tap this card to learn what CLARA gives you each day."
     : "Tap today to protect your money discipline.";
@@ -58,6 +58,16 @@ export default function DailyTipCard({
     : checkedInToday
       ? "Checked in today"
       : "Tap to check in";
+
+  const releaseFlipLock = () => {
+    if (flipUnlockTimerRef.current) {
+      window.clearTimeout(flipUnlockTimerRef.current);
+      flipUnlockTimerRef.current = null;
+    }
+
+    isFlippingRef.current = false;
+    setIsFlipping(false);
+  };
 
   useEffect(() => {
     const syncActiveState = () => setActiveCurrentState(readActiveCurrentState());
@@ -91,16 +101,6 @@ export default function DailyTipCard({
       }
     };
   }, []);
-
-  const releaseFlipLock = () => {
-    if (flipUnlockTimerRef.current) {
-      window.clearTimeout(flipUnlockTimerRef.current);
-      flipUnlockTimerRef.current = null;
-    }
-
-    isFlippingRef.current = false;
-    setIsFlipping(false);
-  };
 
   const triggerCheckInCelebration = () => {
     if (typeof window === "undefined") return;
@@ -282,10 +282,9 @@ export default function DailyTipCard({
 
                 <div className="flex items-center justify-between gap-3 py-1.5">
                   <div className="min-w-0">
-                    <div
-                      className="text-[clamp(18px,4.8vw,21px)] font-black leading-none tracking-[-0.035em] text-white"
-                      dangerouslySetInnerHTML={{ __html: cardHeadline }}
-                    />
+                    <div className="text-[clamp(18px,4.8vw,21px)] font-black leading-none tracking-[-0.035em] text-white">
+                      {cardHeadline}
+                    </div>
 
                     <p className="mt-1 max-w-[13rem] text-[10.5px] font-semibold leading-snug text-cyan-50/72">
                       {cardSubtitle}

--- a/src/components/fresh/main-dashboard/daily-tip/ui/DailyTipCard.jsx
+++ b/src/components/fresh/main-dashboard/daily-tip/ui/DailyTipCard.jsx
@@ -26,15 +26,18 @@ export default function DailyTipCard({
   hasCommittedAccess = true,
   onOpenCommitmentBooklet,
   flushSpacing = false,
+  isGuideMode = false,
+  guideStep = 0,
+  onGuideDailyTipTap,
 }) {
-  const { tip, hasSeenToday, markSeenToday } = useDailyTip();
+  const { tip, hasSeenToday, markSeenToday } = useDailyTip({ simulationMode: isGuideMode });
   const {
     checkedInToday,
     totalCompleted,
     challengeDay,
     currentStreak,
     checkInToday,
-  } = useDailyCheckIn();
+  } = useDailyCheckIn({ simulationMode: isGuideMode });
   const [flipped, setFlipped] = useState(false);
   const [isFlipping, setIsFlipping] = useState(false);
   const [showCelebration, setShowCelebration] = useState(false);
@@ -44,6 +47,17 @@ export default function DailyTipCard({
   const [activeCurrentState, setActiveCurrentState] = useState(() => readActiveCurrentState());
   const [exiting, setExiting] = useState(false);
   const spacingClass = flushSpacing ? "px-3" : "px-3 mt-1.5";
+  const isGuideStepActive = isGuideMode && guideStep === 0;
+  const cardEyebrow = isGuideMode ? "Daily Money Tip" : "Daily Check-In";
+  const cardHeadline = isGuideMode ? "Today&apos;s money reminder" : `Day ${challengeDay} of ${CHECK_IN_DAYS}`;
+  const cardSubtitle = isGuideMode
+    ? "Tap this card to learn what CLARA gives you each day."
+    : "Tap today to protect your money discipline.";
+  const cardStatus = isGuideMode
+    ? "Available"
+    : checkedInToday
+      ? "Checked in today"
+      : "Tap to check in";
 
   useEffect(() => {
     const syncActiveState = () => setActiveCurrentState(readActiveCurrentState());
@@ -57,6 +71,12 @@ export default function DailyTipCard({
       window.removeEventListener("storage", syncActiveState);
     };
   }, []);
+
+  useEffect(() => {
+    if (!isGuideMode) return;
+    setFlipped(false);
+    releaseFlipLock();
+  }, [isGuideMode, guideStep]);
 
   useEffect(() => {
     return () => {
@@ -110,6 +130,13 @@ export default function DailyTipCard({
   };
 
   const handleFlip = () => {
+    if (isGuideMode) {
+      if (guideStep === 0) {
+        onGuideDailyTipTap?.();
+      }
+      return;
+    }
+
     if (!hasCommittedAccess) {
       onOpenCommitmentBooklet?.();
       return;
@@ -161,7 +188,7 @@ export default function DailyTipCard({
     }
   };
 
-  if (activeCurrentState) {
+  if (!isGuideMode && activeCurrentState) {
     return (
       <div className={`clara-budget-focus-shift clara-budget-focus-tip ${spacingClass}`}>
         <div className="relative h-[150px] w-full overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br from-cyan-400/10 via-slate-900/40 to-indigo-500/10 p-4 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]">
@@ -194,7 +221,12 @@ export default function DailyTipCard({
   }
 
   return (
-    <div className={`clara-budget-focus-shift clara-budget-focus-tip ${spacingClass}`}>
+    <div
+      data-clara-daily-tip-card="true"
+      className={`clara-budget-focus-shift clara-budget-focus-tip ${spacingClass} ${
+        isGuideStepActive ? "relative z-[70]" : ""
+      }`}
+    >
       <div
         role="button"
         tabIndex={0}
@@ -206,15 +238,21 @@ export default function DailyTipCard({
           }
         }}
         aria-label={
-          hasCommittedAccess
-            ? checkedInToday
-              ? "Show today's Daily Money Tip"
-              : "Check in for today and reveal Daily Money Tip"
-            : "Open the Committed Version to unlock Daily Check-In"
+          isGuideMode
+            ? "Open the simulated Daily Money Tip guide step"
+            : hasCommittedAccess
+              ? checkedInToday
+                ? "Show today's Daily Money Tip"
+                : "Check in for today and reveal Daily Money Tip"
+              : "Open the Committed Version to unlock Daily Check-In"
         }
         aria-pressed={flipped}
         aria-disabled={isFlipping && hasCommittedAccess}
-        className="group relative h-[clamp(132px,18dvh,150px)] w-full cursor-pointer overflow-hidden rounded-2xl bg-transparent text-left outline-none"
+        className={`group relative h-[clamp(132px,18dvh,150px)] w-full cursor-pointer overflow-hidden rounded-2xl bg-transparent text-left outline-none transition-[box-shadow,filter,transform] duration-300 ${
+          isGuideStepActive
+            ? "ring-2 ring-cyan-200/80 shadow-[0_0_0_1px_rgba(255,255,255,0.10),0_0_42px_rgba(34,211,238,0.34)]"
+            : ""
+        }`}
         style={{ WebkitTapHighlightColor: "transparent" }}
       >
         <div className="clara-daily-tip-scene">
@@ -234,27 +272,28 @@ export default function DailyTipCard({
               <div className="relative grid h-full grid-rows-[auto_1fr_auto] px-4 py-3 text-white">
                 <div className="flex items-center justify-between gap-3">
                   <div className="text-[8.5px] font-black uppercase leading-none tracking-[0.24em] text-cyan-200/70">
-                    Daily Check-In
+                    {cardEyebrow}
                   </div>
 
                   <span className="clara-checkin-pill shrink-0 px-2.5 py-1 text-[8.5px] font-black uppercase tracking-[0.08em]">
-                    {currentStreak}-day streak
+                    {isGuideMode ? "Guide Demo" : `${currentStreak}-day streak`}
                   </span>
                 </div>
 
                 <div className="flex items-center justify-between gap-3 py-1.5">
                   <div className="min-w-0">
-                    <div className="text-[clamp(18px,4.8vw,21px)] font-black leading-none tracking-[-0.035em] text-white">
-                      Day {challengeDay} of {CHECK_IN_DAYS}
-                    </div>
+                    <div
+                      className="text-[clamp(18px,4.8vw,21px)] font-black leading-none tracking-[-0.035em] text-white"
+                      dangerouslySetInnerHTML={{ __html: cardHeadline }}
+                    />
 
                     <p className="mt-1 max-w-[13rem] text-[10.5px] font-semibold leading-snug text-cyan-50/72">
-                      Tap today to protect your money discipline.
+                      {cardSubtitle}
                     </p>
                   </div>
 
                   <span className="shrink-0 rounded-full border border-white/12 bg-white/[0.07] px-2.5 py-1.5 text-right text-[8.5px] font-black uppercase leading-tight tracking-[0.12em] text-white/68 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
-                    {checkedInToday ? "Checked in today" : "Tap to check in"}
+                    {cardStatus}
                   </span>
                 </div>
 

--- a/src/components/fresh/main-dashboard/guide/claraGuideProgress.js
+++ b/src/components/fresh/main-dashboard/guide/claraGuideProgress.js
@@ -1,0 +1,36 @@
+export const CLARA_GUIDE_PROGRESS_KEY = "claraGuideProgress";
+export const DAILY_MONEY_TIP_GUIDE_VERSION = 1;
+
+export function readClaraGuideProgress() {
+  if (typeof window === "undefined") return {};
+
+  try {
+    const raw = window.localStorage.getItem(CLARA_GUIDE_PROGRESS_KEY);
+    const parsed = raw ? JSON.parse(raw) : {};
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function isDailyMoneyTipGuideComplete(progress = readClaraGuideProgress()) {
+  return Number(progress?.dailyMoneyTip || 0) >= DAILY_MONEY_TIP_GUIDE_VERSION;
+}
+
+export function markDailyMoneyTipGuideComplete() {
+  const currentProgress = readClaraGuideProgress();
+  const nextProgress = {
+    ...currentProgress,
+    dailyMoneyTip: DAILY_MONEY_TIP_GUIDE_VERSION,
+  };
+
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.setItem(CLARA_GUIDE_PROGRESS_KEY, JSON.stringify(nextProgress));
+    } catch {
+      // Local-only guide progress should never block the real app.
+    }
+  }
+
+  return nextProgress;
+}

--- a/src/components/fresh/main-dashboard/learning-hub/LearningHub.jsx
+++ b/src/components/fresh/main-dashboard/learning-hub/LearningHub.jsx
@@ -1,4 +1,5 @@
 import { Suspense, lazy, useState } from "react";
+import { ScrollText } from "lucide-react";
 import DailyTipCard from "../daily-tip";
 import {
   openCommittedVersionModal,
@@ -8,12 +9,59 @@ import LearningHubToggleButton from "./ui/LearningHubToggleButton";
 
 const LearningHubLoaded = lazy(() => import("./LearningHubLoaded"));
 
-export default function LearningHub() {
+function ClaraGuideButton({ hasNewGuide = false, onClick }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="clara-learning-motion relative inline-flex h-9 shrink-0 items-center justify-center gap-1.5 overflow-visible rounded-full border border-cyan-200/15 bg-[rgba(6,18,38,0.62)] px-3 text-[9px] font-black uppercase tracking-[0.16em] text-cyan-50/72 shadow-[0_10px_26px_rgba(0,0,0,0.22),inset_0_1px_0_rgba(255,255,255,0.07)] backdrop-blur-xl transition hover:border-cyan-200/28 hover:bg-white/[0.08] active:scale-[0.98]"
+      aria-label="Open CLARA Guide Mode"
+    >
+      <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(circle_at_top_left,rgba(103,232,249,0.16),transparent_46%),radial-gradient(circle_at_bottom_right,rgba(129,140,248,0.14),transparent_50%)]" />
+      <ScrollText className="relative z-10 h-3.5 w-3.5 text-cyan-100/70" />
+      <span className="relative z-10 hidden sm:inline">Guide</span>
+      {hasNewGuide ? (
+        <span className="absolute -right-1.5 -top-2 z-20 rounded-full border border-cyan-100/25 bg-cyan-300 px-1.5 py-0.5 text-[7px] font-black leading-none tracking-[0.12em] text-slate-950 shadow-[0_8px_18px_rgba(34,211,238,0.28)]">
+          NEW
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+function DailyTipGuideBubble() {
+  return (
+    <div className="relative z-[70] px-4">
+      <div className="mx-auto max-w-[22rem] rounded-[24px] border border-cyan-200/18 bg-[rgba(5,17,38,0.86)] p-4 text-white shadow-[0_20px_60px_rgba(0,0,0,0.42),0_0_34px_rgba(34,211,238,0.12)] backdrop-blur-2xl">
+        <div className="mb-2 h-px w-16 bg-gradient-to-r from-cyan-200/0 via-cyan-200/45 to-cyan-200/0" />
+        <p className="text-[12px] font-semibold leading-relaxed text-cyan-50/82">
+          This is your Daily Money Tip. CLARA gives you a short money reminder to help you stay aware before spending.
+        </p>
+        <p className="mt-3 rounded-2xl border border-white/10 bg-white/[0.06] px-3 py-2 text-[10px] font-black uppercase tracking-[0.14em] text-cyan-100/78">
+          Tap the Daily Money Tip card to continue.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function LearningHub({
+  isGuideMode = false,
+  guideFeature = "daily-money-tip",
+  guideStep = 0,
+  hasNewGuide = false,
+  onOpenGuideIntro,
+  onGuideDailyTipTap,
+}) {
   const [shouldLoadHub, setShouldLoadHub] = useState(false);
-  const hasCommittedAccess = useCommittedFeatureAccess();
+  const realHasCommittedAccess = useCommittedFeatureAccess();
+  const hasCommittedAccess = isGuideMode ? true : realHasCommittedAccess;
   const isLocked = !hasCommittedAccess;
+  const isDailyTipGuideStep = isGuideMode && guideFeature === "daily-money-tip" && guideStep === 0;
 
   const handleOpenHub = () => {
+    if (isGuideMode) return;
+
     if (isLocked) {
       openCommittedVersionModal();
       return;
@@ -29,12 +77,17 @@ export default function LearningHub() {
           hasCommittedAccess={hasCommittedAccess}
           onOpenCommitmentBooklet={openCommittedVersionModal}
           flushSpacing
+          isGuideMode={isGuideMode}
+          guideStep={guideStep}
+          onGuideDailyTipTap={onGuideDailyTipTap}
         />
+
+        {isDailyTipGuideStep ? <DailyTipGuideBubble /> : null}
 
         {!shouldLoadHub ? (
           <div
             data-clara-learning-hub-bridge="true"
-            className="flex justify-center"
+            className="relative flex items-center justify-center gap-2"
           >
             <LearningHubToggleButton
               isExpanded={false}
@@ -44,6 +97,10 @@ export default function LearningHub() {
               onClick={handleOpenHub}
               flushSpacing
             />
+
+            {!isGuideMode ? (
+              <ClaraGuideButton hasNewGuide={hasNewGuide} onClick={onOpenGuideIntro} />
+            ) : null}
           </div>
         ) : (
           <Suspense fallback={null}>

--- a/src/components/fresh/main-dashboard/shell/DashboardHomePanel.jsx
+++ b/src/components/fresh/main-dashboard/shell/DashboardHomePanel.jsx
@@ -1,13 +1,72 @@
 import { useCallback, useEffect, useState } from "react";
-import { Clock } from "lucide-react";
+import { Clock, ShieldCheck, Sparkles, X } from "lucide-react";
 import { Link } from "react-router-dom";
 import FinancialCarousel from "@/components/financial-carousel/FinancialCarousel";
 import LearningHub from "@/components/fresh/main-dashboard/learning-hub/LearningHub";
 import DashboardMoneySummaryStable from "@/components/fresh/main-dashboard/money-summary/DashboardMoneySummaryStable";
 import FinanceInlineAlert from "@/components/fresh/main-dashboard/finance-notices/FinanceInlineAlert";
 import { Button } from "@/components/ui/button";
+import {
+  CLARA_GUIDE_PROGRESS_KEY,
+  isDailyMoneyTipGuideComplete,
+  markDailyMoneyTipGuideComplete,
+  readClaraGuideProgress,
+} from "@/components/fresh/main-dashboard/guide/claraGuideProgress";
 
 const CLARA_MONEY_CHAT_EVENT = "clara:money-card-chat";
+const GUIDE_FEATURE_DAILY_MONEY_TIP = "daily-money-tip";
+
+const GUIDE_DEMO_WALLET_MONEY = 3200;
+const GUIDE_DEMO_WALLETS = [
+  {
+    id: "clara-guide-demo-wallet",
+    name: "Guide Wallet",
+    wallet_name: "Guide Wallet",
+    type: "cash",
+    balance: GUIDE_DEMO_WALLET_MONEY,
+    amount: GUIDE_DEMO_WALLET_MONEY,
+    current_balance: GUIDE_DEMO_WALLET_MONEY,
+    sort_order: 0,
+  },
+];
+const GUIDE_DEMO_WALLET_PREVIEW_TRANSACTIONS = [
+  {
+    id: "clara-guide-demo-transaction-1",
+    type: "expense",
+    category: "Food",
+    description: "Sample lunch",
+    amount: 120,
+    created_at: new Date().toISOString(),
+  },
+];
+const GUIDE_DEMO_MONTHLY_BUDGET_PLAN = {
+  declared_budget: 5000,
+  total_budget: 5000,
+  spent_amount: 3550,
+  spent_total: 3550,
+  remaining: 1450,
+  remaining_amount: 1450,
+  status: "guide-demo",
+  is_complete: true,
+  categories: [
+    { id: "guide-essentials", name: "Essentials", allocated_amount: 2500, spent_amount: 1800 },
+    { id: "guide-food", name: "Food", allocated_amount: 1600, spent_amount: 1250 },
+    { id: "guide-flex", name: "Flexible", allocated_amount: 900, spent_amount: 500 },
+  ],
+};
+const GUIDE_DEMO_SAVINGS_GOALS = [
+  {
+    id: "clara-guide-demo-savings",
+    name: "Sample Savings",
+    goal_name: "Sample Savings",
+    saved_amount: 650,
+    current_amount: 650,
+    target_amount: 3000,
+  },
+];
+const GUIDE_DEMO_TOTAL_SAVINGS_SAVED = 650;
+const GUIDE_DEMO_TOTAL_SAVINGS_TARGET = 3000;
+const GUIDE_DEMO_SURVIVAL_EXPENSE = 0;
 
 const runInAnimationFrame = (callback) => {
   if (typeof callback !== "function") return;
@@ -19,6 +78,135 @@ const runInAnimationFrame = (callback) => {
 
   window.requestAnimationFrame(callback);
 };
+
+function ClaraGuideIntroModal({ onStart, onClose }) {
+  return (
+    <div className="fixed inset-0 z-[120] flex items-center justify-center bg-slate-950/78 px-4 py-6 backdrop-blur-xl" role="dialog" aria-modal="true" aria-labelledby="clara-guide-intro-title">
+      <div className="relative w-full max-w-[390px] overflow-hidden rounded-[30px] border border-cyan-100/14 bg-[linear-gradient(145deg,rgba(5,19,41,0.96),rgba(8,24,55,0.94)_48%,rgba(18,13,52,0.94))] p-5 text-white shadow-[0_28px_90px_rgba(0,0,0,0.58),0_0_58px_rgba(34,211,238,0.12)]">
+        <div className="pointer-events-none absolute -left-16 -top-16 h-40 w-40 rounded-full bg-cyan-300/12 blur-3xl" />
+        <div className="pointer-events-none absolute -bottom-20 -right-10 h-48 w-48 rounded-full bg-indigo-400/14 blur-3xl" />
+
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-4 top-4 z-10 flex h-8 w-8 items-center justify-center rounded-full border border-white/10 bg-white/[0.06] text-white/58 transition hover:bg-white/[0.10] hover:text-white/78"
+          aria-label="Close CLARA Guide intro"
+        >
+          <X className="h-4 w-4" />
+        </button>
+
+        <div className="relative z-10">
+          <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-2xl border border-cyan-100/15 bg-cyan-300/10 text-cyan-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]">
+            <ShieldCheck className="h-5 w-5" />
+          </div>
+
+          <p className="text-[9px] font-black uppercase tracking-[0.26em] text-cyan-100/52">
+            Safe walkthrough
+          </p>
+          <h2 id="clara-guide-intro-title" className="mt-2 text-2xl font-black tracking-[-0.04em] text-white">
+            CLARA Guide Mode
+          </h2>
+          <p className="mt-2 text-[13px] font-semibold leading-relaxed text-cyan-50/76">
+            Practice using CLARA without touching your real data.
+          </p>
+
+          <div className="mt-4 space-y-3 rounded-[24px] border border-white/10 bg-white/[0.055] p-4 text-[12px] font-medium leading-relaxed text-white/74 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
+            <p>
+              You’ll enter a safe simulation where CLARA shows you what to tap and what each feature means.
+            </p>
+            <p>
+              Nothing here affects your real wallet, budget, savings, check-ins, streaks, transactions, or records.
+            </p>
+            <p className="font-black text-cyan-100/86">You can exit anytime.</p>
+          </div>
+
+          <div className="mt-5 grid gap-2">
+            <button
+              type="button"
+              onClick={onStart}
+              className="rounded-2xl bg-cyan-200 px-4 py-3 text-[12px] font-black uppercase tracking-[0.16em] text-slate-950 shadow-[0_16px_34px_rgba(34,211,238,0.24)] transition active:scale-[0.99]"
+            >
+              Start Guide Mode
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-2xl border border-white/10 bg-white/[0.06] px-4 py-3 text-[12px] font-black uppercase tracking-[0.16em] text-white/68 transition hover:bg-white/[0.09] active:scale-[0.99]"
+            >
+              Not Now
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ClaraGuideModeBanner({ onExit }) {
+  return (
+    <div className="sticky top-2 z-[95] px-2 pb-2">
+      <div className="mx-auto flex max-w-[430px] items-center justify-between gap-3 rounded-full border border-cyan-100/16 bg-[rgba(4,16,34,0.82)] px-3 py-2 text-white shadow-[0_16px_42px_rgba(0,0,0,0.34),0_0_32px_rgba(34,211,238,0.10)] backdrop-blur-2xl">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-cyan-100/12 bg-cyan-300/10 text-cyan-100">
+            <Sparkles className="h-3.5 w-3.5" />
+          </span>
+          <div className="min-w-0">
+            <p className="text-[10px] font-black uppercase leading-tight tracking-[0.2em] text-cyan-100/78">
+              Guide Mode
+            </p>
+            <p className="truncate text-[10.5px] font-semibold leading-tight text-white/58">
+              Simulation only. Your real data is safe.
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onExit}
+          className="shrink-0 rounded-full border border-white/12 bg-white/[0.07] px-3 py-1.5 text-[9px] font-black uppercase tracking-[0.16em] text-white/70 transition hover:bg-white/[0.11]"
+        >
+          Exit
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function DailyMoneyTipGuideResult({ onUnderstand, onTryRealClara }) {
+  return (
+    <div className="fixed inset-0 z-[110] flex items-end justify-center bg-slate-950/58 px-4 pb-5 pt-20 backdrop-blur-[2px] sm:items-center sm:pb-8" role="dialog" aria-modal="true" aria-labelledby="daily-tip-guide-result-title">
+      <div className="w-full max-w-[390px] overflow-hidden rounded-[30px] border border-cyan-100/14 bg-[linear-gradient(145deg,rgba(4,17,38,0.96),rgba(9,26,55,0.95)_52%,rgba(21,17,57,0.95))] p-5 text-white shadow-[0_28px_90px_rgba(0,0,0,0.58),0_0_48px_rgba(34,211,238,0.12)]">
+        <p className="text-[9px] font-black uppercase tracking-[0.24em] text-cyan-100/54">
+          Simulated result
+        </p>
+        <h2 id="daily-tip-guide-result-title" className="mt-2 text-[22px] font-black tracking-[-0.04em] text-white">
+          What happens when you open it?
+        </h2>
+        <p className="mt-3 text-[13px] font-semibold leading-relaxed text-cyan-50/76">
+          CLARA gives you one quick money insight for today. It is designed to be short, practical, and easy to apply.
+        </p>
+        <div className="mt-4 rounded-[24px] border border-cyan-100/14 bg-cyan-300/[0.08] p-4 text-[12px] font-semibold leading-relaxed text-cyan-50/88">
+          Before spending today, ask: “Is this planned, needed, or just a reaction?”
+        </div>
+        <div className="mt-5 grid gap-2">
+          <button
+            type="button"
+            onClick={onUnderstand}
+            className="rounded-2xl bg-cyan-200 px-4 py-3 text-[12px] font-black uppercase tracking-[0.16em] text-slate-950 shadow-[0_16px_34px_rgba(34,211,238,0.24)] transition active:scale-[0.99]"
+          >
+            I understand this
+          </button>
+          <button
+            type="button"
+            onClick={onTryRealClara}
+            className="rounded-2xl border border-white/10 bg-white/[0.06] px-4 py-3 text-[12px] font-black uppercase tracking-[0.16em] text-white/72 transition hover:bg-white/[0.09] active:scale-[0.99]"
+          >
+            Try it in real CLARA
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export default function DashboardHomePanel({
   isPending,
@@ -78,8 +266,28 @@ export default function DashboardHomePanel({
   fmt,
 }) {
   const [moneySummaryResetKey, setMoneySummaryResetKey] = useState(0);
+  const [isGuideIntroOpen, setIsGuideIntroOpen] = useState(false);
+  const [isGuideMode, setIsGuideMode] = useState(false);
+  const [guideFeature, setGuideFeature] = useState(GUIDE_FEATURE_DAILY_MONEY_TIP);
+  const [guideStep, setGuideStep] = useState(0);
+  const [claraGuideProgress, setClaraGuideProgress] = useState(() => readClaraGuideProgress());
   const currentPlan = user?.plan || user?.subscription?.plan || "free";
+  const effectivePlan = isGuideMode ? "pro" : currentPlan;
   const isFreePlan = currentPlan === "free";
+  const hasNewDailyMoneyTipGuide = !isDailyMoneyTipGuideComplete(claraGuideProgress);
+
+  const effectiveWallets = isGuideMode ? GUIDE_DEMO_WALLETS : wallets;
+  const effectiveWalletMoney = isGuideMode ? GUIDE_DEMO_WALLET_MONEY : walletMoney;
+  const effectiveWalletPreviewTransactions = isGuideMode
+    ? GUIDE_DEMO_WALLET_PREVIEW_TRANSACTIONS
+    : walletPreviewTransactions;
+  const effectiveMonthlyBudgetPlan = isGuideMode ? GUIDE_DEMO_MONTHLY_BUDGET_PLAN : monthlyBudgetPlan;
+  const effectiveSavingsGoals = isGuideMode ? GUIDE_DEMO_SAVINGS_GOALS : savingsGoals;
+  const effectiveTotalSavingsSaved = isGuideMode ? GUIDE_DEMO_TOTAL_SAVINGS_SAVED : totalSavingsSaved;
+  const effectiveTotalSavingsTarget = isGuideMode ? GUIDE_DEMO_TOTAL_SAVINGS_TARGET : totalSavingsTarget;
+  const effectivePrimarySavingsGoal = isGuideMode ? GUIDE_DEMO_SAVINGS_GOALS[0] : primarySavingsGoal;
+  const effectiveSurvivalExpense = isGuideMode ? GUIDE_DEMO_SURVIVAL_EXPENSE : survivalExpense;
+  const effectiveThisMonthSpent = isGuideMode ? 3550 : thisMonthSpent;
 
   const handleSaveBudget = useCallback(() => {
     runInAnimationFrame(() => openBudgetModal());
@@ -149,6 +357,65 @@ export default function DashboardHomePanel({
     [openAddSavingsModal]
   );
 
+  const exitGuideMode = useCallback(({ focusRealDailyTip = false } = {}) => {
+    setIsGuideMode(false);
+    setGuideStep(0);
+    setGuideFeature(GUIDE_FEATURE_DAILY_MONEY_TIP);
+
+    if (focusRealDailyTip && typeof window !== "undefined") {
+      window.setTimeout(() => {
+        const dailyTipCard = document.querySelector("[data-clara-daily-tip-card='true']");
+        dailyTipCard?.scrollIntoView?.({ block: "center", behavior: "smooth" });
+      }, 80);
+    }
+  }, []);
+
+  const startGuideMode = useCallback(() => {
+    setIsGuideIntroOpen(false);
+    setGuideFeature(GUIDE_FEATURE_DAILY_MONEY_TIP);
+    setGuideStep(0);
+    setIsGuideMode(true);
+
+    if (typeof window !== "undefined") {
+      window.setTimeout(() => {
+        document.querySelector("[data-clara-daily-tip-card='true']")?.scrollIntoView?.({
+          block: "center",
+          behavior: "smooth",
+        });
+      }, 80);
+    }
+  }, []);
+
+  const handleGuideDailyTipTap = useCallback(() => {
+    if (!isGuideMode || guideFeature !== GUIDE_FEATURE_DAILY_MONEY_TIP || guideStep !== 0) return;
+    setGuideStep(1);
+  }, [guideFeature, guideStep, isGuideMode]);
+
+  const completeDailyMoneyTipGuide = useCallback(() => {
+    const nextProgress = markDailyMoneyTipGuideComplete();
+    setClaraGuideProgress(nextProgress);
+    exitGuideMode();
+  }, [exitGuideMode]);
+
+  const tryDailyMoneyTipInRealClara = useCallback(() => {
+    exitGuideMode({ focusRealDailyTip: true });
+  }, [exitGuideMode]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+
+    const syncGuideProgress = (event) => {
+      if (event?.key && event.key !== CLARA_GUIDE_PROGRESS_KEY) return;
+      setClaraGuideProgress(readClaraGuideProgress());
+    };
+
+    window.addEventListener("storage", syncGuideProgress);
+
+    return () => {
+      window.removeEventListener("storage", syncGuideProgress);
+    };
+  }, []);
+
   useEffect(() => {
     if (typeof window === "undefined") return undefined;
 
@@ -173,7 +440,17 @@ export default function DashboardHomePanel({
 
   return (
     <>
-      {isPending && (
+      {isGuideMode && guideStep === 0 ? (
+        <div className="fixed inset-0 z-40 bg-slate-950/64 backdrop-blur-[1.5px]" aria-hidden="true" />
+      ) : null}
+
+      {isGuideIntroOpen ? (
+        <ClaraGuideIntroModal onStart={startGuideMode} onClose={() => setIsGuideIntroOpen(false)} />
+      ) : null}
+
+      {isGuideMode ? <ClaraGuideModeBanner onExit={exitGuideMode} /> : null}
+
+      {isPending && !isGuideMode && (
         <div className="flex items-center gap-3 rounded-2xl border border-white/15 bg-secondary/20 p-3">
           <Clock className="h-5 w-5 shrink-0" />
           <div className="flex-1 text-sm">Enrollment Under Review</div>
@@ -184,14 +461,23 @@ export default function DashboardHomePanel({
       )}
 
       <div className="clara-dashboard-hub-rail flex flex-col [--clara-hub-rail-gap:clamp(15px,1.8dvh,18px)] gap-[var(--clara-hub-rail-gap)]">
-        {dashboardShellReady && <LearningHub user={user} />}
+        {dashboardShellReady && (
+          <LearningHub
+            isGuideMode={isGuideMode}
+            guideFeature={guideFeature}
+            guideStep={guideStep}
+            hasNewGuide={hasNewDailyMoneyTipGuide}
+            onOpenGuideIntro={() => setIsGuideIntroOpen(true)}
+            onGuideDailyTipTap={handleGuideDailyTipTap}
+          />
+        )}
 
         <div className="clara-dashboard-bottom-finance-rail flex flex-col [--clara-bottom-finance-gap:clamp(16px,2dvh,20px)] gap-[var(--clara-bottom-finance-gap)]">
-          {!!user && (
+          {(!!user || isGuideMode) && (
             <div className={dashboardScale.financeWrap}>
-              <FinanceInlineAlert notice={financeNotice} onClose={closeFinanceNotice} />
+              {!isGuideMode ? <FinanceInlineAlert notice={financeNotice} onClose={closeFinanceNotice} /> : null}
 
-              {shouldShowNonBlockingRefresh ? (
+              {shouldShowNonBlockingRefresh && !isGuideMode ? (
                 <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-emerald-300/15 bg-emerald-400/10 px-3 py-1.5 text-[11px] font-semibold text-emerald-100/80">
                   <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-300" />
                   Refreshing finance data...
@@ -203,43 +489,44 @@ export default function DashboardHomePanel({
                 dashboardScale={dashboardScale}
                 selectedDashboardTheme={selectedDashboardTheme}
                 themeInactiveDotClass={themeInactiveDotClass}
-                plan={currentPlan}
-                wallets={wallets}
-                walletMoney={walletMoney}
-                walletPreviewTransactions={walletPreviewTransactions}
-                survivalExpense={survivalExpense}
-                user={user}
-                guardChecked={guardChecked}
-                loading={loading}
-                profileData={profileData}
+                plan={effectivePlan}
+                wallets={effectiveWallets}
+                walletMoney={effectiveWalletMoney}
+                walletPreviewTransactions={effectiveWalletPreviewTransactions}
+                survivalExpense={effectiveSurvivalExpense}
+                user={isGuideMode ? null : user}
+                guardChecked={isGuideMode ? false : guardChecked}
+                loading={isGuideMode ? false : loading}
+                profileData={isGuideMode ? { plan: "pro" } : profileData}
                 firstPositiveNumber={firstPositiveNumber}
-                readStoredSurvivalExpense={readStoredSurvivalExpense}
-                monthlyBudgetPlan={monthlyBudgetPlan}
-                thisMonthSpent={thisMonthSpent}
-                savingsGoals={savingsGoals}
-                totalSavingsSaved={totalSavingsSaved}
-                totalSavingsTarget={totalSavingsTarget}
-                primarySavingsGoal={primarySavingsGoal}
-                expandedFinanceCard={expandedFinanceCard}
-                toggleFinanceDetails={toggleFinanceDetails}
-                financeActionLoading={financeActionLoading}
-                onQuickExpense={openManualExpenseModal}
-                onSurvivalSaved={saveSurvivalExpenseInline}
-                onSaveBudget={handleSaveBudget}
-                onEditBudgetCategory={handleEditBudgetCategory}
-                onDeleteBudgetCategory={handleDeleteBudgetCategory}
-                onResetBudget={handleResetBudget}
-                onCreateWallet={handleCreateWallet}
-                onMoveWallet={moveWalletInline}
-                onDeleteWallet={handleDeleteWallet}
-                onAddMoney={handleAddMoney}
-                onTransferMoney={handleTransferMoney}
-                onSaveSavingsGoal={handleSaveSavingsGoal}
-                onDeleteSavingsGoal={handleDeleteSavingsGoal}
-                onAddSavings={handleAddSavings}
-                startClaraAiLongPress={isFreePlan ? undefined : startClaraAiLongPress}
-                endClaraAiLongPress={isFreePlan ? undefined : endClaraAiLongPress}
-                handleClaraAiOrbClickCapture={isFreePlan ? undefined : handleClaraAiOrbClickCapture}
+                readStoredSurvivalExpense={isGuideMode ? undefined : readStoredSurvivalExpense}
+                monthlyBudgetPlan={effectiveMonthlyBudgetPlan}
+                thisMonthSpent={effectiveThisMonthSpent}
+                savingsGoals={effectiveSavingsGoals}
+                totalSavingsSaved={effectiveTotalSavingsSaved}
+                totalSavingsTarget={effectiveTotalSavingsTarget}
+                primarySavingsGoal={effectivePrimarySavingsGoal}
+                expandedFinanceCard={isGuideMode ? null : expandedFinanceCard}
+                toggleFinanceDetails={isGuideMode ? undefined : toggleFinanceDetails}
+                financeActionLoading={isGuideMode ? false : financeActionLoading}
+                onQuickExpense={isGuideMode ? undefined : openManualExpenseModal}
+                onSurvivalSaved={isGuideMode ? undefined : saveSurvivalExpenseInline}
+                onSaveBudget={isGuideMode ? undefined : handleSaveBudget}
+                onEditBudgetCategory={isGuideMode ? undefined : handleEditBudgetCategory}
+                onDeleteBudgetCategory={isGuideMode ? undefined : handleDeleteBudgetCategory}
+                onResetBudget={isGuideMode ? undefined : handleResetBudget}
+                onCreateWallet={isGuideMode ? undefined : handleCreateWallet}
+                onMoveWallet={isGuideMode ? undefined : moveWalletInline}
+                onDeleteWallet={isGuideMode ? undefined : handleDeleteWallet}
+                onAddMoney={isGuideMode ? undefined : handleAddMoney}
+                onTransferMoney={isGuideMode ? undefined : handleTransferMoney}
+                onSaveSavingsGoal={isGuideMode ? undefined : handleSaveSavingsGoal}
+                onDeleteSavingsGoal={isGuideMode ? undefined : handleDeleteSavingsGoal}
+                onAddSavings={isGuideMode ? undefined : handleAddSavings}
+                startClaraAiLongPress={isGuideMode || isFreePlan ? undefined : startClaraAiLongPress}
+                endClaraAiLongPress={isGuideMode || isFreePlan ? undefined : endClaraAiLongPress}
+                handleClaraAiOrbClickCapture={isGuideMode || isFreePlan ? undefined : handleClaraAiOrbClickCapture}
+                isGuideMode={isGuideMode}
               />
             </div>
           )}
@@ -253,27 +540,34 @@ export default function DashboardHomePanel({
             themeSoftTextClass={themeSoftTextClass}
             themePrimaryTextClass={themePrimaryTextClass}
             moneySummaryVisible={moneySummaryVisible}
-            toggleMoneySummaryVisibility={toggleMoneySummaryVisibility}
-            moneyLeftSummaryHandlers={moneyLeftSummaryHandlers}
-            handleMoneyLeftOrbClick={handleMoneyLeftOrbClick}
-            startMoneyLeftOrbLongPress={startMoneyLeftOrbLongPress}
-            moveMoneyLeftOrbLongPress={moveMoneyLeftOrbLongPress}
-            endMoneyLeftOrbLongPress={endMoneyLeftOrbLongPress}
-            stopMoneyLeftOrbEvent={stopMoneyLeftOrbEvent}
-            walletMoney={walletMoney}
-            thisMonthSpent={thisMonthSpent}
-            monthlyBudgetPlan={monthlyBudgetPlan}
-            savingsGoals={savingsGoals}
-            totalSavingsSaved={totalSavingsSaved}
-            totalSavingsTarget={totalSavingsTarget}
-            primarySavingsGoal={primarySavingsGoal}
-            survivalExpense={survivalExpense}
-            wallets={wallets}
-            walletPreviewTransactions={walletPreviewTransactions}
+            toggleMoneySummaryVisibility={isGuideMode ? undefined : toggleMoneySummaryVisibility}
+            moneyLeftSummaryHandlers={isGuideMode ? undefined : moneyLeftSummaryHandlers}
+            handleMoneyLeftOrbClick={isGuideMode ? undefined : handleMoneyLeftOrbClick}
+            startMoneyLeftOrbLongPress={isGuideMode ? undefined : startMoneyLeftOrbLongPress}
+            moveMoneyLeftOrbLongPress={isGuideMode ? undefined : moveMoneyLeftOrbLongPress}
+            endMoneyLeftOrbLongPress={isGuideMode ? undefined : endMoneyLeftOrbLongPress}
+            stopMoneyLeftOrbEvent={isGuideMode ? undefined : stopMoneyLeftOrbEvent}
+            walletMoney={effectiveWalletMoney}
+            thisMonthSpent={effectiveThisMonthSpent}
+            monthlyBudgetPlan={effectiveMonthlyBudgetPlan}
+            savingsGoals={effectiveSavingsGoals}
+            totalSavingsSaved={effectiveTotalSavingsSaved}
+            totalSavingsTarget={effectiveTotalSavingsTarget}
+            primarySavingsGoal={effectivePrimarySavingsGoal}
+            survivalExpense={effectiveSurvivalExpense}
+            wallets={effectiveWallets}
+            walletPreviewTransactions={effectiveWalletPreviewTransactions}
             fmt={fmt}
           />
         </div>
       </div>
+
+      {isGuideMode && guideStep === 1 ? (
+        <DailyMoneyTipGuideResult
+          onUnderstand={completeDailyMoneyTipGuide}
+          onTryRealClara={tryDailyMoneyTipInRealClara}
+        />
+      ) : null}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a small local-only CLARA Guide entry point beside the Learning Hub button with a NEW badge based on `claraGuideProgress`.
- Adds the Guide Mode intro, persistent simulation banner, Daily Money Tip highlight, instruction bubble, and simulated explanation step.
- Adds demo-only finance data while Guide Mode is active and disables real finance/check-in/daily-tip mutations in the guide flow.

## Safety notes
- Guide completion is stored only in localStorage using `claraGuideProgress`.
- Daily Tip and Daily Check-In hooks now accept `simulationMode` to avoid writing real daily tip/check-in keys.
- Financial carousel emergency-fund sync is disabled during Guide Mode.
- Real mutation handlers are not passed into finance cards during Guide Mode.

## Testing
- Not run locally; repository is only available through the connected GitHub tool in this session.