### PR TITLE
Fix Guide Mode carousel visual focus

### DIFF
--- a/src/components/fresh/main-dashboard/learning-hub/LearningHub.jsx
+++ b/src/components/fresh/main-dashboard/learning-hub/LearningHub.jsx
@@ -47,6 +47,7 @@ function DailyTipGuideBubble() {
 
 export default function LearningHub({
   isGuideMode = false,
+  guideFeature = "",
   guideStep = 0,
   isDailyTipGuideActive = false,
   hasNewGuide = false,
@@ -57,6 +58,7 @@ export default function LearningHub({
   const realHasCommittedAccess = useCommittedFeatureAccess();
   const hasCommittedAccess = isGuideMode ? true : realHasCommittedAccess;
   const isLocked = !hasCommittedAccess;
+  const isCarouselGuideActive = isGuideMode && guideFeature === "finance-carousel";
 
   const handleOpenHub = () => {
     if (isGuideMode) return;
@@ -72,7 +74,11 @@ export default function LearningHub({
   return (
     <section className="clara-budget-focus-shift clara-budget-focus-hub w-full">
       <div className="relative flex w-full flex-col gap-[var(--clara-hub-rail-gap,14px)] overflow-visible px-1 py-0">
-        <div className={`${isDailyTipGuideActive ? "relative z-[150] isolate" : "relative"} overflow-visible`}>
+        <div
+          className={`${isDailyTipGuideActive ? "relative z-[150] isolate" : "relative"} ${
+            isCarouselGuideActive ? "clara-guide-daily-tip-muted" : ""
+          } overflow-visible`}
+        >
           <DailyTipCard
             hasCommittedAccess={hasCommittedAccess}
             onOpenCommitmentBooklet={openCommittedVersionModal}

--- a/src/guide-mode-stacking.css
+++ b/src/guide-mode-stacking.css
@@ -24,6 +24,29 @@ html.clara-guide-finance-carousel-active
   pointer-events: none !important;
 }
 
+html.clara-guide-finance-carousel-active
+#root .clara-guide-daily-tip-muted [data-clara-daily-tip-card="true"] {
+  opacity: 0.22;
+  filter: brightness(0.38) saturate(0.55) contrast(0.9);
+  pointer-events: none;
+}
+
+html.clara-guide-finance-carousel-active
+#root .clara-guide-daily-tip-muted .clara-daily-tip-face {
+  border-color: rgba(255, 255, 255, 0.06) !important;
+  background: linear-gradient(
+    135deg,
+    rgba(2, 6, 23, 0.98),
+    rgba(4, 8, 22, 0.98)
+  ) !important;
+  box-shadow: none !important;
+}
+
+html.clara-guide-finance-carousel-active
+#root .clara-guide-daily-tip-muted .clara-daily-tip-face * {
+  color: rgba(255, 255, 255, 0.42);
+}
+
 #root .fixed.inset-0.z-\[60\] ~ .clara-dashboard-hub-rail .clara-budget-focus-hub .clara-guide-bubble-shell {
   z-index: 220 !important;
 }
@@ -123,9 +146,35 @@ html.clara-guide-finance-carousel-active
   z-index: 190 !important;
   isolation: isolate;
   overflow: visible !important;
-  filter: brightness(1) saturate(1) contrast(1) !important;
   opacity: 1 !important;
   pointer-events: auto !important;
+  filter: brightness(1) saturate(1) contrast(1) !important;
+  transform: translate3d(0, 0, 0) scale(1.01);
+}
+
+html.clara-guide-finance-carousel-active
+#root .clara-guide-carousel-target .clara-finance-slide-surface {
+  border-color: rgba(186, 242, 255, 0.34) !important;
+  filter: brightness(1.14) saturate(1.08) contrast(1.03) !important;
+  box-shadow:
+    0 28px 92px rgba(34, 211, 238, 0.22),
+    0 0 0 1px rgba(255, 255, 255, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1) !important;
+}
+
+html.clara-guide-finance-carousel-active
+#root .clara-guide-carousel-target::before {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  inset: -10px;
+  z-index: -1;
+  border-radius: 34px;
+  background:
+    radial-gradient(circle at 18% 18%, rgba(34, 211, 238, 0.22), transparent 46%),
+    radial-gradient(circle at 82% 12%, rgba(129, 140, 248, 0.20), transparent 42%);
+  filter: blur(10px);
+  opacity: 0.82;
 }
 
 html.clara-guide-finance-carousel-active


### PR DESCRIPTION
## Summary
- Adds a carousel-mode muted wrapper state for the Daily Money Tip inside LearningHub.
- Darkens and disables Daily Tip visuals only while `finance-carousel` is the active Guide Mode feature.
- Strengthens the active carousel target/surface glow while preserving pointer events for swipe.

## Preserved
- Daily Tip active guard remains `isGuideMode && isDailyTipGuideActive && guideStep === 0`.
- Carousel guide bubble stays fixed/root-level in DashboardHomePanel.
- Runtime transition class/event behavior remains unchanged.
- Carousel viewport/swipe internals untouched.