### PR TITLE
Simplify Monthly Coaching time header

### DIFF
--- a/src/welcome-session-calendar-status.css
+++ b/src/welcome-session-calendar-status.css
@@ -36,3 +36,56 @@ button[aria-label*="no available appointment"]::after {
   background: rgb(251 113 133 / 0.82);
   box-shadow: 0 0 10px rgb(251 113 133 / 0.18);
 }
+
+/*
+  Time-selection header: the selected date is the only important heading here.
+  Remove the repeated clock tile and the redundant “Monthly coaching times”
+  eyebrow, then allow the complete date to wrap instead of truncating to “…”.
+*/
+section:has(button[aria-label="Back to Monthly Coaching overview"])
+  > div:last-child
+  > div:first-child
+  > div:first-child {
+  flex: 1 1 auto;
+  gap: 0 !important;
+}
+
+section:has(button[aria-label="Back to Monthly Coaching overview"])
+  > div:last-child
+  > div:first-child
+  > div:first-child
+  > div:first-child {
+  display: none !important;
+}
+
+section:has(button[aria-label="Back to Monthly Coaching overview"])
+  > div:last-child
+  > div:first-child
+  > div:first-child
+  > div:last-child {
+  width: 100%;
+  min-width: 0;
+}
+
+section:has(button[aria-label="Back to Monthly Coaching overview"])
+  > div:last-child
+  > div:first-child
+  > div:first-child
+  > div:last-child
+  > p:first-child {
+  display: none !important;
+}
+
+section:has(button[aria-label="Back to Monthly Coaching overview"])
+  > div:last-child
+  > div:first-child
+  > div:first-child
+  > div:last-child
+  > h1 {
+  margin-top: 0 !important;
+  padding-right: 0.25rem;
+  overflow: visible !important;
+  text-overflow: clip !important;
+  white-space: normal !important;
+  line-height: 1.12;
+}


### PR DESCRIPTION
Refines the selected-date time screen for better use of space.

Changes:
- removes the large clock icon tile
- removes the redundant “Monthly coaching times” eyebrow
- gives the selected date the full header width
- allows the complete date to wrap instead of being cut off with an ellipsis
- keeps the X action and time-slot flow unchanged