### PR TITLE
Remove redundant Me Guide support line

### DIFF
--- a/src/components/fresh/main-dashboard/guide/ClaraGuideMePageOverlay.jsx
+++ b/src/components/fresh/main-dashboard/guide/ClaraGuideMePageOverlay.jsx
@@ -9,7 +9,7 @@ const COPY = {
   "me-page-preview": {
     title: "WHY ME MATTERS",
     body: "The same amount of money can mean something different depending on your responsibilities and current life stage.",
-    supporting: "This profile helps CLARA personalize her guidance.",
+    supporting: "",
     footer: "CLARA LEARNS THE PERSON BEHIND THE NUMBERS.",
   },
   complete: {


### PR DESCRIPTION
Removes the “This profile helps CLARA personalize her guidance.” sentence from the WHY ME MATTERS bubble so the main message has more breathing room. The completion-step safety sentence remains unchanged. Only one copy line changes.