### PR TITLE
Fully spotlight Learning Hub Guide target

### DIFF
--- a/src/components/fresh/main-dashboard/guide/ClaraGuideLearningHubOverlay.jsx
+++ b/src/components/fresh/main-dashboard/guide/ClaraGuideLearningHubOverlay.jsx
@@ -102,7 +102,7 @@ export default function ClaraGuideLearningHubOverlay({ phase = "await-open", onN
   return createPortal(
     <div
       data-clara-guide-learning-hub-bubble="true"
-      className="pointer-events-none fixed left-1/2 z-[165] w-[min(calc(100vw-24px),390px)] -translate-x-1/2 px-2"
+      className="pointer-events-none fixed left-1/2 z-[240] w-[min(calc(100vw-48px),360px)] -translate-x-1/2 isolate"
       style={{ top: top === null ? "clamp(116px, 14dvh, 144px)" : `${top}px` }}
     >
       <div
@@ -110,10 +110,10 @@ export default function ClaraGuideLearningHubOverlay({ phase = "await-open", onN
         role="dialog"
         aria-live="polite"
         aria-labelledby="clara-guide-learning-hub-title"
-        className="pointer-events-auto relative mx-auto w-full max-w-[360px] rounded-[26px] border border-cyan-100/24 bg-[linear-gradient(145deg,rgba(5,18,36,0.985),rgba(10,22,54,0.985)_52%,rgba(27,18,65,0.985))] px-5 py-4 text-white shadow-[0_24px_76px_rgba(0,0,0,0.72),0_0_44px_rgba(34,211,238,0.18)] backdrop-blur-2xl"
+        className="pointer-events-auto relative min-h-[150px] rounded-[30px] border border-cyan-100/24 bg-[linear-gradient(145deg,rgba(5,18,36,0.98),rgba(10,22,54,0.98)_52%,rgba(27,18,65,0.98))] px-6 py-5 text-white shadow-[0_22px_70px_rgba(0,0,0,0.72),0_0_44px_rgba(34,211,238,0.18)] backdrop-blur-2xl"
       >
         <div
-          className={`pointer-events-none absolute left-12 h-4 w-4 rotate-45 border-cyan-100/24 bg-[rgba(12,21,49,0.985)] ${
+          className={`pointer-events-none absolute left-11 h-4 w-4 rotate-45 border-cyan-100/24 bg-[rgba(10,22,54,0.98)] ${
             arrowPlacement === "top"
               ? "-top-2 border-l border-t"
               : "-bottom-2 border-b border-r"
@@ -122,31 +122,34 @@ export default function ClaraGuideLearningHubOverlay({ phase = "await-open", onN
 
         <p
           id="clara-guide-learning-hub-title"
-          className="text-[9px] font-black uppercase tracking-[0.22em] text-cyan-100"
+          className="relative z-10 text-[10px] font-black uppercase tracking-[0.22em] text-cyan-100"
         >
           {copy.title}
         </p>
-        <p className="mt-2 text-[12px] font-bold leading-[1.5] text-white">{copy.body}</p>
+
+        <p className="relative z-10 mt-3 text-[14px] font-bold leading-relaxed text-white">
+          {copy.body}
+        </p>
+
         {copy.supporting ? (
-          <p className="mt-1.5 text-[11px] font-semibold leading-[1.5] text-white/68">
+          <p className="relative z-10 mt-2 text-[12px] font-semibold leading-relaxed text-white/70">
             {copy.supporting}
           </p>
         ) : null}
-        <div className="mt-3 h-px bg-cyan-100/15" />
-        <div className="mt-3 flex items-center justify-between gap-4">
-          <p className="max-w-[230px] text-[8px] font-black uppercase leading-[1.45] tracking-[0.07em] text-cyan-100/88">
-            {copy.footer}
-          </p>
-          {hasNext ? (
-            <button
-              type="button"
-              onClick={onNext}
-              className="clara-guide-learning-hub-next min-h-[42px] shrink-0 touch-manipulation rounded-full border border-cyan-100/30 bg-cyan-100/15 px-5 py-2.5 text-[10px] font-black uppercase tracking-[0.18em] text-cyan-50 shadow-[0_12px_34px_rgba(34,211,238,0.16),inset_0_1px_0_rgba(255,255,255,0.12)] transition hover:bg-cyan-100/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100/80 active:scale-[0.99]"
-            >
-              NEXT
-            </button>
-          ) : null}
-        </div>
+
+        <p className="relative z-10 mt-3 border-t border-cyan-100/15 pt-3 text-[12px] font-black uppercase leading-relaxed tracking-[0.08em] text-cyan-100/90">
+          {copy.footer}
+        </p>
+
+        {hasNext ? (
+          <button
+            type="button"
+            onClick={onNext}
+            className="clara-guide-learning-hub-next pointer-events-auto relative z-20 mt-4 min-h-[44px] w-full touch-manipulation select-none cursor-pointer rounded-full border border-cyan-100/30 bg-cyan-100/15 px-4 py-3 text-[11px] font-black uppercase tracking-[0.18em] text-cyan-50 shadow-[0_12px_34px_rgba(34,211,238,0.16),inset_0_1px_0_rgba(255,255,255,0.12)] transition hover:bg-cyan-100/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 active:scale-[0.99]"
+          >
+            NEXT
+          </button>
+        ) : null}
       </div>
     </div>,
     document.body,

--- a/src/guide-mode-learning-hub-polish.css
+++ b/src/guide-mode-learning-hub-polish.css
@@ -1,0 +1,19 @@
+html.clara-guide-learning-hub-await-active #root [data-clara-guide-learning-hub-toggle='true'] {
+  opacity: 1 !important;
+  filter: brightness(1.35) saturate(1.25) !important;
+  transform: scale(1.06) !important;
+  border-color: rgba(207, 250, 254, 0.95) !important;
+  background: linear-gradient(135deg, rgba(8, 145, 170, 0.98), rgba(30, 86, 175, 0.98), rgba(87, 48, 166, 0.98)) !important;
+  color: white !important;
+  box-shadow: 0 0 0 2px rgba(207, 250, 254, 0.9), 0 0 36px rgba(34, 211, 238, 0.65), 0 0 72px rgba(99, 102, 241, 0.38) !important;
+}
+
+html.clara-guide-learning-hub-await-active #root [data-clara-guide-learning-hub-toggle='true'] span,
+html.clara-guide-learning-hub-await-active #root [data-clara-guide-learning-hub-toggle='true'] svg {
+  color: white !important;
+  opacity: 1 !important;
+}
+
+html:is(.clara-guide-learning-hub-await-active, .clara-guide-learning-hub-preview-active) [data-clara-guide-learning-hub-bubble='true'] {
+  z-index: 240 !important;
+}

--- a/src/guide-mode-me-bubble-spacing.css
+++ b/src/guide-mode-me-bubble-spacing.css
@@ -1,4 +1,5 @@
 @import "./guide-mode-learning-hub.css";
+@import "./guide-mode-learning-hub-polish.css";
 
 /* Me Page Guide bubble spacing refinement. */
 #root#root [data-clara-guide-me-bubble='true'] {


### PR DESCRIPTION
Corrects the Learning Hub Guide presentation after the first implementation left the target visually dim.

Changes:
- Forces the active Learning Hub pill to use a bright cyan/blue/violet surface instead of its normal low-opacity state
- Forces the icon, label, and chevron to full white visibility
- Adds a stronger spotlight ring and glow
- Rebuilds the Learning Hub explanation bubble with the exact sizing, typography, spacing, footer treatment, and full-width NEXT style used by the existing finance Guide bubbles
- Keeps behavior, sequencing, and Learning Hub data unchanged