### PR TITLE
Repair CLARA Guide touch regression

### DIFF
--- a/src/guide-mode-next-buttons.css
+++ b/src/guide-mode-next-buttons.css
@@ -149,22 +149,15 @@
   margin-top: 0 !important;
 }
 
-/* Touch screens need a more forgiving physical target and must not reinterpret a
-   light tap as a tiny scroll gesture before the progression action can run. */
+/* Only the finance-card terminal NEXT receives the larger mobile target. Keeping
+   orb-preview controls at their original size prevents the first orb tap from
+   landing on a newly mounted preview action. */
 @media (pointer: coarse) {
-  #root#root button:is(
-    .clara-guide-next-button,
-    .clara-guide-carousel-next-button,
-    .clara-guide-orb-next,
-    .clara-guide-orb-feature-next,
-    [data-clara-guide-action='next'],
-    [data-clara-guide-orb-preview-next='true'],
-    [data-clara-guide-orb-ui-next='true']
-  ) {
+  #root#root .clara-guide-carousel-next-button {
     min-width: 132px !important;
     min-height: 50px !important;
     padding: 13px 24px !important;
-    touch-action: none !important;
+    touch-action: manipulation !important;
   }
 }
 

--- a/src/runtime/installClaraGuideCarouselStep.js
+++ b/src/runtime/installClaraGuideCarouselStep.js
@@ -7,13 +7,16 @@ const MONEY_LEFT_PRIVACY_CLASS = "clara-guide-money-left-privacy-active";
 const MONEY_LEFT_ORB_CLASS = "clara-guide-money-left-orb-active";
 const NEXT_CLASS = "clara-guide-next-button";
 const CAROUSEL_NEXT_SELECTOR = ".clara-guide-carousel-next-button";
+const ORB_PREVIEW_NEXT_SELECTOR = "[data-clara-guide-orb-preview-next='true']";
 const TARGET_CHANGE_EVENT = "clara:guide-target-change";
 const GUIDE_MODE_CHANGE_EVENT = "clara:guide-mode-change";
 const GUIDE_EXIT_EVENT = "clara:guide-exit";
 const GUIDE_ORB_SELECTOR = "[data-clara-manual-expense-orb='true']";
 const GUIDE_SUMMARY_SELECTOR = "[data-clara-dashboard-section='money-summary']";
+const GUIDE_TOUCH_MOVE_LIMIT = 20;
 
 let protectSingleTapUntil = 0;
