### PR TITLE
Move Me Guide bubble to top open area

### DIFF
--- a/src/components/fresh/main-dashboard/guide/ClaraGuideMePageOverlay.jsx
+++ b/src/components/fresh/main-dashboard/guide/ClaraGuideMePageOverlay.jsx
@@ -43,14 +43,14 @@ function getSafeTop(previewRect) {
     "[data-clara-guide-me-target='true'], [data-clara-guide-exit='true']"
   );
   const navBottom = guideNav?.getBoundingClientRect?.().bottom || 0;
-  return Math.max(previewRect.top + 12, navBottom + 12, 12);
+  return Math.max(previewRect.top + 10, navBottom + 10, 10);
 }
 
 export default function ClaraGuideMePageOverlay({ phase = "me-page-preview" }) {
   const bubbleRef = useRef(null);
   const completionDispatchRef = useRef(false);
   const [top, setTop] = useState(null);
-  const [arrowPlacement, setArrowPlacement] = useState("top");
+  const [arrowPlacement, setArrowPlacement] = useState("bottom");
   const copy = COPY[phase] || COPY["me-page-preview"];
 
   const updatePosition = useCallback(() => {
@@ -61,8 +61,8 @@ export default function ClaraGuideMePageOverlay({ phase = "me-page-preview" }) {
     const previewRect = preview.getBoundingClientRect();
     const bubbleRect = bubble.getBoundingClientRect();
     const setupCard = findSetupCard(preview);
-    const padding = 12;
-    const gap = 10;
+    const padding = 10;
+    const gap = 8;
     const safeTop = getSafeTop(previewRect);
     const safeBottom = Math.min(previewRect.bottom, window.innerHeight - padding);
     const maxTop = Math.max(safeTop, safeBottom - bubbleRect.height);
@@ -74,10 +74,28 @@ export default function ClaraGuideMePageOverlay({ phase = "me-page-preview" }) {
     }
 
     const cardRect = setupCard.getBoundingClientRect();
-    const belowCard = cardRect.bottom + gap;
     const aboveCard = cardRect.top - bubbleRect.height - gap;
-    const fitsBelow = belowCard + bubbleRect.height <= safeBottom;
+    const belowCard = cardRect.bottom + gap;
     const fitsAbove = aboveCard >= safeTop;
+    const fitsBelow = belowCard + bubbleRect.height <= safeBottom;
+
+    // The unconfigured Me Page intentionally leaves a calm open zone above the
+    // Life Stage card. Keep the Guide bubble in that zone first so the actual
+    // profile UI remains fully readable.
+    if (fitsAbove) {
+      setArrowPlacement("bottom");
+      setTop(aboveCard);
+      return;
+    }
+
+    // Keep the user-requested top placement even on shorter screens. The bubble
+    // is deliberately compact enough to fit this slot on the supported phone
+    // viewport; this clamp prevents it from touching the top navigation.
+    if (safeTop < cardRect.top) {
+      setArrowPlacement("bottom");
+      setTop(Math.max(safeTop, Math.min(maxTop, safeTop)));
+      return;
+    }
 
     if (fitsBelow) {
       setArrowPlacement("top");
@@ -85,17 +103,8 @@ export default function ClaraGuideMePageOverlay({ phase = "me-page-preview" }) {
       return;
     }
 
-    if (fitsAbove) {
-      setArrowPlacement("bottom");
-      setTop(aboveCard);
-      return;
-    }
-
-    const distanceBelow = Math.abs(safeBottom - cardRect.bottom);
-    const distanceAbove = Math.abs(cardRect.top - safeTop);
-    const fallbackTop = distanceBelow >= distanceAbove ? maxTop : safeTop;
-    setArrowPlacement(fallbackTop === maxTop ? "top" : "bottom");
-    setTop(Math.max(safeTop, Math.min(maxTop, fallbackTop)));
+    setArrowPlacement("top");
+    setTop(maxTop);
   }, []);
 
   useLayoutEffect(() => {
@@ -156,40 +165,40 @@ export default function ClaraGuideMePageOverlay({ phase = "me-page-preview" }) {
   return createPortal(
     <div
       data-clara-guide-me-bubble="true"
-      className="pointer-events-none fixed left-1/2 z-[95] w-[min(calc(100vw-20px),406px)] -translate-x-1/2 px-2.5"
-      style={{ top: top === null ? "calc(100svh - 176px)" : `${top}px` }}
+      className="pointer-events-none fixed left-1/2 z-[95] w-[min(calc(100vw-16px),414px)] -translate-x-1/2 px-2"
+      style={{ top: top === null ? "clamp(108px, 13dvh, 124px)" : `${top}px` }}
     >
       <div
         ref={bubbleRef}
         role="dialog"
         aria-live="polite"
         aria-labelledby="clara-guide-me-page-title"
-        className="pointer-events-auto relative mx-auto w-full max-w-[360px] rounded-[24px] border border-cyan-100/24 bg-[linear-gradient(145deg,rgba(5,18,36,0.985),rgba(10,22,54,0.985)_52%,rgba(27,18,65,0.985))] px-4 py-3.5 text-white shadow-[0_24px_76px_rgba(0,0,0,0.74),0_0_48px_rgba(34,211,238,0.18)] backdrop-blur-2xl"
+        className="pointer-events-auto relative mx-auto w-full max-w-[372px] rounded-[22px] border border-cyan-100/24 bg-[linear-gradient(145deg,rgba(5,18,36,0.985),rgba(10,22,54,0.985)_52%,rgba(27,18,65,0.985))] px-3.5 py-3 text-white shadow-[0_20px_60px_rgba(0,0,0,0.68),0_0_38px_rgba(34,211,238,0.16)] backdrop-blur-2xl"
       >
         <div
-          className={`pointer-events-none absolute left-12 h-4 w-4 rotate-45 border-cyan-100/24 bg-[rgba(12,21,49,0.985)] ${
+          className={`pointer-events-none absolute left-12 h-3.5 w-3.5 rotate-45 border-cyan-100/24 bg-[rgba(12,21,49,0.985)] ${
             arrowPlacement === "top"
-              ? "-top-2 border-l border-t"
-              : "-bottom-2 border-b border-r"
+              ? "-top-[7px] border-l border-t"
+              : "-bottom-[7px] border-b border-r"
           }`}
         />
         <p
           id="clara-guide-me-page-title"
-          className="text-[9px] font-black uppercase tracking-[0.22em] text-cyan-100"
+          className="text-[8px] font-black uppercase tracking-[0.2em] text-cyan-100"
         >
           {copy.title}
         </p>
-        <p className="mt-1.5 text-[11px] font-bold leading-[1.4] text-white">{copy.body}</p>
-        <p className="mt-1 text-[10px] font-semibold leading-[1.4] text-white/66">{copy.supporting}</p>
-        <div className="mt-2.5 h-px bg-cyan-100/15" />
-        <div className="mt-2.5 flex items-center justify-between gap-3">
-          <p className="max-w-[215px] text-[8px] font-black uppercase leading-[1.35] tracking-[0.07em] text-cyan-100/86">
+        <p className="mt-1 text-[10px] font-bold leading-[1.3] text-white">{copy.body}</p>
+        <p className="mt-0.5 text-[9px] font-semibold leading-[1.3] text-white/66">{copy.supporting}</p>
+        <div className="mt-2 h-px bg-cyan-100/15" />
+        <div className="mt-2 flex items-center justify-between gap-3">
+          <p className="max-w-[220px] text-[7px] font-black uppercase leading-[1.25] tracking-[0.06em] text-cyan-100/86">
             {copy.footer}
           </p>
           <button
             type="button"
             onClick={handleNext}
-            className="min-h-[42px] shrink-0 touch-manipulation rounded-full border border-cyan-100/30 bg-cyan-100/15 px-5 py-2.5 text-[10px] font-black uppercase tracking-[0.18em] text-cyan-50 shadow-[0_12px_34px_rgba(34,211,238,0.16),inset_0_1px_0_rgba(255,255,255,0.12)] transition hover:bg-cyan-100/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100/80 active:scale-[0.99]"
+            className="min-h-[38px] shrink-0 touch-manipulation rounded-full border border-cyan-100/30 bg-cyan-100/15 px-4 py-2 text-[9px] font-black uppercase tracking-[0.16em] text-cyan-50 shadow-[0_10px_28px_rgba(34,211,238,0.14),inset_0_1px_0_rgba(255,255,255,0.12)] transition hover:bg-cyan-100/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100/80 active:scale-[0.99]"
           >
             NEXT
           </button>


### PR DESCRIPTION
Places the Me Page Guide bubble in the open space above the Life Stage card, directly below the top navigation. The top slot is now preferred, the bubble is compacted to fit without covering the card, and the arrow points down toward the Life Stage UI. Only ClaraGuideMePageOverlay.jsx changes.