### PR TITLE
Add breathing room to Me Guide bubble

### DIFF
--- a/src/guide-mode-me-bubble-spacing.css
+++ b/src/guide-mode-me-bubble-spacing.css
@@ -1,0 +1,51 @@
+/* Me Page Guide bubble spacing refinement. */
+#root#root [data-clara-guide-me-bubble='true'] {
+  width: min(calc(100vw - 12px), 418px) !important;
+  padding-inline: 6px !important;
+}
+
+#root#root [data-clara-guide-me-bubble='true'] > [role='dialog'] {
+  max-width: 382px !important;
+  padding: 14px 16px !important;
+  border-radius: 24px !important;
+}
+
+#root#root #clara-guide-me-page-title {
+  font-size: 9px !important;
+  line-height: 1.25 !important;
+}
+
+#root#root #clara-guide-me-page-title + p {
+  margin-top: 8px !important;
+  font-size: 11px !important;
+  line-height: 1.5 !important;
+}
+
+#root#root #clara-guide-me-page-title + p + p {
+  margin-top: 6px !important;
+  font-size: 10px !important;
+  line-height: 1.5 !important;
+  color: rgba(255, 255, 255, 0.68) !important;
+}
+
+#root#root #clara-guide-me-page-title + p + p + div {
+  margin-top: 12px !important;
+}
+
+#root#root #clara-guide-me-page-title + p + p + div + div {
+  margin-top: 12px !important;
+  gap: 16px !important;
+  align-items: center !important;
+}
+
+#root#root #clara-guide-me-page-title + p + p + div + div > p {
+  max-width: 228px !important;
+  font-size: 8px !important;
+  line-height: 1.45 !important;
+  letter-spacing: 0.065em !important;
+}
+
+#root#root #clara-guide-me-page-title + p + p + div + div > button {
+  min-height: 42px !important;
+  padding: 10px 20px !important;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -19,6 +19,7 @@ import "./guide-mode-stacking.css";
 import "./guide-mode-finance-spotlight.css";
 import "./guide-mode-money-left-spotlight.css";
 import "./guide-mode-money-left-orb.css";
+import "./guide-mode-me-bubble-spacing.css";
 import "./welcome-session-calendar-status.css";
 
 window.CLARA_BILLING = window.CLARA_BILLING || {};


### PR DESCRIPTION
Refines the Me Page Guide bubble typography and spacing without changing its top placement or Guide behavior.

Changes:
- Slightly wider bubble to reduce awkward wrapping
- Larger title, body, support, and footer text
- Increased line-height and vertical spacing between text blocks
- More separation around the divider and footer row
- Restored a 42px NEXT button height

Scope is limited to one new scoped CSS file plus its import in main.jsx.