### PR TITLE
Insert Learning Hub before finance Guide

### DIFF
--- a/src/components/fresh/main-dashboard/guide/ClaraGuideLearningHubOverlay.jsx
+++ b/src/components/fresh/main-dashboard/guide/ClaraGuideLearningHubOverlay.jsx
@@ -1,0 +1,154 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+const COPY = {
+  "await-open": {
+    title: "LEARNING HUB",
+    body: "This is where CLARA turns money lessons into practical learning, games, and guided activities.",
+    supporting: "",
+    footer: "TAP LEARNING HUB NOW.",
+  },
+  preview: {
+    title: "LEARN • PLAY • APPLY",
+    body: "Explore lessons, money games, videos, and practical tools designed to strengthen your financial habits.",
+    supporting: "Swipe through the Learning Hub to see what is available.",
+    footer: "LEARNING BECOMES POWERFUL WHEN YOU APPLY IT.",
+  },
+};
+
+const TARGET_SELECTORS = {
+  "await-open": "[data-clara-guide-learning-hub-toggle='true']",
+  preview: "[data-clara-guide-learning-hub-preview='true']",
+};
+
+function getSafeTop() {
+  const navTarget = document.querySelector(
+    "[data-clara-guide-exit='true'], [data-clara-guide-me-target='true']",
+  );
+  const navBottom = navTarget?.getBoundingClientRect?.().bottom || 0;
+  return Math.max(12, navBottom + 12);
+}
+
+export default function ClaraGuideLearningHubOverlay({ phase = "await-open", onNext }) {
+  const bubbleRef = useRef(null);
+  const [top, setTop] = useState(null);
+  const [arrowPlacement, setArrowPlacement] = useState("top");
+  const copy = COPY[phase] || COPY["await-open"];
+  const hasNext = phase === "preview" && typeof onNext === "function";
+
+  const updatePosition = useCallback(() => {
+    const bubble = bubbleRef.current;
+    const target = document.querySelector(TARGET_SELECTORS[phase] || TARGET_SELECTORS["await-open"]);
+    if (!bubble || !target) return;
+
+    const targetRect = target.getBoundingClientRect();
+    const bubbleRect = bubble.getBoundingClientRect();
+    const gap = 12;
+    const safeTop = getSafeTop();
+    const safeBottom = window.innerHeight - 12;
+    const belowTarget = targetRect.bottom + gap;
+    const aboveTarget = targetRect.top - bubbleRect.height - gap;
+    const maxTop = Math.max(safeTop, safeBottom - bubbleRect.height);
+
+    if (belowTarget + bubbleRect.height <= safeBottom) {
+      setArrowPlacement("top");
+      setTop(belowTarget);
+      return;
+    }
+
+    if (aboveTarget >= safeTop) {
+      setArrowPlacement("bottom");
+      setTop(aboveTarget);
+      return;
+    }
+
+    const targetCenter = targetRect.top + targetRect.height / 2;
+    const viewportCenter = window.innerHeight / 2;
+    const fallbackTop = targetCenter <= viewportCenter ? maxTop : safeTop;
+    setArrowPlacement(fallbackTop === maxTop ? "top" : "bottom");
+    setTop(Math.max(safeTop, Math.min(maxTop, fallbackTop)));
+  }, [phase]);
+
+  useLayoutEffect(() => {
+    updatePosition();
+    const frame = window.requestAnimationFrame(updatePosition);
+    return () => window.cancelAnimationFrame(frame);
+  }, [updatePosition]);
+
+  useEffect(() => {
+    const handleChange = () => updatePosition();
+    window.addEventListener("resize", handleChange);
+    window.addEventListener("orientationchange", handleChange);
+    window.addEventListener("scroll", handleChange, true);
+
+    const target = document.querySelector(TARGET_SELECTORS[phase] || TARGET_SELECTORS["await-open"]);
+    const observer =
+      typeof ResizeObserver !== "undefined" && target
+        ? new ResizeObserver(handleChange)
+        : null;
+    if (target) observer?.observe(target);
+    if (bubbleRef.current) observer?.observe(bubbleRef.current);
+
+    return () => {
+      window.removeEventListener("resize", handleChange);
+      window.removeEventListener("orientationchange", handleChange);
+      window.removeEventListener("scroll", handleChange, true);
+      observer?.disconnect();
+    };
+  }, [phase, updatePosition]);
+
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      data-clara-guide-learning-hub-bubble="true"
+      className="pointer-events-none fixed left-1/2 z-[165] w-[min(calc(100vw-24px),390px)] -translate-x-1/2 px-2"
+      style={{ top: top === null ? "clamp(116px, 14dvh, 144px)" : `${top}px` }}
+    >
+      <div
+        ref={bubbleRef}
+        role="dialog"
+        aria-live="polite"
+        aria-labelledby="clara-guide-learning-hub-title"
+        className="pointer-events-auto relative mx-auto w-full max-w-[360px] rounded-[26px] border border-cyan-100/24 bg-[linear-gradient(145deg,rgba(5,18,36,0.985),rgba(10,22,54,0.985)_52%,rgba(27,18,65,0.985))] px-5 py-4 text-white shadow-[0_24px_76px_rgba(0,0,0,0.72),0_0_44px_rgba(34,211,238,0.18)] backdrop-blur-2xl"
+      >
+        <div
+          className={`pointer-events-none absolute left-12 h-4 w-4 rotate-45 border-cyan-100/24 bg-[rgba(12,21,49,0.985)] ${
+            arrowPlacement === "top"
+              ? "-top-2 border-l border-t"
+              : "-bottom-2 border-b border-r"
+          }`}
+        />
+
+        <p
+          id="clara-guide-learning-hub-title"
+          className="text-[9px] font-black uppercase tracking-[0.22em] text-cyan-100"
+        >
+          {copy.title}
+        </p>
+        <p className="mt-2 text-[12px] font-bold leading-[1.5] text-white">{copy.body}</p>
+        {copy.supporting ? (
+          <p className="mt-1.5 text-[11px] font-semibold leading-[1.5] text-white/68">
+            {copy.supporting}
+          </p>
+        ) : null}
+        <div className="mt-3 h-px bg-cyan-100/15" />
+        <div className="mt-3 flex items-center justify-between gap-4">
+          <p className="max-w-[230px] text-[8px] font-black uppercase leading-[1.45] tracking-[0.07em] text-cyan-100/88">
+            {copy.footer}
+          </p>
+          {hasNext ? (
+            <button
+              type="button"
+              onClick={onNext}
+              className="clara-guide-learning-hub-next min-h-[42px] shrink-0 touch-manipulation rounded-full border border-cyan-100/30 bg-cyan-100/15 px-5 py-2.5 text-[10px] font-black uppercase tracking-[0.18em] text-cyan-50 shadow-[0_12px_34px_rgba(34,211,238,0.16),inset_0_1px_0_rgba(255,255,255,0.12)] transition hover:bg-cyan-100/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100/80 active:scale-[0.99]"
+            >
+              NEXT
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/fresh/main-dashboard/guide/ClaraGuideLearningHubPreview.jsx
+++ b/src/components/fresh/main-dashboard/guide/ClaraGuideLearningHubPreview.jsx
@@ -1,0 +1,16 @@
+import useLearningHub from "../learning-hub/logic/useLearningHub";
+import LearningHubCarousel from "../learning-hub/ui/LearningHubCarousel";
+
+export default function ClaraGuideLearningHubPreview({ flushSpacing = true }) {
+  const { carouselItems } = useLearningHub();
+
+  return (
+    <LearningHubCarousel
+      items={carouselItems}
+      hasCommittedAccess
+      initialExpanded
+      flushSpacing={flushSpacing}
+      guidePreviewMode
+    />
+  );
+}

--- a/src/components/fresh/main-dashboard/guide/ClaraGuideLearningHubPreview.jsx
+++ b/src/components/fresh/main-dashboard/guide/ClaraGuideLearningHubPreview.jsx
@@ -4,13 +4,28 @@ import LearningHubCarousel from "../learning-hub/ui/LearningHubCarousel";
 export default function ClaraGuideLearningHubPreview({ flushSpacing = true }) {
   const { carouselItems } = useLearningHub();
 
+  const blockPreviewActivation = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
   return (
-    <LearningHubCarousel
-      items={carouselItems}
-      hasCommittedAccess
-      initialExpanded
-      flushSpacing={flushSpacing}
-      guidePreviewMode
-    />
+    <div
+      data-clara-guide-learning-hub-preview="true"
+      aria-label="Learning Hub Guide preview"
+      onClickCapture={blockPreviewActivation}
+      onKeyDownCapture={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          blockPreviewActivation(event);
+        }
+      }}
+    >
+      <LearningHubCarousel
+        items={carouselItems}
+        hasCommittedAccess
+        initialExpanded
+        flushSpacing={flushSpacing}
+      />
+    </div>
   );
 }

--- a/src/components/fresh/main-dashboard/learning-hub/LearningHub.jsx
+++ b/src/components/fresh/main-dashboard/learning-hub/LearningHub.jsx
@@ -1,7 +1,8 @@
-import { Suspense, lazy, useState } from "react";
+import { Suspense, lazy, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { CalendarClock, ScrollText } from "lucide-react";
 import DailyTipCard from "../daily-tip";
+import ClaraGuideLearningHubOverlay from "../guide/ClaraGuideLearningHubOverlay";
 import {
   openCommittedVersionModal,
   useCommittedFeatureAccess,
@@ -9,6 +10,11 @@ import {
 import LearningHubToggleButton from "./ui/LearningHubToggleButton";
 
 const LearningHubLoaded = lazy(() => import("./LearningHubLoaded"));
+
+const LEARNING_HUB_PHASE_EVENT = "clara:guide-learning-hub-phase";
+const GUIDE_MODE_CHANGE_EVENT = "clara:guide-mode-change";
+const GUIDE_EXIT_EVENT = "clara:guide-exit";
+const GUIDE_TARGET_CHANGE_EVENT = "clara:guide-target-change";
 
 function ClaraGuideButton({ hasNewGuide = false, onClick }) {
   return (
@@ -64,6 +70,15 @@ function DailyTipGuideBubble() {
   );
 }
 
+function emitLearningHubPhase(phase) {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent(LEARNING_HUB_PHASE_EVENT, {
+      detail: { phase },
+    }),
+  );
+}
+
 export default function LearningHub({
   isGuideMode = false,
   guideFeature = "",
@@ -75,13 +90,80 @@ export default function LearningHub({
 }) {
   const navigate = useNavigate();
   const [shouldLoadHub, setShouldLoadHub] = useState(false);
+  const [learningHubGuidePhase, setLearningHubGuidePhase] = useState("inactive");
   const realHasCommittedAccess = useCommittedFeatureAccess();
   const hasCommittedAccess = isGuideMode ? true : realHasCommittedAccess;
   const isLocked = !hasCommittedAccess;
   const isCarouselGuideActive = isGuideMode && guideFeature === "finance-carousel";
+  const isLearningHubGuideActive =
+    isGuideMode &&
+    (learningHubGuidePhase === "await-open" || learningHubGuidePhase === "preview");
+  const isLearningHubGuideAwaitOpen =
+    isLearningHubGuideActive && learningHubGuidePhase === "await-open";
+  const isLearningHubGuidePreview =
+    isLearningHubGuideActive && learningHubGuidePhase === "preview";
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+
+    const resetGuidePreview = () => {
+      setLearningHubGuidePhase("inactive");
+      setShouldLoadHub(false);
+    };
+
+    const handleLearningHubPhase = (event) => {
+      const phase = event?.detail?.phase;
+      if (phase === "await-open") {
+        setShouldLoadHub(false);
+        setLearningHubGuidePhase("await-open");
+        return;
+      }
+
+      if (phase === "preview") {
+        setShouldLoadHub(true);
+        setLearningHubGuidePhase("preview");
+        return;
+      }
+
+      resetGuidePreview();
+    };
+
+    const handleGuideModeChange = (event) => {
+      if (event?.detail?.active) {
+        resetGuidePreview();
+      } else {
+        resetGuidePreview();
+      }
+    };
+
+    const handleTargetChange = (event) => {
+      if (event?.detail?.feature !== "learning-hub") {
+        resetGuidePreview();
+      }
+    };
+
+    window.addEventListener(LEARNING_HUB_PHASE_EVENT, handleLearningHubPhase);
+    window.addEventListener(GUIDE_MODE_CHANGE_EVENT, handleGuideModeChange);
+    window.addEventListener(GUIDE_EXIT_EVENT, resetGuidePreview);
+    window.addEventListener(GUIDE_TARGET_CHANGE_EVENT, handleTargetChange);
+
+    return () => {
+      window.removeEventListener(LEARNING_HUB_PHASE_EVENT, handleLearningHubPhase);
+      window.removeEventListener(GUIDE_MODE_CHANGE_EVENT, handleGuideModeChange);
+      window.removeEventListener(GUIDE_EXIT_EVENT, resetGuidePreview);
+      window.removeEventListener(GUIDE_TARGET_CHANGE_EVENT, handleTargetChange);
+    };
+  }, []);
 
   const handleOpenHub = () => {
-    if (isGuideMode) return;
+    if (isGuideMode) {
+      if (isLearningHubGuideAwaitOpen) {
+        setShouldLoadHub(true);
+        setLearningHubGuidePhase("preview");
+        emitLearningHubPhase("preview");
+      }
+      return;
+    }
 
     if (isLocked) {
       openCommittedVersionModal();
@@ -91,8 +173,32 @@ export default function LearningHub({
     setShouldLoadHub(true);
   };
 
+  const handleGuideLearningHubNext = () => {
+    if (!isLearningHubGuidePreview || typeof window === "undefined") return;
+
+    setShouldLoadHub(false);
+    setLearningHubGuidePhase("inactive");
+    emitLearningHubPhase("inactive");
+
+    window.dispatchEvent(
+      new CustomEvent(GUIDE_TARGET_CHANGE_EVENT, {
+        detail: { feature: "finance-carousel" },
+      }),
+    );
+
+    window.setTimeout(() => {
+      document.querySelector(".clara-guide-carousel-anchor")?.scrollIntoView?.({
+        block: "center",
+        behavior: "smooth",
+      });
+    }, 80);
+  };
+
   return (
-    <section className="clara-budget-focus-shift clara-budget-focus-hub w-full">
+    <section
+      data-clara-guide-learning-hub-section="true"
+      className="clara-budget-focus-shift clara-budget-focus-hub w-full"
+    >
       <div className="relative flex w-full flex-col gap-[var(--clara-hub-rail-gap,14px)] overflow-visible px-1 py-0">
         <div
           className={`${isDailyTipGuideActive ? "relative z-[150] isolate" : "relative"} ${
@@ -136,6 +242,7 @@ export default function LearningHub({
               headerLabel="Learning Hub"
               onClick={handleOpenHub}
               flushSpacing
+              guideTarget={isLearningHubGuideAwaitOpen}
             />
 
             {!isGuideMode ? (
@@ -148,9 +255,20 @@ export default function LearningHub({
           </div>
         ) : (
           <Suspense fallback={null}>
-            <LearningHubLoaded initialExpanded flushSpacing={true} />
+            <LearningHubLoaded
+              initialExpanded
+              flushSpacing={true}
+              guidePreviewMode={isLearningHubGuidePreview}
+            />
           </Suspense>
         )}
+
+        {isLearningHubGuideActive ? (
+          <ClaraGuideLearningHubOverlay
+            phase={learningHubGuidePhase}
+            onNext={isLearningHubGuidePreview ? handleGuideLearningHubNext : undefined}
+          />
+        ) : null}
       </div>
     </section>
   );

--- a/src/components/fresh/main-dashboard/learning-hub/LearningHub.jsx
+++ b/src/components/fresh/main-dashboard/learning-hub/LearningHub.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { CalendarClock, ScrollText } from "lucide-react";
 import DailyTipCard from "../daily-tip";
 import ClaraGuideLearningHubOverlay from "../guide/ClaraGuideLearningHubOverlay";
+import ClaraGuideLearningHubPreview from "../guide/ClaraGuideLearningHubPreview";
 import {
   openCommittedVersionModal,
   useCommittedFeatureAccess,
@@ -128,12 +129,8 @@ export default function LearningHub({
       resetGuidePreview();
     };
 
-    const handleGuideModeChange = (event) => {
-      if (event?.detail?.active) {
-        resetGuidePreview();
-      } else {
-        resetGuidePreview();
-      }
+    const handleGuideModeChange = () => {
+      resetGuidePreview();
     };
 
     const handleTargetChange = (event) => {
@@ -253,13 +250,11 @@ export default function LearningHub({
               <span aria-hidden="true" />
             )}
           </div>
+        ) : isLearningHubGuidePreview ? (
+          <ClaraGuideLearningHubPreview flushSpacing />
         ) : (
           <Suspense fallback={null}>
-            <LearningHubLoaded
-              initialExpanded
-              flushSpacing={true}
-              guidePreviewMode={isLearningHubGuidePreview}
-            />
+            <LearningHubLoaded initialExpanded flushSpacing={true} />
           </Suspense>
         )}
 

--- a/src/components/fresh/main-dashboard/learning-hub/ui/LearningHubToggleButton.jsx
+++ b/src/components/fresh/main-dashboard/learning-hub/ui/LearningHubToggleButton.jsx
@@ -18,12 +18,14 @@ export default function LearningHubToggleButton({
   onTouchEnd,
   className = "",
   flushSpacing = false,
+  guideTarget = false,
 }) {
   const spacingClass = flushSpacing || isExpanded ? "mt-0 mb-0" : "mt-3 mb-0";
 
   return (
     <button
       type="button"
+      data-clara-guide-learning-hub-toggle={guideTarget ? "true" : undefined}
       aria-expanded={isLocked ? false : isExpanded}
       aria-label={
         isLocked

--- a/src/guide-mode-learning-hub.css
+++ b/src/guide-mode-learning-hub.css
@@ -75,6 +75,13 @@ html.clara-guide-learning-hub-preview-active
 }
 
 html.clara-guide-learning-hub-preview-active
+#root [data-clara-guide-learning-hub-preview='true'] > section > button,
+html.clara-guide-learning-hub-preview-active
+#root [data-clara-guide-learning-hub-preview='true'] [data-clara-learning-hub-loaded-bridge='true'] button {
+  pointer-events: none !important;
+}
+
+html.clara-guide-learning-hub-preview-active
 #root [data-clara-guide-learning-hub-preview='true'] button {
   cursor: default !important;
 }

--- a/src/guide-mode-learning-hub.css
+++ b/src/guide-mode-learning-hub.css
@@ -1,0 +1,104 @@
+/* CLARA Guide Mode — Learning Hub chapter. */
+
+html:is(.clara-guide-learning-hub-await-active, .clara-guide-learning-hub-preview-active)
+#root .clara-budget-focus-hub .clara-guide-bubble-shell {
+  display: none !important;
+}
+
+html:is(.clara-guide-learning-hub-await-active, .clara-guide-learning-hub-preview-active)
+#root .clara-budget-focus-hub [data-clara-daily-tip-card='true'] {
+  opacity: 0.2 !important;
+  filter: brightness(0.34) saturate(0.5) contrast(0.9) !important;
+  pointer-events: none !important;
+}
+
+html:is(.clara-guide-learning-hub-await-active, .clara-guide-learning-hub-preview-active)
+#root .clara-budget-focus-hub [data-clara-daily-tip-card='true'] * {
+  pointer-events: none !important;
+}
+
+html.clara-guide-learning-hub-await-active
+#root [data-clara-guide-learning-hub-toggle='true'] {
+  position: relative;
+  z-index: 190 !important;
+  isolation: isolate;
+  opacity: 1 !important;
+  filter: none !important;
+  pointer-events: auto !important;
+  box-shadow:
+    0 0 0 2px rgba(186, 242, 255, 0.72),
+    0 0 34px rgba(34, 211, 238, 0.34),
+    0 0 56px rgba(129, 140, 248, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1) !important;
+}
+
+html.clara-guide-learning-hub-await-active
+#root [data-clara-learning-hub-bridge='true'] {
+  position: relative;
+  z-index: 190 !important;
+  isolation: isolate;
+  overflow: visible !important;
+}
+
+html.clara-guide-learning-hub-preview-active
+#root [data-clara-guide-learning-hub-preview='true'] {
+  position: relative;
+  z-index: 190 !important;
+  isolation: isolate;
+  overflow: visible !important;
+  opacity: 1 !important;
+  filter: none !important;
+  pointer-events: auto !important;
+}
+
+html.clara-guide-learning-hub-preview-active
+#root [data-clara-guide-learning-hub-preview='true']::before {
+  content: '';
+  pointer-events: none;
+  position: absolute;
+  inset: -10px;
+  z-index: -1;
+  border-radius: 36px;
+  border: 2px solid rgba(186, 242, 255, 0.68);
+  background:
+    radial-gradient(circle at 16% 12%, rgba(34, 211, 238, 0.2), transparent 44%),
+    radial-gradient(circle at 82% 84%, rgba(129, 140, 248, 0.18), transparent 46%);
+  box-shadow:
+    0 0 38px rgba(34, 211, 238, 0.28),
+    0 0 64px rgba(129, 140, 248, 0.16);
+}
+
+html.clara-guide-learning-hub-preview-active
+#root [data-clara-guide-learning-hub-preview='true'] .clara-learning-hub-stage {
+  pointer-events: auto !important;
+  touch-action: pan-y !important;
+}
+
+html.clara-guide-learning-hub-preview-active
+#root [data-clara-guide-learning-hub-preview='true'] button {
+  cursor: default !important;
+}
+
+html:is(.clara-guide-learning-hub-await-active, .clara-guide-learning-hub-preview-active)
+#root .clara-dashboard-bottom-finance-rail {
+  position: relative;
+  z-index: 10 !important;
+  pointer-events: none !important;
+}
+
+html:is(.clara-guide-learning-hub-await-active, .clara-guide-learning-hub-preview-active)
+#root .clara-dashboard-bottom-finance-rail * {
+  pointer-events: none !important;
+}
+
+html:is(.clara-guide-learning-hub-await-active, .clara-guide-learning-hub-preview-active)
+[data-clara-guide-learning-hub-bubble='true'] {
+  z-index: 205 !important;
+}
+
+html:is(.clara-guide-learning-hub-await-active, .clara-guide-learning-hub-preview-active)
+.clara-guide-learning-hub-next {
+  pointer-events: auto !important;
+  touch-action: manipulation !important;
+  -webkit-tap-highlight-color: transparent;
+}

--- a/src/guide-mode-me-bubble-spacing.css
+++ b/src/guide-mode-me-bubble-spacing.css
@@ -1,3 +1,5 @@
+@import "./guide-mode-learning-hub.css";
+
 /* Me Page Guide bubble spacing refinement. */
 #root#root [data-clara-guide-me-bubble='true'] {
   width: min(calc(100vw - 12px), 418px) !important;

--- a/src/runtime/installClaraGuideCarouselStep.js
+++ b/src/runtime/installClaraGuideCarouselStep.js
@@ -2,6 +2,8 @@ import "../guide-mode-next-buttons.css";
 
 const SAMPLE_CLASS = "clara-guide-daily-tip-sample-active";
 const CAROUSEL_CLASS = "clara-guide-finance-carousel-active";
+const LEARNING_HUB_AWAIT_CLASS = "clara-guide-learning-hub-await-active";
+const LEARNING_HUB_PREVIEW_CLASS = "clara-guide-learning-hub-preview-active";
 const MONEY_LEFT_CLASS = "clara-guide-money-left-active";
 const MONEY_LEFT_PRIVACY_CLASS = "clara-guide-money-left-privacy-active";
 const MONEY_LEFT_ORB_CLASS = "clara-guide-money-left-orb-active";
@@ -11,6 +13,7 @@ const ORB_PREVIEW_NEXT_SELECTOR = "[data-clara-guide-orb-preview-next='true']";
 const TARGET_CHANGE_EVENT = "clara:guide-target-change";
 const GUIDE_MODE_CHANGE_EVENT = "clara:guide-mode-change";
 const GUIDE_EXIT_EVENT = "clara:guide-exit";
+const LEARNING_HUB_PHASE_EVENT = "clara:guide-learning-hub-phase";
 const GUIDE_ORB_SELECTOR = "[data-clara-manual-expense-orb='true']";
 const GUIDE_SUMMARY_SELECTOR = "[data-clara-dashboard-section='money-summary']";
 const GUIDE_TOUCH_MOVE_LIMIT = 20;
@@ -24,6 +27,37 @@ function hasGuideSample() {
 
 function hasCarouselStep() {
   return document.documentElement.classList.contains(CAROUSEL_CLASS);
+}
+
+function hasLearningHubStep() {
+  const root = document.documentElement;
+  return (
+    root.classList.contains(LEARNING_HUB_AWAIT_CLASS) ||
+    root.classList.contains(LEARNING_HUB_PREVIEW_CLASS)
+  );
+}
+
+function applyLearningHubPhase(phase, { emit = true } = {}) {
+  if (typeof document === "undefined") return;
+
+  const root = document.documentElement;
+  const isAwaitOpen = phase === "await-open";
+  const isPreview = phase === "preview";
+
+  root.classList.toggle(LEARNING_HUB_AWAIT_CLASS, isAwaitOpen);
+  root.classList.toggle(LEARNING_HUB_PREVIEW_CLASS, isPreview);
+
+  if ((isAwaitOpen || isPreview) && root.classList.contains(CAROUSEL_CLASS)) {
+    root.classList.remove(CAROUSEL_CLASS);
+  }
+
+  if (emit && typeof window !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent(LEARNING_HUB_PHASE_EVENT, {
+        detail: { phase: isAwaitOpen ? "await-open" : isPreview ? "preview" : "inactive" },
+      }),
+    );
+  }
 }
 
 function isAwaitSingleOrb(target) {
@@ -84,7 +118,7 @@ function finishFinanceNextPointer(event, cancelled = false) {
 }
 
 function ensureNextButton() {
-  if (!hasGuideSample() || hasCarouselStep()) return;
+  if (!hasGuideSample() || hasCarouselStep() || hasLearningHubStep()) return;
 
   const surface = document.querySelector(".clara-guide-bubble-surface");
   if (!surface || surface.querySelector(`.${NEXT_CLASS}`)) return;
@@ -104,6 +138,8 @@ export function clearClaraGuideFeatureClasses() {
   document.documentElement.classList.remove(
     SAMPLE_CLASS,
     CAROUSEL_CLASS,
+    LEARNING_HUB_AWAIT_CLASS,
+    LEARNING_HUB_PREVIEW_CLASS,
     MONEY_LEFT_CLASS,
     MONEY_LEFT_PRIVACY_CLASS,
     MONEY_LEFT_ORB_CLASS,
@@ -128,7 +164,14 @@ function scrollDashboardGuideToTop(behavior = "smooth") {
   window.scrollTo?.({ top: 0, behavior });
 }
 
-function goToCarouselStep() {
+function scrollLearningHubIntoView() {
+  const learningHubToggle = document.querySelector(
+    "[data-clara-guide-learning-hub-toggle='true']",
+  );
+  learningHubToggle?.scrollIntoView?.({ block: "center", behavior: "smooth" });
+}
+
+function goToLearningHubStep() {
   if (!hasGuideSample()) {
     removeNextButton();
     return;
@@ -136,23 +179,18 @@ function goToCarouselStep() {
 
   document.documentElement.classList.remove(
     SAMPLE_CLASS,
+    CAROUSEL_CLASS,
     MONEY_LEFT_CLASS,
     MONEY_LEFT_PRIVACY_CLASS,
     MONEY_LEFT_ORB_CLASS,
   );
-  document.documentElement.classList.add(CAROUSEL_CLASS);
-
-  window.dispatchEvent(
-    new CustomEvent(TARGET_CHANGE_EVENT, {
-      detail: { feature: "finance-carousel" },
-    }),
-  );
+  applyLearningHubPhase("await-open");
 
   removeNextButton();
   protectSingleTapUntil = 0;
   financeNextPointer = null;
 
-  window.setTimeout(() => scrollDashboardGuideToTop("smooth"), 80);
+  window.setTimeout(scrollLearningHubIntoView, 80);
 }
 
 export function installClaraGuideCarouselStep() {
@@ -211,13 +249,17 @@ export function installClaraGuideCarouselStep() {
     if (nextButton) {
       event.preventDefault();
       event.stopPropagation();
-      goToCarouselStep();
+      goToLearningHubStep();
       return;
     }
 
     window.setTimeout(() => {
       if (hasGuideSample()) ensureNextButton();
     }, 60);
+  });
+
+  window.addEventListener(LEARNING_HUB_PHASE_EVENT, (event) => {
+    applyLearningHubPhase(event?.detail?.phase, { emit: false });
   });
 
   window.addEventListener(GUIDE_MODE_CHANGE_EVENT, () => {
@@ -233,6 +275,10 @@ export function installClaraGuideCarouselStep() {
   window.addEventListener(TARGET_CHANGE_EVENT, (event) => {
     protectSingleTapUntil = 0;
     financeNextPointer = null;
+
+    if (event?.detail?.feature !== "learning-hub") {
+      applyLearningHubPhase("inactive", { emit: false });
+    }
 
     if (event?.detail?.feature !== "money-left-orb") {
       document.documentElement.classList.remove(MONEY_LEFT_ORB_CLASS);


### PR DESCRIPTION
Adds a Learning Hub chapter between Daily Money Tip and the Financial Carousel. Uses the real Learning Hub toggle, carousel, and cards in a safe preview where swiping works but content activation is blocked. No membership, billing, Supabase, learning progress, routing, or finance logic changed.