+let financeNextPointer = null;
 
 function hasGuideSample() {
   return document.documentElement.classList.contains(SAMPLE_CLASS);
@@ -31,16 +34,52 @@ function isAwaitSingleOrb(target) {
   return summary?.dataset?.claraGuideOrbPhase === "await-single";
 }
 
-function captureGuideNextPointer(event) {
-  if (event.pointerType === "mouse") return;
+function rememberFinanceNextPointer(event) {
+  if (event.pointerType === "mouse" || !hasCarouselStep()) return;
 
   const button = event.target?.closest?.(CAROUSEL_NEXT_SELECTOR);
   if (!button || button.disabled) return;
 
-  try {
-    button.setPointerCapture?.(event.pointerId);
-  } catch {
-    // Pointer capture is optional. The coarse-pointer CSS remains the fallback.
+  financeNextPointer = {
+    pointerId: event.pointerId,
+    startX: event.clientX,
+    startY: event.clientY,
+  };
+}
+
+function finishFinanceNextPointer(event, cancelled = false) {
+  const pointer = financeNextPointer;
+  if (!pointer || pointer.pointerId !== event.pointerId) return;
+
+  financeNextPointer = null;
+  if (cancelled || !hasCarouselStep()) return;
+
+  const distance = Math.hypot(
+    event.clientX - pointer.startX,
+    event.clientY - pointer.startY,
+  );
+  if (distance > GUIDE_TOUCH_MOVE_LIMIT) return;
+
+  event.preventDefault();
+  event.stopImmediatePropagation();
+
+  const dashboardScroller = getDashboardGuideScroller();
+  const lockedScrollTop = Number(dashboardScroller?.scrollTop) || 0;
+
+  window.dispatchEvent(
+    new CustomEvent(TARGET_CHANGE_EVENT, {
+      detail: { feature: "money-left" },
+    }),
+  );
+
+  if (dashboardScroller && typeof window !== "undefined") {
+    const restore = () => {
+      dashboardScroller.scrollTop = lockedScrollTop;
+    };
+    window.requestAnimationFrame(() => {
+      restore();
+      window.requestAnimationFrame(restore);
+    });
   }
 }
 
@@ -70,6 +109,7 @@ export function clearClaraGuideFeatureClasses() {
     MONEY_LEFT_ORB_CLASS,
   );
   protectSingleTapUntil = 0;
+  financeNextPointer = null;
 }
 
 function getDashboardGuideScroller() {
@@ -110,9 +150,8 @@ function goToCarouselStep() {
 
   removeNextButton();
   protectSingleTapUntil = 0;
+  financeNextPointer = null;
 
-  // Keep the complete top navigation visible when the finance walkthrough starts.
-  // This existing transition intentionally returns the guide to the dashboard top.
   window.setTimeout(() => scrollDashboardGuideToTop("smooth"), 80);
 }
 
@@ -121,13 +160,36 @@ export function installClaraGuideCarouselStep() {
   if (window.__CLARA_GUIDE_CAROUSEL_STEP_INSTALLED__) return;
   window.__CLARA_GUIDE_CAROUSEL_STEP_INSTALLED__ = true;
 
-  document.addEventListener("pointerdown", captureGuideNextPointer, true);
+  document.addEventListener("pointerdown", rememberFinanceNextPointer, true);
+  document.addEventListener(
+    "pointerup",
+    (event) => finishFinanceNextPointer(event, false),
+    true,
+  );
+  document.addEventListener(
+    "pointercancel",
+    (event) => finishFinanceNextPointer(event, true),
+    true,
+  );
 
   document.addEventListener(
     "pointerup",
     (event) => {
       if (isAwaitSingleOrb(event.target)) {
         protectSingleTapUntil = Date.now() + 400;
+      }
+    },
+    true,
+  );
+
+  document.addEventListener(
+    "click",
+    (event) => {
+      const isProtectedPreviewAction = event.target?.closest?.(ORB_PREVIEW_NEXT_SELECTOR);
+      if (Date.now() <= protectSingleTapUntil && isProtectedPreviewAction) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        protectSingleTapUntil = 0;
       }
     },
     true,
@@ -170,6 +232,7 @@ export function installClaraGuideCarouselStep() {
 
   window.addEventListener(TARGET_CHANGE_EVENT, (event) => {
     protectSingleTapUntil = 0;
+    financeNextPointer = null;
 
     if (event?.detail?.feature !== "money-left-orb") {
       document.documentElement.classList.remove(MONEY_LEFT_ORB_CLASS);


### PR DESCRIPTION
## What went wrong

The previous mobile sizing rule was applied to every Guide progression control, including the newly mounted Orb preview `Next` button. On touch devices, the first Orb release could therefore land on that enlarged preview action and immediately advance to the double-tap lesson.

The previous pointer-capture addition also did not address the original Debt-card `Next` delay because the action still depended on the browser producing a later synthetic click.

## Repair

- Restore Orb preview buttons to their original size and touch behavior.
- Keep the larger coarse-pointer target scoped only to the finance-card terminal `Next` button.
- Handle the Debt-card `Next` directly on a valid touch release while preserving dashboard scroll position.
- Add a short guard so the first Orb tap cannot activate the newly mounted preview `Next` action from the same touch sequence.
- Preserve mouse and keyboard behavior.

## Scope

Only these files change:
- `src/guide-mode-next-buttons.css`
- `src/runtime/installClaraGuideCarouselStep.js`

No finance data, calculations, carousel training, persistence, routing, billing, Supabase, or Me Page logic changed.

## Validation

- Branch is based on the current `main` and is not behind.
- Runtime JavaScript passes `node --check`.
- Diff is limited to the two Guide input files.