### PR TITLE
Add Me Page to CLARA Guide Mode

### DIFF
--- a/src/components/fresh/main-dashboard/dashboard-panels/me/DashboardMeLifePanel.jsx
+++ b/src/components/fresh/main-dashboard/dashboard-panels/me/DashboardMeLifePanel.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { CLARA_ENVIRONMENT_UPDATED, countEnvironmentSignals, readEnvironmentSignals } from "./claraEnvironmentUtils";
 import ClaraGuideMePageOverlay from "../../guide/ClaraGuideMePageOverlay";
 import FinancialClimateScreen from "./FinancialClimateUniversalScreen";
@@ -6,6 +6,53 @@ import FinancialClimateScreen from "./FinancialClimateUniversalScreen";
 const CLARA_GUIDE_EXIT_EVENT = "clara:guide-exit";
 const CLARA_GUIDE_MODE_CHANGE_EVENT = "clara:guide-mode-change";
 const CLARA_GUIDE_ME_PHASE_CHANGE_EVENT = "clara:guide-me-phase-change";
+const GUIDE_PROTECTED_STORAGE_KEYS = new Set([
+  "clara_life_stage_profile_v1",
+  "clara_life_stage_images_v1",
+]);
+
+let guideStorageGuardUsers = 0;
+let originalStorageSetItem = null;
+
+function isMeGuideRootActive() {
+  if (typeof document === "undefined") return false;
+  const root = document.documentElement;
+  return (
+    root.classList.contains("clara-guide-me-preview-active") ||
+    root.classList.contains("clara-guide-me-complete-active")
+  );
+}
+
+function acquireGuideStorageGuard() {
+  if (
+    typeof window === "undefined" ||
+    typeof Storage === "undefined" ||
+    !Storage.prototype?.setItem
+  ) {
+    return () => {};
+  }
+
+  if (guideStorageGuardUsers === 0) {
+    originalStorageSetItem = Storage.prototype.setItem;
+    Storage.prototype.setItem = function guardedGuideStorageSetItem(key, value) {
+      const isProtectedLifeStageWrite =
+        this === window.localStorage && GUIDE_PROTECTED_STORAGE_KEYS.has(String(key));
+
+      if (isProtectedLifeStageWrite && isMeGuideRootActive()) return undefined;
+      return originalStorageSetItem.call(this, key, value);
+    };
+  }
+
+  guideStorageGuardUsers += 1;
+
+  return () => {
+    guideStorageGuardUsers = Math.max(0, guideStorageGuardUsers - 1);
+    if (guideStorageGuardUsers === 0 && originalStorageSetItem) {
+      Storage.prototype.setItem = originalStorageSetItem;
+      originalStorageSetItem = null;
+    }
+  };
+}
 
 function readMeGuidePhase() {
   if (typeof document === "undefined") return "inactive";
@@ -23,6 +70,11 @@ export default function DashboardMeLifePanel() {
   const signalTotal = Math.max(signalCount, 1);
   const guidePreviewMode = meGuidePhase === "me-page-preview" || meGuidePhase === "complete";
   const refresh = () => setSignals(readEnvironmentSignals());
+
+  useLayoutEffect(() => {
+    if (!guidePreviewMode) return undefined;
+    return acquireGuideStorageGuard();
+  }, [guidePreviewMode]);
 
   useEffect(() => {
     const handler = () => refresh();

--- a/src/components/fresh/main-dashboard/dashboard-panels/me/DashboardMeLifePanel.jsx
+++ b/src/components/fresh/main-dashboard/dashboard-panels/me/DashboardMeLifePanel.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 import { CLARA_ENVIRONMENT_UPDATED, countEnvironmentSignals, readEnvironmentSignals } from "./claraEnvironmentUtils";
-import ClaraGuideMePageOverlay from "../../guide/ClaraGuideMePageOverlay";
 import FinancialClimateScreen from "./FinancialClimateUniversalScreen";
 
 const CLARA_GUIDE_EXIT_EVENT = "clara:guide-exit";
@@ -35,6 +34,7 @@ export default function DashboardMeLifePanel() {
   }, []);
 
   useEffect(() => {
+    const syncPhaseFromRoot = () => setMeGuidePhase(readMeGuidePhase());
     const handleMeGuidePhaseChange = (event) => {
       setMeGuidePhase(event?.detail?.phase || "inactive");
     };
@@ -43,11 +43,21 @@ export default function DashboardMeLifePanel() {
       if (event?.detail?.active === false) setMeGuidePhase("inactive");
     };
 
+    const observer =
+      typeof MutationObserver !== "undefined"
+        ? new MutationObserver(syncPhaseFromRoot)
+        : null;
+    observer?.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
     window.addEventListener(CLARA_GUIDE_ME_PHASE_CHANGE_EVENT, handleMeGuidePhaseChange);
     window.addEventListener(CLARA_GUIDE_EXIT_EVENT, handleGuideExit);
     window.addEventListener(CLARA_GUIDE_MODE_CHANGE_EVENT, handleGuideModeChange);
 
     return () => {
+      observer?.disconnect();
       window.removeEventListener(CLARA_GUIDE_ME_PHASE_CHANGE_EVENT, handleMeGuidePhaseChange);
       window.removeEventListener(CLARA_GUIDE_EXIT_EVENT, handleGuideExit);
       window.removeEventListener(CLARA_GUIDE_MODE_CHANGE_EVENT, handleGuideModeChange);
@@ -89,8 +99,6 @@ export default function DashboardMeLifePanel() {
           guidePreviewMode={guidePreviewMode}
         />
       </div>
-
-      {guidePreviewMode ? <ClaraGuideMePageOverlay phase={meGuidePhase} /> : null}
     </div>
   );
 }

--- a/src/components/fresh/main-dashboard/dashboard-panels/me/DashboardMeLifePanel.jsx
+++ b/src/components/fresh/main-dashboard/dashboard-panels/me/DashboardMeLifePanel.jsx
@@ -1,12 +1,27 @@
 import { useEffect, useMemo, useState } from "react";
 import { CLARA_ENVIRONMENT_UPDATED, countEnvironmentSignals, readEnvironmentSignals } from "./claraEnvironmentUtils";
+import ClaraGuideMePageOverlay from "../../guide/ClaraGuideMePageOverlay";
 import FinancialClimateScreen from "./FinancialClimateUniversalScreen";
+
+const CLARA_GUIDE_EXIT_EVENT = "clara:guide-exit";
+const CLARA_GUIDE_MODE_CHANGE_EVENT = "clara:guide-mode-change";
+const CLARA_GUIDE_ME_PHASE_CHANGE_EVENT = "clara:guide-me-phase-change";
+
+function readMeGuidePhase() {
+  if (typeof document === "undefined") return "inactive";
+  const root = document.documentElement;
+  if (root.classList.contains("clara-guide-me-complete-active")) return "complete";
+  if (root.classList.contains("clara-guide-me-preview-active")) return "me-page-preview";
+  return "inactive";
+}
 
 export default function DashboardMeLifePanel() {
   const [signals, setSignals] = useState(() => readEnvironmentSignals());
+  const [meGuidePhase, setMeGuidePhase] = useState(() => readMeGuidePhase());
 
   const signalCount = useMemo(() => countEnvironmentSignals(signals), [signals]);
   const signalTotal = Math.max(signalCount, 1);
+  const guidePreviewMode = meGuidePhase === "me-page-preview" || meGuidePhase === "complete";
   const refresh = () => setSignals(readEnvironmentSignals());
 
   useEffect(() => {
@@ -19,9 +34,63 @@ export default function DashboardMeLifePanel() {
     };
   }, []);
 
+  useEffect(() => {
+    const handleMeGuidePhaseChange = (event) => {
+      setMeGuidePhase(event?.detail?.phase || "inactive");
+    };
+    const handleGuideExit = () => setMeGuidePhase("inactive");
+    const handleGuideModeChange = (event) => {
+      if (event?.detail?.active === false) setMeGuidePhase("inactive");
+    };
+
+    window.addEventListener(CLARA_GUIDE_ME_PHASE_CHANGE_EVENT, handleMeGuidePhaseChange);
+    window.addEventListener(CLARA_GUIDE_EXIT_EVENT, handleGuideExit);
+    window.addEventListener(CLARA_GUIDE_MODE_CHANGE_EVENT, handleGuideModeChange);
+
+    return () => {
+      window.removeEventListener(CLARA_GUIDE_ME_PHASE_CHANGE_EVENT, handleMeGuidePhaseChange);
+      window.removeEventListener(CLARA_GUIDE_EXIT_EVENT, handleGuideExit);
+      window.removeEventListener(CLARA_GUIDE_MODE_CHANGE_EVENT, handleGuideModeChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!guidePreviewMode) return undefined;
+
+    const stopStaticPreviewInteraction = (event) => {
+      if (!event.target?.closest?.("[data-clara-guide-me-static-surface='true']")) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    };
+
+    document.addEventListener("click", stopStaticPreviewInteraction, true);
+    document.addEventListener("change", stopStaticPreviewInteraction, true);
+    document.addEventListener("submit", stopStaticPreviewInteraction, true);
+
+    return () => {
+      document.removeEventListener("click", stopStaticPreviewInteraction, true);
+      document.removeEventListener("change", stopStaticPreviewInteraction, true);
+      document.removeEventListener("submit", stopStaticPreviewInteraction, true);
+    };
+  }, [guidePreviewMode]);
+
   return (
-    <div className="h-[calc(100svh-126px)] min-h-0 overflow-hidden rounded-[30px] bg-[#020817] shadow-[0_18px_52px_rgba(0,0,0,.24)]">
-      <FinancialClimateScreen signals={signals} signalCount={signalCount} signalTotal={signalTotal} />
+    <div
+      data-clara-guide-me-preview={guidePreviewMode ? "true" : undefined}
+      className={`relative h-[calc(100svh-126px)] min-h-0 rounded-[30px] bg-[#020817] shadow-[0_18px_52px_rgba(0,0,0,.24)] ${
+        guidePreviewMode ? "z-[80] overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden" : "overflow-hidden"
+      }`}
+    >
+      <div data-clara-guide-me-static-surface="true" className="h-full min-h-0">
+        <FinancialClimateScreen
+          signals={signals}
+          signalCount={signalCount}
+          signalTotal={signalTotal}
+          guidePreviewMode={guidePreviewMode}
+        />
+      </div>
+
+      {guidePreviewMode ? <ClaraGuideMePageOverlay phase={meGuidePhase} /> : null}
     </div>
   );
 }

--- a/src/components/fresh/main-dashboard/dashboard-panels/me/DashboardMeLifePanel.jsx
+++ b/src/components/fresh/main-dashboard/dashboard-panels/me/DashboardMeLifePanel.jsx
@@ -76,6 +76,39 @@ export default function DashboardMeLifePanel() {
     return acquireGuideStorageGuard();
   }, [guidePreviewMode]);
 
+  useLayoutEffect(() => {
+    if (!guidePreviewMode || typeof document === "undefined") return undefined;
+
+    const surface = document.querySelector("[data-clara-guide-me-static-surface='true']");
+    if (!surface) return undefined;
+
+    const controls = Array.from(
+      surface.querySelectorAll("button, input, select, textarea, a[href], [role='button']")
+    );
+    const snapshots = controls.map((control) => ({
+      control,
+      disabled: "disabled" in control ? control.disabled : undefined,
+      ariaDisabled: control.getAttribute("aria-disabled"),
+      tabIndex: control.getAttribute("tabindex"),
+    }));
+
+    controls.forEach((control) => {
+      if ("disabled" in control) control.disabled = true;
+      control.setAttribute("aria-disabled", "true");
+      control.setAttribute("tabindex", "-1");
+    });
+
+    return () => {
+      snapshots.forEach(({ control, disabled, ariaDisabled, tabIndex }) => {
+        if ("disabled" in control && disabled !== undefined) control.disabled = disabled;
+        if (ariaDisabled === null) control.removeAttribute("aria-disabled");
+        else control.setAttribute("aria-disabled", ariaDisabled);
+        if (tabIndex === null) control.removeAttribute("tabindex");
+        else control.setAttribute("tabindex", tabIndex);
+      });
+    };
+  }, [guidePreviewMode]);
+
   useEffect(() => {
     const handler = () => refresh();
     window.addEventListener("storage", handler);
@@ -141,7 +174,9 @@ export default function DashboardMeLifePanel() {
     <div
       data-clara-guide-me-preview={guidePreviewMode ? "true" : undefined}
       className={`relative h-[calc(100svh-126px)] min-h-0 rounded-[30px] bg-[#020817] shadow-[0_18px_52px_rgba(0,0,0,.24)] ${
-        guidePreviewMode ? "z-[80] overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden" : "overflow-hidden"
+        guidePreviewMode
+          ? "z-[80] overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&_button]:cursor-default [&_a]:cursor-default"
+          : "overflow-hidden"
       }`}
     >
       <div data-clara-guide-me-static-surface="true" className="h-full min-h-0">

--- a/src/components/fresh/main-dashboard/dashboard-panels/me/DashboardMeLifePanel.jsx
+++ b/src/components/fresh/main-dashboard/dashboard-panels/me/DashboardMeLifePanel.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { CLARA_ENVIRONMENT_UPDATED, countEnvironmentSignals, readEnvironmentSignals } from "./claraEnvironmentUtils";
+import ClaraGuideMePageOverlay from "../../guide/ClaraGuideMePageOverlay";
 import FinancialClimateScreen from "./FinancialClimateUniversalScreen";
 
 const CLARA_GUIDE_EXIT_EVENT = "clara:guide-exit";
@@ -99,6 +100,8 @@ export default function DashboardMeLifePanel() {
           guidePreviewMode={guidePreviewMode}
         />
       </div>
+
+      {guidePreviewMode ? <ClaraGuideMePageOverlay phase={meGuidePhase} /> : null}
     </div>
   );
 }

--- a/src/components/fresh/main-dashboard/guide/ClaraGuideMePageOverlay.jsx
+++ b/src/components/fresh/main-dashboard/guide/ClaraGuideMePageOverlay.jsx
@@ -27,7 +27,7 @@ export default function ClaraGuideMePageOverlay({ phase = "me-page-preview" }) {
 
   const updatePosition = useCallback(() => {
     const bubble = bubbleRef.current;
-    const preview = bubble?.closest?.("[data-clara-guide-me-preview='true']");
+    const preview = document.querySelector("[data-clara-guide-me-preview='true']");
     if (!bubble || !preview) return;
 
     const previewRect = preview.getBoundingClientRect();
@@ -35,14 +35,14 @@ export default function ClaraGuideMePageOverlay({ phase = "me-page-preview" }) {
     const setupCta = preview.querySelector("[data-clara-life-stage-setup-cta='true']");
     const padding = 14;
     const gap = 14;
-    const minTop = padding;
-    const maxTop = Math.max(minTop, previewRect.height - bubbleRect.height - padding);
+    const minTop = previewRect.top + padding;
+    const maxTop = Math.max(minTop, previewRect.bottom - bubbleRect.height - padding);
     let nextTop = maxTop;
 
     if (setupCta) {
       const ctaRect = setupCta.getBoundingClientRect();
-      const belowCta = ctaRect.bottom - previewRect.top + gap;
-      const aboveCta = ctaRect.top - previewRect.top - bubbleRect.height - gap;
+      const belowCta = ctaRect.bottom + gap;
+      const aboveCta = ctaRect.top - bubbleRect.height - gap;
 
       if (belowCta <= maxTop) nextTop = belowCta;
       else if (aboveCta >= minTop) nextTop = aboveCta;
@@ -60,7 +60,7 @@ export default function ClaraGuideMePageOverlay({ phase = "me-page-preview" }) {
     const handleResize = () => updatePosition();
     window.addEventListener("resize", handleResize);
 
-    const preview = bubbleRef.current?.closest?.("[data-clara-guide-me-preview='true']");
+    const preview = document.querySelector("[data-clara-guide-me-preview='true']");
     const observer =
       typeof ResizeObserver !== "undefined" && preview
         ? new ResizeObserver(handleResize)
@@ -96,8 +96,8 @@ export default function ClaraGuideMePageOverlay({ phase = "me-page-preview" }) {
 
   return (
     <div
-      className="pointer-events-none absolute inset-x-0 z-[95] px-3"
-      style={{ top: top === null ? "auto" : `${top}px`, bottom: top === null ? "14px" : "auto" }}
+      className="pointer-events-none fixed left-1/2 z-[95] w-[min(calc(100vw-24px),406px)] -translate-x-1/2 px-3"
+      style={{ top: top === null ? "calc(100svh - 250px)" : `${top}px` }}
     >
       <div
         ref={bubbleRef}

--- a/src/components/fresh/main-dashboard/guide/ClaraGuideMePageOverlay.jsx
+++ b/src/components/fresh/main-dashboard/guide/ClaraGuideMePageOverlay.jsx
@@ -20,6 +20,19 @@ const COPY = {
   },
 };
 
+function findSetupCta(preview) {
+  const markedCta = preview?.querySelector?.("[data-clara-life-stage-setup-cta='true']");
+  if (markedCta) return markedCta;
+
+  return Array.from(preview?.querySelectorAll?.("button") || []).find((button) =>
+    String(button.textContent || "")
+      .replace(/\s+/g, " ")
+      .trim()
+      .toUpperCase()
+      .includes("SET LIFE STAGE NOW")
+  );
+}
+
 export default function ClaraGuideMePageOverlay({ phase = "me-page-preview" }) {
   const bubbleRef = useRef(null);
   const completionDispatchRef = useRef(false);
@@ -33,11 +46,15 @@ export default function ClaraGuideMePageOverlay({ phase = "me-page-preview" }) {
 
     const previewRect = preview.getBoundingClientRect();
     const bubbleRect = bubble.getBoundingClientRect();
-    const setupCta = preview.querySelector("[data-clara-life-stage-setup-cta='true']");
+    const setupCta = findSetupCta(preview);
     const padding = 14;
     const gap = 14;
-    const minTop = previewRect.top + padding;
-    const maxTop = Math.max(minTop, previewRect.bottom - bubbleRect.height - padding);
+    const viewportBottom = window.innerHeight - padding;
+    const minTop = Math.max(previewRect.top + padding, padding);
+    const maxTop = Math.max(
+      minTop,
+      Math.min(previewRect.bottom, viewportBottom) - bubbleRect.height - padding
+    );
     let nextTop = maxTop;
 
     if (setupCta) {
@@ -58,18 +75,20 @@ export default function ClaraGuideMePageOverlay({ phase = "me-page-preview" }) {
 
   useEffect(() => {
     completionDispatchRef.current = false;
-    const handleResize = () => updatePosition();
-    window.addEventListener("resize", handleResize);
+    const handleViewportChange = () => updatePosition();
+    window.addEventListener("resize", handleViewportChange);
+    window.addEventListener("orientationchange", handleViewportChange);
 
     const preview = document.querySelector("[data-clara-guide-me-preview='true']");
     const observer =
       typeof ResizeObserver !== "undefined" && preview
-        ? new ResizeObserver(handleResize)
+        ? new ResizeObserver(handleViewportChange)
         : null;
     observer?.observe(preview);
 
     return () => {
-      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("resize", handleViewportChange);
+      window.removeEventListener("orientationchange", handleViewportChange);
       observer?.disconnect();
     };
   }, [phase, updatePosition]);

--- a/src/components/fresh/main-dashboard/guide/ClaraGuideMePageOverlay.jsx
+++ b/src/components/fresh/main-dashboard/guide/ClaraGuideMePageOverlay.jsx
@@ -1,0 +1,1 @@
+export default function ClaraGuideMePageOverlay() { return null; }

--- a/src/components/fresh/main-dashboard/guide/ClaraGuideMePageOverlay.jsx
+++ b/src/components/fresh/main-dashboard/guide/ClaraGuideMePageOverlay.jsx
@@ -1,1 +1,134 @@
-export default function ClaraGuideMePageOverlay() { return null; }
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+const CLARA_GUIDE_FEATURE_COMPLETE_EVENT = "clara:guide-feature-complete";
+const CLARA_GUIDE_ME_PHASE_REQUEST_EVENT = "clara:guide-me-phase-request";
+const GUIDE_FEATURE_ME_PAGE = "me-page";
+
+const COPY = {
+  "me-page-preview": {
+    title: "WHY ME MATTERS",
+    body: "The same amount of money can mean something different depending on your responsibilities and current life stage.",
+    supporting: "This profile helps CLARA personalize her guidance.",
+    footer: "CLARA LEARNS THE PERSON BEHIND THE NUMBERS.",
+  },
+  complete: {
+    title: "ME PAGE READY",
+    body: "CLARA can now connect money decisions with your real-life context.",
+    supporting: "Your existing profile remains unchanged while you are inside Guide Mode.",
+    footer: "YOUR REAL-LIFE CONTEXT MAKES THE GUIDANCE PERSONAL.",
+  },
+};
+
+export default function ClaraGuideMePageOverlay({ phase = "me-page-preview" }) {
+  const bubbleRef = useRef(null);
+  const completionDispatchRef = useRef(false);
+  const [top, setTop] = useState(null);
+  const copy = COPY[phase] || COPY["me-page-preview"];
+
+  const updatePosition = useCallback(() => {
+    const bubble = bubbleRef.current;
+    const preview = bubble?.closest?.("[data-clara-guide-me-preview='true']");
+    if (!bubble || !preview) return;
+
+    const previewRect = preview.getBoundingClientRect();
+    const bubbleRect = bubble.getBoundingClientRect();
+    const setupCta = preview.querySelector("[data-clara-life-stage-setup-cta='true']");
+    const padding = 14;
+    const gap = 14;
+    const minTop = padding;
+    const maxTop = Math.max(minTop, previewRect.height - bubbleRect.height - padding);
+    let nextTop = maxTop;
+
+    if (setupCta) {
+      const ctaRect = setupCta.getBoundingClientRect();
+      const belowCta = ctaRect.bottom - previewRect.top + gap;
+      const aboveCta = ctaRect.top - previewRect.top - bubbleRect.height - gap;
+
+      if (belowCta <= maxTop) nextTop = belowCta;
+      else if (aboveCta >= minTop) nextTop = aboveCta;
+    }
+
+    setTop(Math.max(minTop, Math.min(maxTop, nextTop)));
+  }, []);
+
+  useLayoutEffect(() => {
+    updatePosition();
+  }, [phase, updatePosition]);
+
+  useEffect(() => {
+    completionDispatchRef.current = false;
+    const handleResize = () => updatePosition();
+    window.addEventListener("resize", handleResize);
+
+    const preview = bubbleRef.current?.closest?.("[data-clara-guide-me-preview='true']");
+    const observer =
+      typeof ResizeObserver !== "undefined" && preview
+        ? new ResizeObserver(handleResize)
+        : null;
+    observer?.observe(preview);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      observer?.disconnect();
+    };
+  }, [phase, updatePosition]);
+
+  const handleNext = () => {
+    if (typeof window === "undefined") return;
+
+    if (phase !== "complete") {
+      window.dispatchEvent(
+        new CustomEvent(CLARA_GUIDE_ME_PHASE_REQUEST_EVENT, {
+          detail: { phase: "complete" },
+        })
+      );
+      return;
+    }
+
+    if (completionDispatchRef.current) return;
+    completionDispatchRef.current = true;
+    window.dispatchEvent(
+      new CustomEvent(CLARA_GUIDE_FEATURE_COMPLETE_EVENT, {
+        detail: { feature: GUIDE_FEATURE_ME_PAGE },
+      })
+    );
+  };
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-x-0 z-[95] px-3"
+      style={{ top: top === null ? "auto" : `${top}px`, bottom: top === null ? "14px" : "auto" }}
+    >
+      <div
+        ref={bubbleRef}
+        role="dialog"
+        aria-live="polite"
+        aria-labelledby="clara-guide-me-page-title"
+        className="pointer-events-auto relative mx-auto w-full max-w-[360px] rounded-[28px] border border-cyan-100/24 bg-[linear-gradient(145deg,rgba(5,18,36,0.985),rgba(10,22,54,0.985)_52%,rgba(27,18,65,0.985))] px-5 py-5 text-white shadow-[0_24px_76px_rgba(0,0,0,0.74),0_0_48px_rgba(34,211,238,0.18)] backdrop-blur-2xl"
+      >
+        <div className="pointer-events-none absolute -top-2 left-12 h-4 w-4 rotate-45 border-l border-t border-cyan-100/24 bg-[rgba(8,20,45,0.985)]" />
+        <p
+          id="clara-guide-me-page-title"
+          className="text-[10px] font-black uppercase tracking-[0.22em] text-cyan-100"
+        >
+          {copy.title}
+        </p>
+        <p className="mt-3 text-[13px] font-bold leading-5 text-white">{copy.body}</p>
+        <p className="mt-2 text-[12px] font-semibold leading-5 text-white/66">{copy.supporting}</p>
+        <div className="mt-4 h-px bg-cyan-100/15" />
+        <div className="mt-4 flex items-end justify-between gap-3">
+          <p className="max-w-[220px] text-[10px] font-black uppercase leading-4 tracking-[0.08em] text-cyan-100/86">
+            {copy.footer}
+          </p>
+          <button
+            type="button"
+            onClick={handleNext}
+            className="min-h-[42px] shrink-0 rounded-full border border-cyan-100/30 bg-cyan-100/15 px-5 py-2.5 text-[10px] font-black uppercase tracking-[0.18em] text-cyan-50 shadow-[0_12px_34px_rgba(34,211,238,0.16),inset_0_1px_0_rgba(255,255,255,0.12)] transition hover:bg-cyan-100/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100/80 active:scale-[0.99]"
+          >
+            NEXT
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/fresh/main-dashboard/guide/ClaraGuideMePageOverlay.jsx
+++ b/src/components/fresh/main-dashboard/guide/ClaraGuideMePageOverlay.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 const CLARA_GUIDE_FEATURE_COMPLETE_EVENT = "clara:guide-feature-complete";
 const CLARA_GUIDE_ME_PHASE_REQUEST_EVENT = "clara:guide-me-phase-request";
@@ -94,7 +95,9 @@ export default function ClaraGuideMePageOverlay({ phase = "me-page-preview" }) {
     );
   };
 
-  return (
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
     <div
       className="pointer-events-none fixed left-1/2 z-[95] w-[min(calc(100vw-24px),406px)] -translate-x-1/2 px-3"
       style={{ top: top === null ? "calc(100svh - 250px)" : `${top}px` }}
@@ -129,6 +132,7 @@ export default function ClaraGuideMePageOverlay({ phase = "me-page-preview" }) {
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/src/components/fresh/main-dashboard/top-nav/DashboardTopNav.jsx
+++ b/src/components/fresh/main-dashboard/top-nav/DashboardTopNav.jsx
@@ -1,8 +1,56 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { X } from "lucide-react";
 
 const CLARA_GUIDE_EXIT_EVENT = "clara:guide-exit";
 const CLARA_GUIDE_MODE_CHANGE_EVENT = "clara:guide-mode-change";
+const CLARA_GUIDE_FEATURE_COMPLETE_EVENT = "clara:guide-feature-complete";
+const CLARA_GUIDE_ME_PHASE_CHANGE_EVENT = "clara:guide-me-phase-change";
+const CLARA_GUIDE_ME_PHASE_REQUEST_EVENT = "clara:guide-me-phase-request";
+const GUIDE_FEATURE_MONEY_LEFT_ORB = "money-left-orb";
+
+const ME_GUIDE_PHASES = {
+  INACTIVE: "inactive",
+  AWAIT_ME_TAB: "await-me-tab",
+  ME_PAGE_PREVIEW: "me-page-preview",
+  COMPLETE: "complete",
+};
+
+const GUIDE_ROOT_FEATURE_CLASSES = [
+  "clara-guide-finance-carousel-active",
+  "clara-guide-money-left-active",
+  "clara-guide-money-left-privacy-active",
+  "clara-guide-money-left-orb-active",
+];
+
+function ClaraGuideMeNavigationBubble() {
+  return (
+    <div
+      className="pointer-events-none fixed left-1/2 z-[240] w-[min(calc(100vw-40px),360px)] -translate-x-1/2"
+      style={{ top: "clamp(112px, 15dvh, 150px)" }}
+    >
+      <div
+        role="dialog"
+        aria-live="polite"
+        aria-labelledby="clara-guide-me-navigation-title"
+        className="relative rounded-[28px] border border-cyan-100/24 bg-[linear-gradient(145deg,rgba(5,18,36,0.98),rgba(10,22,54,0.98)_52%,rgba(27,18,65,0.98))] px-5 py-5 text-white shadow-[0_22px_70px_rgba(0,0,0,0.72),0_0_44px_rgba(34,211,238,0.18)] backdrop-blur-2xl"
+      >
+        <div className="pointer-events-none absolute -top-2 left-[37.5%] h-4 w-4 -translate-x-1/2 rotate-45 border-l border-t border-cyan-100/24 bg-[rgba(8,20,45,0.98)]" />
+        <p
+          id="clara-guide-me-navigation-title"
+          className="text-[10px] font-black uppercase tracking-[0.22em] text-cyan-100"
+        >
+          ME PAGE
+        </p>
+        <p className="mt-3 text-[14px] font-bold leading-relaxed text-white">
+          This is where CLARA learns the life behind your money—not just the numbers.
+        </p>
+        <p className="mt-3 border-t border-cyan-100/15 pt-3 text-[12px] font-black uppercase leading-relaxed tracking-[0.08em] text-cyan-100/90">
+          TAP ME NOW.
+        </p>
+      </div>
+    </div>
+  );
+}
 
 export default function DashboardTopNav({
   dashboardScale,
@@ -18,141 +66,284 @@ export default function DashboardTopNav({
   themeIsLight = false,
 }) {
   const [isGuideModeTopNav, setIsGuideModeTopNav] = useState(false);
+  const [meGuidePhase, setMeGuidePhase] = useState(ME_GUIDE_PHASES.INACTIVE);
+  const isAwaitingMeTab = meGuidePhase === ME_GUIDE_PHASES.AWAIT_ME_TAB;
+  const isMePagePreviewActive = meGuidePhase === ME_GUIDE_PHASES.ME_PAGE_PREVIEW;
+  const isMeGuideComplete = meGuidePhase === ME_GUIDE_PHASES.COMPLETE;
+  const isMePageGuideVisible = isMePagePreviewActive || isMeGuideComplete;
+
+  const publishMeGuidePhase = useCallback((phase) => {
+    if (typeof window === "undefined") return;
+    window.dispatchEvent(
+      new CustomEvent(CLARA_GUIDE_ME_PHASE_CHANGE_EVENT, {
+        detail: { phase },
+      })
+    );
+  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined") return undefined;
 
     const handleGuideModeChange = (event) => {
-      setIsGuideModeTopNav(Boolean(event?.detail?.active));
+      const active = Boolean(event?.detail?.active);
+      setIsGuideModeTopNav(active);
+      if (!active) setMeGuidePhase(ME_GUIDE_PHASES.INACTIVE);
+    };
+
+    const handleGuideFeatureComplete = (event) => {
+      if (event?.detail?.feature !== GUIDE_FEATURE_MONEY_LEFT_ORB) return;
+
+      GUIDE_ROOT_FEATURE_CLASSES.forEach((className) => {
+        document.documentElement.classList.remove(className);
+      });
+      document.documentElement.classList.add("clara-guide-me-await-active");
+      setMeGuidePhase(ME_GUIDE_PHASES.AWAIT_ME_TAB);
+    };
+
+    const handleMeGuidePhaseRequest = (event) => {
+      const requestedPhase = event?.detail?.phase;
+      if (requestedPhase === ME_GUIDE_PHASES.COMPLETE) {
+        setMeGuidePhase(ME_GUIDE_PHASES.COMPLETE);
+      }
     };
 
     window.addEventListener(CLARA_GUIDE_MODE_CHANGE_EVENT, handleGuideModeChange);
+    window.addEventListener(CLARA_GUIDE_FEATURE_COMPLETE_EVENT, handleGuideFeatureComplete);
+    window.addEventListener(CLARA_GUIDE_ME_PHASE_REQUEST_EVENT, handleMeGuidePhaseRequest);
 
     return () => {
       window.removeEventListener(CLARA_GUIDE_MODE_CHANGE_EVENT, handleGuideModeChange);
+      window.removeEventListener(CLARA_GUIDE_FEATURE_COMPLETE_EVENT, handleGuideFeatureComplete);
+      window.removeEventListener(CLARA_GUIDE_ME_PHASE_REQUEST_EVENT, handleMeGuidePhaseRequest);
     };
   }, []);
 
+  useEffect(() => {
+    if (typeof document === "undefined") return undefined;
+
+    const root = document.documentElement;
+    root.classList.toggle("clara-guide-me-await-active", isAwaitingMeTab);
+    root.classList.toggle("clara-guide-me-preview-active", isMePagePreviewActive);
+    root.classList.toggle("clara-guide-me-complete-active", isMeGuideComplete);
+    publishMeGuidePhase(meGuidePhase);
+
+    return () => {
+      root.classList.remove(
+        "clara-guide-me-await-active",
+        "clara-guide-me-preview-active",
+        "clara-guide-me-complete-active"
+      );
+    };
+  }, [isAwaitingMeTab, isMeGuideComplete, isMePagePreviewActive, meGuidePhase, publishMeGuidePhase]);
+
   const handleGuideExit = () => {
     setIsGuideModeTopNav(false);
+    setMeGuidePhase(ME_GUIDE_PHASES.INACTIVE);
+    publishMeGuidePhase(ME_GUIDE_PHASES.INACTIVE);
+
+    if (typeof document !== "undefined") {
+      document.documentElement.classList.remove(
+        "clara-guide-me-await-active",
+        "clara-guide-me-preview-active",
+        "clara-guide-me-complete-active"
+      );
+    }
 
     if (typeof window !== "undefined") {
       window.dispatchEvent(new CustomEvent(CLARA_GUIDE_EXIT_EVENT));
     }
   };
 
+  const handleGuideNavigationTargetClick = (itemKey) => {
+    if (!isAwaitingMeTab || itemKey !== "me") return;
+
+    if (typeof document !== "undefined") {
+      document.documentElement.classList.remove("clara-guide-me-await-active");
+      document.documentElement.classList.add("clara-guide-me-preview-active");
+    }
+
+    openDashboardPanel("me");
+    setMeGuidePhase(ME_GUIDE_PHASES.ME_PAGE_PREVIEW);
+    publishMeGuidePhase(ME_GUIDE_PHASES.ME_PAGE_PREVIEW);
+  };
+
   return (
-    <div className={`relative shrink-0 ${isGuideModeTopNav ? "z-[100]" : "z-30"} ${dashboardScale.headerOuter}`}>
-      <div className="mx-auto w-full max-w-[430px] overflow-visible">
-        <div
-          className={`relative w-full overflow-hidden border backdrop-blur-xl ${dashboardScale.headerPanel}`}
-          style={themeQuickActionPanelStyle}
-        >
+    <>
+      <style>{`
+        html.clara-guide-me-await-active .clara-guide-carousel-bubble-shell {
+          display: none !important;
+        }
+
+        html.clara-guide-me-preview-active div:has(> div > [data-clara-guide-me-preview="true"]) > div:first-child,
+        html.clara-guide-me-complete-active div:has(> div > [data-clara-guide-me-preview="true"]) > div:first-child {
+          pointer-events: auto !important;
+          opacity: 1 !important;
+          filter: none !important;
+        }
+
+        html.clara-guide-me-preview-active div:has(> div > [data-clara-guide-me-preview="true"]) > div:nth-child(2),
+        html.clara-guide-me-complete-active div:has(> div > [data-clara-guide-me-preview="true"]) > div:nth-child(2) {
+          display: none !important;
+        }
+      `}</style>
+
+      {isMePageGuideVisible ? (
+        <div className="fixed inset-0 z-[60] bg-slate-950/82 backdrop-blur-[2px]" aria-hidden="true" />
+      ) : null}
+
+      {isAwaitingMeTab ? <ClaraGuideMeNavigationBubble /> : null}
+
+      <div className={`relative shrink-0 ${isGuideModeTopNav ? "z-[100]" : "z-30"} ${dashboardScale.headerOuter}`}>
+        <div className="mx-auto w-full max-w-[430px] overflow-visible">
           <div
-            className="pointer-events-none absolute inset-0 rounded-[inherit] opacity-70"
-            style={themeQuickActionGlowStyle}
-          />
-          <div className="pointer-events-none absolute inset-0 rounded-[inherit] bg-[linear-gradient(180deg,rgba(255,255,255,0.065),transparent_42%,rgba(0,0,0,0.14))]" />
-          <div className="pointer-events-none absolute inset-x-7 top-0 h-px bg-gradient-to-r from-transparent via-white/28 to-transparent" />
-          <div className="pointer-events-none absolute inset-x-8 bottom-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
+            className={`relative w-full overflow-hidden border backdrop-blur-xl ${dashboardScale.headerPanel}`}
+            style={themeQuickActionPanelStyle}
+          >
+            <div
+              className="pointer-events-none absolute inset-0 rounded-[inherit] opacity-70"
+              style={themeQuickActionGlowStyle}
+            />
+            <div className="pointer-events-none absolute inset-0 rounded-[inherit] bg-[linear-gradient(180deg,rgba(255,255,255,0.065),transparent_42%,rgba(0,0,0,0.14))]" />
+            <div className="pointer-events-none absolute inset-x-7 top-0 h-px bg-gradient-to-r from-transparent via-white/28 to-transparent" />
+            <div className="pointer-events-none absolute inset-x-8 bottom-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
 
-          <div className="relative grid grid-cols-4 gap-1.5 sm:gap-2">
-            {headerQuickActions.map((item, index) => {
-              const isGuideExitSlot = isGuideModeTopNav && item.key === "settings";
-              const isGuideStaticSlot = isGuideModeTopNav && !isGuideExitSlot;
-              const Icon = isGuideExitSlot ? X : item.icon;
-              const itemLabel = isGuideExitSlot ? "Exit" : item.label;
-              const isActive = isGuideExitSlot || (!isGuideModeTopNav && activeDashboardPanel === item.key);
-              const pillGlow =
-                item.key === "feed"
-                  ? "shadow-[0_0_12px_rgba(59,130,246,0.20)]"
-                  : item.key === "task"
-                    ? "shadow-[0_0_12px_rgba(250,204,21,0.22)]"
-                    : "";
-              const iconHoverGlow =
-                item.key === "feed"
-                  ? "group-hover:shadow-[0_0_24px_rgba(59,130,246,0.18)]"
-                  : item.key === "task"
-                    ? "group-hover:shadow-[0_0_24px_rgba(250,204,21,0.18)]"
-                    : item.key === "settings"
-                      ? "group-hover:shadow-[0_0_22px_rgba(255,255,255,0.16)]"
-                      : "group-hover:shadow-[0_0_22px_rgba(255,255,255,0.10)]";
+            <div className="relative grid grid-cols-4 gap-1.5 sm:gap-2">
+              {headerQuickActions.map((item, index) => {
+                const isGuideTargetSlot = isGuideModeTopNav && isAwaitingMeTab && item.key === "me";
+                const isGuideExitSlot = isGuideModeTopNav && item.key === "settings";
+                const isGuideStaticSlot =
+                  isGuideModeTopNav && !isGuideExitSlot && !isGuideTargetSlot;
+                const isGuideMeActiveSlot =
+                  isGuideModeTopNav &&
+                  isMePageGuideVisible &&
+                  item.key === "me" &&
+                  activeDashboardPanel === "me";
+                const Icon = isGuideExitSlot ? X : item.icon;
+                const itemLabel = isGuideExitSlot ? "Exit" : item.label;
+                const isActive =
+                  isGuideExitSlot ||
+                  isGuideMeActiveSlot ||
+                  (!isGuideModeTopNav && activeDashboardPanel === item.key);
+                const pillGlow =
+                  item.key === "feed"
+                    ? "shadow-[0_0_12px_rgba(59,130,246,0.20)]"
+                    : item.key === "task"
+                      ? "shadow-[0_0_12px_rgba(250,204,21,0.22)]"
+                      : "";
+                const iconHoverGlow =
+                  item.key === "feed"
+                    ? "group-hover:shadow-[0_0_24px_rgba(59,130,246,0.18)]"
+                    : item.key === "task"
+                      ? "group-hover:shadow-[0_0_24px_rgba(250,204,21,0.18)]"
+                      : item.key === "settings"
+                        ? "group-hover:shadow-[0_0_22px_rgba(255,255,255,0.16)]"
+                        : "group-hover:shadow-[0_0_22px_rgba(255,255,255,0.10)]";
 
-              const activeItemClass = themeIsLight
-                ? "border-emerald-400/45 bg-[linear-gradient(135deg,rgba(255,255,255,0.92)_0%,rgba(236,253,245,0.82)_42%,rgba(237,233,254,0.82)_100%)] text-slate-950 shadow-[inset_0_1px_0_rgba(255,255,255,0.95),0_12px_28px_rgba(15,23,42,0.12),0_0_26px_rgba(20,184,166,0.16)]"
-                : "border-emerald-100/24 bg-[linear-gradient(135deg,rgba(10,126,128,0.50)_0%,rgba(17,44,85,0.62)_46%,rgba(82,45,147,0.66)_100%)] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.12),0_0_34px_rgba(45,212,191,0.16),0_16px_32px_rgba(0,0,0,0.26)]";
+                const activeItemClass = themeIsLight
+                  ? "border-emerald-400/45 bg-[linear-gradient(135deg,rgba(255,255,255,0.92)_0%,rgba(236,253,245,0.82)_42%,rgba(237,233,254,0.82)_100%)] text-slate-950 shadow-[inset_0_1px_0_rgba(255,255,255,0.95),0_12px_28px_rgba(15,23,42,0.12),0_0_26px_rgba(20,184,166,0.16)]"
+                  : "border-emerald-100/24 bg-[linear-gradient(135deg,rgba(10,126,128,0.50)_0%,rgba(17,44,85,0.62)_46%,rgba(82,45,147,0.66)_100%)] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.12),0_0_34px_rgba(45,212,191,0.16),0_16px_32px_rgba(0,0,0,0.26)]";
 
-              const inactiveItemClass = themeIsLight
-                ? "border-transparent text-slate-700 hover:border-slate-300/40 hover:bg-white/48 hover:text-slate-950"
-                : "border-transparent text-white/76 hover:border-white/[0.09] hover:bg-white/[0.055] hover:text-white";
+                const inactiveItemClass = themeIsLight
+                  ? "border-transparent text-slate-700 hover:border-slate-300/40 hover:bg-white/48 hover:text-slate-950"
+                  : "border-transparent text-white/76 hover:border-white/[0.09] hover:bg-white/[0.055] hover:text-white";
 
-              const activeIconClass = themeIsLight
-                ? "border-emerald-500/55 bg-emerald-500/14 text-emerald-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.92),0_0_24px_rgba(16,185,129,0.18)]"
-                : "border-emerald-100/45 bg-emerald-400/[0.18] text-emerald-50 shadow-[inset_0_1px_0_rgba(255,255,255,0.14),0_0_26px_rgba(94,234,212,0.28)]";
+                const activeIconClass = themeIsLight
+                  ? "border-emerald-500/55 bg-emerald-500/14 text-emerald-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.92),0_0_24px_rgba(16,185,129,0.18)]"
+                  : "border-emerald-100/45 bg-emerald-400/[0.18] text-emerald-50 shadow-[inset_0_1px_0_rgba(255,255,255,0.14),0_0_26px_rgba(94,234,212,0.28)]";
 
-              return (
-                <button
-                  key={item.key}
-                  type="button"
-                  data-clara-guide-exit={isGuideExitSlot ? "true" : undefined}
-                  onClick={isGuideExitSlot ? handleGuideExit : isGuideStaticSlot ? undefined : () => openDashboardPanel(item.key)}
-                  className={`group relative flex min-w-0 ${isGuideStaticSlot ? "pointer-events-none opacity-35 saturate-50" : ""}`}
-                  aria-label={isGuideExitSlot ? "Exit CLARA Guide Mode" : item.label}
-                  aria-current={!isGuideModeTopNav && isActive ? "page" : undefined}
-                  disabled={isGuideStaticSlot}
-                >
-                  <div
-                    className={`relative flex w-full flex-col items-center justify-center overflow-hidden border transition duration-200 ${isGuideStaticSlot ? "" : "hover:-translate-y-[1px] active:scale-[0.985]"} ${dashboardScale.headerItem} ${isActive ? activeItemClass : `${inactiveItemClass} ${themeQuickActionBaseClass}`} ${isActive ? "clara-theme-nav-pill-active" : ""}`}
+                return (
+                  <button
+                    key={item.key}
+                    type="button"
+                    data-clara-guide-exit={isGuideExitSlot ? "true" : undefined}
+                    data-clara-guide-me-target={isGuideTargetSlot ? "true" : undefined}
+                    onClick={
+                      isGuideExitSlot
+                        ? handleGuideExit
+                        : isGuideTargetSlot
+                          ? () => handleGuideNavigationTargetClick(item.key)
+                          : isGuideStaticSlot
+                            ? undefined
+                            : () => openDashboardPanel(item.key)
+                    }
+                    className={`group relative flex min-w-0 ${
+                      isGuideStaticSlot ? "pointer-events-none opacity-35 saturate-50" : ""
+                    } ${
+                      isGuideTargetSlot
+                        ? "z-[120] rounded-[24px] ring-2 ring-cyan-200/75 ring-offset-2 ring-offset-slate-950/80 shadow-[0_0_34px_rgba(34,211,238,0.34)]"
+                        : ""
+                    }`}
+                    aria-label={isGuideExitSlot ? "Exit CLARA Guide Mode" : item.label}
+                    aria-current={isActive && !isGuideExitSlot ? "page" : undefined}
+                    disabled={isGuideStaticSlot}
                   >
-                    {isActive ? (
-                      <>
-                        <div className="pointer-events-none absolute inset-0 rounded-[inherit] bg-[radial-gradient(circle_at_18%_28%,rgba(94,234,212,0.24),transparent_44%),radial-gradient(circle_at_88%_54%,rgba(168,85,247,0.24),transparent_50%)]" />
-                        <div className="pointer-events-none absolute inset-x-4 top-0 h-px bg-gradient-to-r from-transparent via-emerald-100/50 to-transparent" />
-                      </>
-                    ) : (
-                      <div className={`pointer-events-none absolute inset-0 rounded-[inherit] opacity-0 transition duration-200 group-hover:opacity-100 ${themeIsLight ? "bg-[radial-gradient(circle_at_top,rgba(148,163,184,0.14),transparent_58%)]" : "bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.08),transparent_58%)]"}`} />
-                    )}
-
                     <div
-                      className={`relative flex shrink-0 items-center justify-center rounded-full border transition duration-200 ${dashboardScale.headerIcon} ${isActive ? activeIconClass : `${themeQuickActionIconShellClass} ${iconHoverGlow}`}`}
+                      className={`relative flex w-full flex-col items-center justify-center overflow-hidden border transition duration-200 ${
+                        isGuideStaticSlot ? "" : "hover:-translate-y-[1px] active:scale-[0.985]"
+                      } ${dashboardScale.headerItem} ${
+                        isActive || isGuideTargetSlot
+                          ? activeItemClass
+                          : `${inactiveItemClass} ${themeQuickActionBaseClass}`
+                      } ${isActive || isGuideTargetSlot ? "clara-theme-nav-pill-active" : ""}`}
                     >
-                      <Icon className={dashboardScale.headerIconSvg} />
+                      {isActive || isGuideTargetSlot ? (
+                        <>
+                          <div className="pointer-events-none absolute inset-0 rounded-[inherit] bg-[radial-gradient(circle_at_18%_28%,rgba(94,234,212,0.24),transparent_44%),radial-gradient(circle_at_88%_54%,rgba(168,85,247,0.24),transparent_50%)]" />
+                          <div className="pointer-events-none absolute inset-x-4 top-0 h-px bg-gradient-to-r from-transparent via-emerald-100/50 to-transparent" />
+                        </>
+                      ) : (
+                        <div className={`pointer-events-none absolute inset-0 rounded-[inherit] opacity-0 transition duration-200 group-hover:opacity-100 ${themeIsLight ? "bg-[radial-gradient(circle_at_top,rgba(148,163,184,0.14),transparent_58%)]" : "bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.08),transparent_58%)]"}`} />
+                      )}
 
-                      {!isGuideExitSlot && item.badge?.type === "count" ? (
-                        <span
-                          className={`absolute -right-1.5 -top-1.5 inline-flex min-w-[16px] items-center justify-center rounded-full border px-1 py-[2px] text-[8px] font-bold leading-none shadow-[0_4px_12px_rgba(0,0,0,0.24)] ${item.badge.className}`}
-                        >
-                          {item.badge.value}
-                        </span>
-                      ) : !isGuideExitSlot && item.badge?.type === "pill" ? (
-                        <span
-                          className={`absolute -right-2 -top-1.5 inline-flex items-center justify-center rounded-full border px-1.5 py-[2px] text-[8px] font-semibold leading-none ${pillGlow} ${item.badge.className}`}
-                        >
-                          {item.badge.value}
-                        </span>
-                      ) : !isGuideExitSlot && item.badge?.type === "dot" ? (
-                        <span
-                          className={`absolute right-0 top-0 h-1.5 w-1.5 rounded-full border shadow-[0_0_10px_rgba(56,189,248,0.45),0_4px_10px_rgba(0,0,0,0.22)] ${item.badge.className}`}
-                        />
-                      ) : null}
+                      <div
+                        className={`relative flex shrink-0 items-center justify-center rounded-full border transition duration-200 ${dashboardScale.headerIcon} ${
+                          isActive || isGuideTargetSlot
+                            ? activeIconClass
+                            : `${themeQuickActionIconShellClass} ${iconHoverGlow}`
+                        }`}
+                      >
+                        <Icon className={dashboardScale.headerIconSvg} />
+
+                        {!isGuideExitSlot && item.badge?.type === "count" ? (
+                          <span
+                            className={`absolute -right-1.5 -top-1.5 inline-flex min-w-[16px] items-center justify-center rounded-full border px-1 py-[2px] text-[8px] font-bold leading-none shadow-[0_4px_12px_rgba(0,0,0,0.24)] ${item.badge.className}`}
+                          >
+                            {item.badge.value}
+                          </span>
+                        ) : !isGuideExitSlot && item.badge?.type === "pill" ? (
+                          <span
+                            className={`absolute -right-2 -top-1.5 inline-flex items-center justify-center rounded-full border px-1.5 py-[2px] text-[8px] font-semibold leading-none ${pillGlow} ${item.badge.className}`}
+                          >
+                            {item.badge.value}
+                          </span>
+                        ) : !isGuideExitSlot && item.badge?.type === "dot" ? (
+                          <span
+                            className={`absolute right-0 top-0 h-1.5 w-1.5 rounded-full border shadow-[0_0_10px_rgba(56,189,248,0.45),0_4px_10px_rgba(0,0,0,0.22)] ${item.badge.className}`}
+                          />
+                        ) : null}
+                      </div>
+
+                      <span
+                        className={`relative max-w-full shrink-0 truncate leading-none transition ${dashboardScale.headerLabel} ${
+                          isActive || isGuideTargetSlot
+                            ? "font-black tracking-[-0.01em]"
+                            : `font-semibold ${themeSecondaryTextClass}`
+                        }`}
+                      >
+                        {itemLabel}
+                      </span>
                     </div>
 
-                    <span
-                      className={`relative max-w-full shrink-0 truncate leading-none transition ${dashboardScale.headerLabel} ${isActive ? "font-black tracking-[-0.01em]" : `font-semibold ${themeSecondaryTextClass}`}`}
-                    >
-                      {itemLabel}
-                    </span>
-                  </div>
-
-                  {index < headerQuickActions.length - 1 ? (
-                    <div className={`pointer-events-none absolute -right-1 top-1/2 hidden h-9 w-px -translate-y-1/2 bg-gradient-to-b from-transparent ${themeDividerClass} to-transparent sm:block`} />
-                  ) : null}
-                </button>
-              );
-            })}
+                    {index < headerQuickActions.length - 1 ? (
+                      <div className={`pointer-events-none absolute -right-1 top-1/2 hidden h-9 w-px -translate-y-1/2 bg-gradient-to-b from-transparent ${themeDividerClass} to-transparent sm:block`} />
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Adds the real **Me Page** as the next CLARA Guide chapter after the Money Left Orb walkthrough.

### Guide flow
- Orb Ready → Next keeps Guide Mode active on Home
- Only the Me tab is spotlighted and unlocked
- Tapping Me uses the existing dashboard panel transition
- The actual Me Page is shown in a static, non-mutating preview
- A viewport-aware `WHY ME MATTERS` bubble explains personalization
- Next advances to `ME PAGE READY` and emits `me-page` completion
- Exit clears all temporary Me Guide state and restores normal navigation/access behavior

### Safety and scope
- No membership, entitlement, purchase, billing, Schedule, Supabase, or AI-memory changes
- The committed-access lock is visually bypassed only while the Me Guide preview root class is active
- Real Me Page clicks, changes, and submissions are intercepted during preview while scrolling remains available
- Life-stage profile/image local-storage writes are blocked only during the Me Guide preview and restored on exit
- Existing configured and unconfigured Me Page states remain intact; no sample profile data is injected

### Files
- `DashboardTopNav.jsx`
- `DashboardMeLifePanel.jsx`
- `guide/ClaraGuideMePageOverlay.jsx`

### Validation
- JSX/JavaScript syntax validation completed with TypeScript `--allowJs --jsx preserve --noEmit`
- PR is mergeable with current `main` and changes only the three files above
- Vercel status is currently blocked by the project build-rate limit, so an automated deployment preview was not produced
