### PR TITLE
Fix CLARA Guide NEXT touch response

### DIFF
--- a/src/guide-mode-next-buttons.css
+++ b/src/guide-mode-next-buttons.css
@@ -149,6 +149,25 @@
   margin-top: 0 !important;
 }
 
+/* Touch screens need a more forgiving physical target and must not reinterpret a
+   light tap as a tiny scroll gesture before the progression action can run. */
+@media (pointer: coarse) {
+  #root#root button:is(
+    .clara-guide-next-button,
+    .clara-guide-carousel-next-button,
+    .clara-guide-orb-next,
+    .clara-guide-orb-feature-next,
+    [data-clara-guide-action='next'],
+    [data-clara-guide-orb-preview-next='true'],
+    [data-clara-guide-orb-ui-next='true']
+  ) {
+    min-width: 132px !important;
+    min-height: 50px !important;
+    padding: 13px 24px !important;
+    touch-action: none !important;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   #root#root button:is(
     .clara-guide-next-button,

--- a/src/runtime/installClaraGuideCarouselStep.js
+++ b/src/runtime/installClaraGuideCarouselStep.js
@@ -6,6 +6,7 @@ const MONEY_LEFT_CLASS = "clara-guide-money-left-active";
 const MONEY_LEFT_PRIVACY_CLASS = "clara-guide-money-left-privacy-active";
 const MONEY_LEFT_ORB_CLASS = "clara-guide-money-left-orb-active";
 const NEXT_CLASS = "clara-guide-next-button";
+const CAROUSEL_NEXT_SELECTOR = ".clara-guide-carousel-next-button";
 const TARGET_CHANGE_EVENT = "clara:guide-target-change";
 const GUIDE_MODE_CHANGE_EVENT = "clara:guide-mode-change";
 const GUIDE_EXIT_EVENT = "clara:guide-exit";
@@ -28,6 +29,19 @@ function isAwaitSingleOrb(target) {
   const orb = target?.closest?.(GUIDE_ORB_SELECTOR);
   const summary = orb?.closest?.(GUIDE_SUMMARY_SELECTOR);
   return summary?.dataset?.claraGuideOrbPhase === "await-single";
+}
+
+function captureGuideNextPointer(event) {
+  if (event.pointerType === "mouse") return;
+
+  const button = event.target?.closest?.(CAROUSEL_NEXT_SELECTOR);
+  if (!button || button.disabled) return;
+
+  try {
+    button.setPointerCapture?.(event.pointerId);
+  } catch {
+    // Pointer capture is optional. The coarse-pointer CSS remains the fallback.
+  }
 }
 
 function ensureNextButton() {
@@ -106,6 +120,8 @@ export function installClaraGuideCarouselStep() {
   if (typeof window === "undefined" || typeof document === "undefined") return;
   if (window.__CLARA_GUIDE_CAROUSEL_STEP_INSTALLED__) return;
   window.__CLARA_GUIDE_CAROUSEL_STEP_INSTALLED__ = true;
+
+  document.addEventListener("pointerdown", captureGuideNextPointer, true);
 
   document.addEventListener(
     "pointerup",


### PR DESCRIPTION
## Summary

Fixes the Guide Mode `NEXT` control feeling like it needs two taps or a hard press on touch devices.

### Changes
- Captures the touch pointer on the carousel Guide `NEXT` button so a small finger movement does not cancel the release/click sequence.
- Keeps mouse behavior unchanged.
- Enlarges Guide progression controls on coarse-pointer devices to a 132px × 50px minimum target.
- Uses `touch-action: none` only on the progression button itself so a light tap is not reinterpreted as a tiny scroll gesture.

### Scope
- `src/runtime/installClaraGuideCarouselStep.js`
- `src/guide-mode-next-buttons.css`
- No finance data, carousel progression, Guide copy, routing, persistence, billing, Supabase, or Me Page logic changed.

### Validation
- Branch is based on the current `main` and is not behind.
- JavaScript syntax was validated with `node --check`.
- Diff is limited to the two expected Guide input files.

This PR is intentionally left unmerged for review.