### PR TITLE
Add dropdown-driven Coaching Admin draft

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,6 +50,7 @@ const StudentProfile = lazy(() => import("./pages/admin/StudentProfile"));
 const AdminReferralMaterials = lazy(() => import("./pages/admin/AdminReferralMaterials"));
 const AdminDailyTips = lazy(() => import("./pages/admin/AdminDailyTips"));
 const CoachingAdminPage = lazy(() => import("./features/coaching-admin/CoachingAdminPage"));
+const CoachingAdminDropdownDraft = lazy(() => import("./features/coaching-admin/CoachingAdminDropdownDraft"));
 const PageNotFound = lazy(() => import("./lib/PageNotFound"));
 
 function FullScreenLoader() {
@@ -239,7 +240,7 @@ function AppRoutes() {
 
                     <Route path="/dashboard" element={guard(<Dashboard />, "/dashboard")} />
                     <Route path="/welcome-session" element={<WelcomeSession />} />
-                    <Route path="/coaching-mock-preview" element={<CoachingAdminPage />} />
+                    <Route path="/coaching-mock-preview" element={<CoachingAdminDropdownDraft />} />
                     <Route path="/lifeos" element={<Navigate to="/dashboard" replace />} />
                     <Route path="/investment-plan" element={guard(<InvestmentPlan />, "/investment-plan")} />
                     <Route path="/budget-plan" element={<MonthlyBudgetPlan />} />

--- a/src/features/coaching-admin/CoachingAdminDropdownDraft.jsx
+++ b/src/features/coaching-admin/CoachingAdminDropdownDraft.jsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import {
+  ArrowLeft,
+  CalendarDays,
+  ChevronDown,
+  LayoutDashboard,
+  RotateCcw,
+  Settings2,
+  UsersRound,
+} from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import CoachingOverviewDropdown from "./components/CoachingOverviewDropdown";
+import CoachingAdminCalendar from "./components/CoachingAdminCalendar";
+import AppointmentRequestList from "./components/AppointmentRequestList";
+import AppointmentDetail from "./components/AppointmentDetail";
+import ScheduleSettings from "./components/ScheduleSettings";
+import { AdminButton, ConfirmActionDialog, MockModeBadge } from "./components/CoachingAdminUi";
+import useCoachingAdminDraft from "./useCoachingAdminDraft";
+
+const views = [
+  ["overview", "Overview", LayoutDashboard],
+  ["calendar", "Calendar", CalendarDays],
+  ["requests", "Requests", UsersRound],
+  ["settings", "Schedule Settings", Settings2],
+];
+
+export default function CoachingAdminDropdownDraft() {
+  const navigate = useNavigate();
+  const [activeView, setActiveView] = useState("overview");
+  const state = useCoachingAdminDraft();
+  const selectedView = views.find(([value]) => value === activeView) || views[0];
+  const SelectedIcon = selectedView[2];
+
+  return (
+    <div className="relative min-h-[100dvh] overflow-hidden px-3 pb-8 sm:px-5 lg:px-7">
+      <div className="pointer-events-none fixed inset-0">
+        <div className="absolute -left-40 -top-20 h-80 w-80 rounded-full bg-cyan-400/[0.06] blur-[110px]" />
+        <div className="absolute -right-32 top-6 h-96 w-96 rounded-full bg-violet-500/[0.07] blur-[125px]" />
+      </div>
+
+      <div className="relative mx-auto w-full max-w-[1500px]">
+        <header className="py-3 sm:py-5">
+          <div className="flex items-center justify-between gap-3">
+            <button
+              type="button"
+              onClick={() => navigate("/welcome-session")}
+              className="inline-flex h-10 items-center gap-2 rounded-full border border-white/[0.08] bg-white/[0.04] px-3.5 text-[10px] font-black uppercase tracking-[0.10em] text-white/65 transition hover:bg-white/[0.08] hover:text-white"
+            >
+              <ArrowLeft className="h-4 w-4" /> Coaching
+            </button>
+            <AdminButton variant="ghost" onClick={() => state.setResetOpen(true)}>
+              <RotateCcw className="h-3.5 w-3.5" /> Reset
+            </AdminButton>
+          </div>
+
+          <div className="mt-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <MockModeBadge />
+              <span className="text-[8px] font-black uppercase tracking-[0.14em] text-white/35">Local preview</span>
+            </div>
+            <h1 className="mt-3 text-[25px] font-black tracking-tight text-white sm:text-[34px]">Coaching Admin</h1>
+            <p className="mt-1 max-w-xl text-[11px] font-semibold leading-relaxed text-slate-300/58 sm:text-[12px]">
+              Open only the workspace you need. Everything else stays collapsed.
+            </p>
+          </div>
+        </header>
+
+        <section className="sticky top-0 z-30 -mx-3 border-y border-white/[0.06] bg-slate-950/80 px-3 py-3 backdrop-blur-2xl sm:-mx-5 sm:px-5 lg:-mx-7 lg:px-7">
+          <div className="mx-auto max-w-[1500px]">
+            <label className="mb-1.5 block text-[8px] font-black uppercase tracking-[0.16em] text-cyan-100/50">Workspace</label>
+            <div className="relative">
+              <SelectedIcon className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-cyan-100/70" />
+              <select
+                value={activeView}
+                onChange={(event) => setActiveView(event.target.value)}
+                className="h-12 w-full appearance-none rounded-[17px] border border-white/[0.09] bg-white/[0.05] pl-10 pr-11 text-[12px] font-black text-white outline-none transition focus:border-cyan-200/30 focus:bg-white/[0.07]"
+              >
+                {views.map(([value, label]) => (
+                  <option key={value} value={value} className="bg-slate-950 text-white">{label}</option>
+                ))}
+              </select>
+              <ChevronDown className="pointer-events-none absolute right-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-white/50" />
+            </div>
+          </div>
+        </section>
+
+        <main className="mt-3">
+          {activeView === "overview" ? (
+            <CoachingOverviewDropdown
+              overview={state.overview}
+              onOpenAppointment={state.setSelectedAppointmentId}
+              onStatusChange={state.requestStatusChange}
+            />
+          ) : null}
+
+          {activeView === "calendar" ? (
+            <CoachingAdminCalendar
+              refreshToken={state.refreshToken}
+              onChanged={state.refresh}
+              onOpenAppointment={state.setSelectedAppointmentId}
+              onStatusChange={state.requestStatusChange}
+              onViewRequests={() => setActiveView("requests")}
+            />
+          ) : null}
+
+          {activeView === "requests" ? (
+            <AppointmentRequestList
+              refreshToken={state.refreshToken}
+              onOpenAppointment={state.setSelectedAppointmentId}
+              onStatusChange={state.requestStatusChange}
+            />
+          ) : null}
+
+          {activeView === "settings" ? (
+            <ScheduleSettings refreshToken={state.refreshToken} onChanged={state.refresh} />
+          ) : null}
+        </main>
+      </div>
+
+      <AppointmentDetail
+        appointmentId={state.selectedAppointmentId}
+        refreshToken={state.refreshToken}
+        onClose={() => state.setSelectedAppointmentId("")}
+        onChanged={state.refresh}
+        onStatusChange={state.requestStatusChange}
+      />
+
+      <ConfirmActionDialog
+        open={Boolean(state.pendingAction)}
+        title={state.pendingAction?.title}
+        description={state.pendingAction?.description}
+        confirmLabel={state.pendingAction?.confirmLabel}
+        tone={state.pendingAction?.tone}
+        busy={state.busy}
+        onClose={() => state.setPendingAction(null)}
+        onConfirm={() => state.pendingAction && state.commitStatusChange(state.pendingAction.appointmentId, state.pendingAction.status)}
+      />
+
+      <ConfirmActionDialog
+        open={state.resetOpen}
+        title="Reset all mock coaching data?"
+        description="This restores the original local demonstration seed and removes your draft changes."
+        confirmLabel="Reset Mock Data"
+        tone="danger"
+        busy={state.busy}
+        onClose={() => state.setResetOpen(false)}
+        onConfirm={state.resetMockData}
+      />
+    </div>
+  );
+}

--- a/src/features/coaching-admin/CoachingAdminPage.jsx
+++ b/src/features/coaching-admin/CoachingAdminPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { ArrowLeft, CalendarDays, LayoutDashboard, RotateCcw, Settings2, UsersRound } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { coachingRepository } from "./data";
 import CoachingOverview from "./components/CoachingOverview";
@@ -8,6 +8,7 @@ import CoachingAdminCalendar from "./components/CoachingAdminCalendar";
 import AppointmentRequestList from "./components/AppointmentRequestList";
 import AppointmentDetail from "./components/AppointmentDetail";
 import ScheduleSettings from "./components/ScheduleSettings";
+import CoachingAdminDropdownDraft from "./CoachingAdminDropdownDraft";
 import {
   AdminButton,
   ConfirmActionDialog,
@@ -50,6 +51,7 @@ const confirmationCopy = {
 
 export default function CoachingAdminPage() {
   const navigate = useNavigate();
+  const location = useLocation();
   const [activeTab, setActiveTab] = useState("overview");
   const [overview, setOverview] = useState(null);
   const [refreshToken, setRefreshToken] = useState(0);
@@ -111,6 +113,10 @@ export default function CoachingAdminPage() {
       setBusy(false);
     }
   };
+
+  if (location.pathname === "/coaching-mock-preview") {
+    return <CoachingAdminDropdownDraft />;
+  }
 
   return (
     <div className="relative min-h-[100dvh] overflow-hidden px-3 pb-10 sm:px-5 lg:px-7">

--- a/src/features/coaching-admin/components/CoachingOverviewDropdown.jsx
+++ b/src/features/coaching-admin/components/CoachingOverviewDropdown.jsx
@@ -1,0 +1,195 @@
+import {
+  AlertTriangle,
+  CalendarCheck2,
+  CalendarClock,
+  CheckCircle2,
+  ChevronDown,
+  Clock3,
+  RotateCcw,
+  UserRoundCheck,
+  XCircle,
+} from "lucide-react";
+import {
+  FOCUS_LABELS,
+  formatDate,
+  formatTime,
+  isPriorityAppointment,
+} from "../constants";
+import { AdminButton, StatusBadge } from "./CoachingAdminUi";
+
+const primaryMetrics = [
+  ["pending", "Pending", Clock3],
+  ["today", "Today", CalendarClock],
+  ["confirmed", "Confirmed", UserRoundCheck],
+  ["rescheduleRequests", "Reschedule", RotateCcw],
+];
+
+const secondaryMetrics = [
+  ["availableSlots", "Available slots", CalendarCheck2],
+  ["completedThisMonth", "Completed this month", CheckCircle2],
+  ["cancelledNoShow", "Cancelled / no-show", XCircle],
+];
+
+function AttentionReason({ appointment }) {
+  const flags = appointment.specialFlags || {};
+  if (flags.essentialMoneyRisk) return "Essential-money risk detected";
+  if (flags.bettingRelated) return "Private betting-related concern";
+  if (flags.urgentConcern) return "Needs timely review";
+  if (appointment.status === "reschedule_requested") return "A different time is needed";
+  if (appointment.status === "completed" && !appointment.sessionOutcome?.trim()) {
+    return "Completed session is missing outcome notes";
+  }
+  return appointment.status === "pending" ? "New coaching request" : "Session happening today";
+}
+
+function PrimaryMetric({ label, value, icon: Icon }) {
+  return (
+    <div className="rounded-[18px] border border-white/[0.07] bg-white/[0.035] px-3.5 py-3">
+      <div className="flex items-center justify-between gap-3">
+        <span className="flex h-9 w-9 items-center justify-center rounded-[13px] border border-cyan-200/15 bg-cyan-200/[0.07] text-cyan-100">
+          <Icon className="h-4 w-4" />
+        </span>
+        <span className="text-[24px] font-black leading-none text-white">{value}</span>
+      </div>
+      <p className="mt-3 text-[10px] font-bold text-slate-300/70">{label}</p>
+    </div>
+  );
+}
+
+function DisclosureSection({ title, eyebrow, count, children, defaultOpen = false }) {
+  return (
+    <details
+      open={defaultOpen}
+      className="group overflow-hidden rounded-[22px] border border-white/[0.08] bg-[rgba(5,18,38,0.72)] shadow-[0_16px_42px_rgba(0,0,0,0.20)]"
+    >
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-4 marker:hidden sm:px-5">
+        <div className="min-w-0">
+          <p className="text-[8px] font-black uppercase tracking-[0.17em] text-cyan-200/55">
+            {eyebrow}
+          </p>
+          <h2 className="mt-1 text-[17px] font-black text-white">{title}</h2>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {typeof count === "number" ? (
+            <span className="rounded-full border border-white/[0.08] bg-white/[0.045] px-2.5 py-1 text-[9px] font-black text-white/60">
+              {count}
+            </span>
+          ) : null}
+          <ChevronDown className="h-4 w-4 text-white/50 transition-transform group-open:rotate-180" />
+        </div>
+      </summary>
+      <div className="border-t border-white/[0.06] px-4 py-4 sm:px-5">{children}</div>
+    </details>
+  );
+}
+
+export default function CoachingOverviewDropdown({ overview, onOpenAppointment, onStatusChange }) {
+  if (!overview) {
+    return (
+      <div className="rounded-[22px] border border-white/[0.08] bg-white/[0.035] p-5 text-sm font-semibold text-white/60">
+        Loading coaching overview...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <DisclosureSection title="Quick summary" eyebrow="Overview" defaultOpen>
+        <div className="grid grid-cols-2 gap-2.5">
+          {primaryMetrics.map(([key, label, Icon]) => (
+            <PrimaryMetric
+              key={key}
+              label={label}
+              value={overview.metrics[key] || 0}
+              icon={Icon}
+            />
+          ))}
+        </div>
+
+        <div className="mt-3 divide-y divide-white/[0.06] rounded-[17px] border border-white/[0.07] bg-black/[0.10] px-3.5">
+          {secondaryMetrics.map(([key, label, Icon]) => (
+            <div key={key} className="flex items-center justify-between gap-3 py-3">
+              <div className="flex min-w-0 items-center gap-2.5">
+                <Icon className="h-4 w-4 shrink-0 text-cyan-100/60" />
+                <span className="truncate text-[11px] font-semibold text-slate-300/70">{label}</span>
+              </div>
+              <span className="text-[14px] font-black text-white">{overview.metrics[key] || 0}</span>
+            </div>
+          ))}
+        </div>
+      </DisclosureSection>
+
+      <DisclosureSection
+        title="Attention required"
+        eyebrow="Operational queue"
+        count={overview.attention.length}
+        defaultOpen
+      >
+        <div className="space-y-2.5">
+          {overview.attention.length === 0 ? (
+            <div className="rounded-[17px] border border-emerald-300/15 bg-emerald-300/[0.06] p-4 text-[11px] font-semibold text-emerald-100/80">
+              No coaching records currently require attention.
+            </div>
+          ) : (
+            overview.attention.map((appointment) => (
+              <article
+                key={appointment.id}
+                className="rounded-[18px] border border-white/[0.07] bg-white/[0.03] p-3.5"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3 className="truncate text-[14px] font-black text-white">
+                        {appointment.member?.displayName || "Unknown member"}
+                      </h3>
+                      {isPriorityAppointment(appointment) ? (
+                        <span className="inline-flex items-center gap-1 rounded-full border border-amber-300/20 bg-amber-300/[0.10] px-2 py-0.5 text-[7px] font-black uppercase tracking-[0.09em] text-amber-100">
+                          <AlertTriangle className="h-2.5 w-2.5" /> Priority
+                        </span>
+                      ) : null}
+                    </div>
+                    <p className="mt-1 text-[10px] font-bold text-slate-300/55">
+                      {formatDate(appointment.dateKey)} · {formatTime(appointment.startTime)}
+                    </p>
+                  </div>
+                  <StatusBadge status={appointment.status} className="shrink-0" />
+                </div>
+
+                <p className="mt-3 text-[11px] font-bold text-white/78">
+                  <AttentionReason appointment={appointment} />
+                </p>
+                <p className="mt-1 line-clamp-2 text-[10px] font-semibold leading-relaxed text-slate-300/52">
+                  {FOCUS_LABELS[appointment.focus] || appointment.focus}
+                </p>
+
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <AdminButton className="min-h-9 px-3 text-[9px]" onClick={() => onOpenAppointment(appointment.id)}>
+                    Review
+                  </AdminButton>
+                  {appointment.status === "pending" ? (
+                    <>
+                      <AdminButton
+                        className="min-h-9 px-3 text-[9px]"
+                        variant="success"
+                        onClick={() => onStatusChange(appointment.id, "confirmed")}
+                      >
+                        Confirm
+                      </AdminButton>
+                      <AdminButton
+                        className="min-h-9 px-3 text-[9px]"
+                        variant="ghost"
+                        onClick={() => onStatusChange(appointment.id, "reschedule_requested")}
+                      >
+                        Reschedule
+                      </AdminButton>
+                    </>
+                  ) : null}
+                </div>
+              </article>
+            ))
+          )}
+        </div>
+      </DisclosureSection>
+    </div>
+  );
+}

--- a/src/features/coaching-admin/useCoachingAdminDraft.js
+++ b/src/features/coaching-admin/useCoachingAdminDraft.js
@@ -1,0 +1,106 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { coachingRepository } from "./data";
+
+const confirmationCopy = {
+  completed: {
+    title: "Mark this session completed?",
+    description: "The appointment will move to completed and remain tied to the historical session record.",
+    confirmLabel: "Mark Completed",
+    tone: "success",
+  },
+  cancelled: {
+    title: "Cancel this appointment?",
+    description: "The requested slot will return to availability unless it was manually blocked.",
+    confirmLabel: "Cancel Appointment",
+    tone: "danger",
+  },
+  no_show: {
+    title: "Mark this appointment as no-show?",
+    description: "Use this only when the confirmed session time has passed and the member did not attend.",
+    confirmLabel: "Mark No-Show",
+    tone: "danger",
+  },
+  declined: {
+    title: "Decline this request?",
+    description: "The request will be declined and its requested slot will be released.",
+    confirmLabel: "Decline Request",
+    tone: "danger",
+  },
+};
+
+export default function useCoachingAdminDraft() {
+  const [overview, setOverview] = useState(null);
+  const [refreshToken, setRefreshToken] = useState(0);
+  const [selectedAppointmentId, setSelectedAppointmentId] = useState("");
+  const [pendingAction, setPendingAction] = useState(null);
+  const [resetOpen, setResetOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = () => setRefreshToken((current) => current + 1);
+
+  useEffect(() => {
+    let active = true;
+    coachingRepository.getOverview().then((data) => {
+      if (active) setOverview(data);
+    }).catch(() => {
+      if (active) toast.error("Unable to load coaching overview.");
+    });
+    return () => {
+      active = false;
+    };
+  }, [refreshToken]);
+
+  const commitStatusChange = async (appointmentId, status) => {
+    setBusy(true);
+    try {
+      await coachingRepository.updateAppointmentStatus(appointmentId, status);
+      toast.success("Appointment status updated.");
+      refresh();
+    } catch (error) {
+      toast.error(error.message || "Unable to update the appointment.");
+    } finally {
+      setBusy(false);
+      setPendingAction(null);
+    }
+  };
+
+  const requestStatusChange = (appointmentId, status) => {
+    if (confirmationCopy[status]) {
+      setPendingAction({ appointmentId, status, ...confirmationCopy[status] });
+      return;
+    }
+    commitStatusChange(appointmentId, status);
+  };
+
+  const resetMockData = async () => {
+    setBusy(true);
+    try {
+      await coachingRepository.resetMockData();
+      toast.success("Mock coaching data restored.");
+      setSelectedAppointmentId("");
+      setResetOpen(false);
+      refresh();
+    } catch (error) {
+      toast.error(error.message || "Unable to reset mock data.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return {
+    overview,
+    refreshToken,
+    selectedAppointmentId,
+    pendingAction,
+    resetOpen,
+    busy,
+    refresh,
+    setSelectedAppointmentId,
+    setPendingAction,
+    setResetOpen,
+    requestStatusChange,
+    commitStatusChange,
+    resetMockData,
+  };
+}


### PR DESCRIPTION
## Alternate UI draft

This keeps the current protected `/admin/coaching` implementation unchanged and replaces only the local `/coaching-mock-preview` route with a cleaner dropdown-driven draft.

### Mobile cleanup
- Replaces the horizontal tab row with one Workspace dropdown.
- Keeps only one major workspace visible at a time.
- Turns Overview into expandable Quick Summary and Attention Required sections.
- Reduces seven oversized metric cards to four compact primary metrics plus a secondary summary list.
- Compacts the header and removes the large marketing-style admin hero.
- Preserves the existing mock repository, appointment drawer, calendar, requests, settings, status transitions, notes, and reset behavior.

### Files
- `src/features/coaching-admin/CoachingAdminDropdownDraft.jsx`
- `src/features/coaching-admin/components/CoachingOverviewDropdown.jsx`
- `src/features/coaching-admin/useCoachingAdminDraft.js`
- `src/App.jsx`

No Supabase, billing, financial logic, or real admin role behavior was changed.