### PR TITLE
Remove Learning Hub spotlight fog

### DIFF
--- a/src/guide-mode-learning-hub-crisp.css
+++ b/src/guide-mode-learning-hub-crisp.css
@@ -1,6 +1,74 @@
-html:is(.clara-guide-learning-hub-await-active,.clara-guide-learning-hub-preview-active) #root .fixed.inset-0[class*='z-[60]']{background:transparent!important;backdrop-filter:none!important;-webkit-backdrop-filter:none!important}
-html.clara-guide-learning-hub-await-active #root [data-clara-learning-hub-bridge='true'],html.clara-guide-learning-hub-preview-active #root [data-clara-guide-learning-hub-preview='true']{position:relative;z-index:220!important;isolation:isolate;overflow:visible!important}
-html.clara-guide-learning-hub-await-active #root [data-clara-learning-hub-bridge='true']::before,html.clara-guide-learning-hub-preview-active #root [data-clara-guide-learning-hub-preview='true']::after{content:'';position:fixed;inset:0;z-index:-2;pointer-events:none;background:rgba(2,6,23,.82);backdrop-filter:blur(2px);-webkit-backdrop-filter:blur(2px)}
-html.clara-guide-learning-hub-await-active #root [data-clara-guide-learning-hub-toggle='true']{position:relative;z-index:225!important;isolation:isolate;opacity:1!important;filter:brightness(1.35) saturate(1.25)!important;transform:translate3d(0,0,0) scale(1.06)!important;border-color:rgba(207,250,254,.95)!important;background:linear-gradient(135deg,rgba(8,145,170,.98),rgba(30,86,175,.98),rgba(87,48,166,.98))!important;color:#fff!important;box-shadow:0 0 0 2px rgba(207,250,254,.9),0 0 0 7px rgba(34,211,238,.12),0 0 36px rgba(34,211,238,.65),0 0 72px rgba(99,102,241,.38),0 18px 42px rgba(0,0,0,.46)!important}
-html.clara-guide-learning-hub-await-active #root [data-clara-guide-learning-hub-toggle='true'] span,html.clara-guide-learning-hub-await-active #root [data-clara-guide-learning-hub-toggle='true'] svg{color:#fff!important;opacity:1!important;filter:none!important}
-html.clara-guide-learning-hub-await-active #root [data-clara-guide-learning-hub-toggle='true']>span.pointer-events-none.absolute.inset-0{backdrop-filter:none!important;-webkit-backdrop-filter:none!important}
+/* Learning Hub Guide spotlight: keep one dashboard veil and lift the real target above it. */
+html:is(.clara-guide-learning-hub-await-active, .clara-guide-learning-hub-preview-active)
+#root .fixed.inset-0[class*='z-[60]'] {
+  background: rgba(2, 6, 23, 0.82) !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
+html.clara-guide-learning-hub-await-active
+#root [data-clara-learning-hub-bridge='true'],
+html.clara-guide-learning-hub-preview-active
+#root [data-clara-guide-learning-hub-preview='true'] {
+  position: relative;
+  z-index: 220 !important;
+  isolation: isolate;
+  overflow: visible !important;
+  opacity: 1 !important;
+  filter: none !important;
+}
+
+html.clara-guide-learning-hub-await-active
+#root [data-clara-guide-learning-hub-toggle='true'] {
+  position: relative;
+  z-index: 225 !important;
+  isolation: isolate;
+  opacity: 1 !important;
+  filter: none !important;
+  mix-blend-mode: normal !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+  transform: translate3d(0, 0, 0) scale(1.06) !important;
+  border-color: rgba(207, 250, 254, 0.95) !important;
+  background: linear-gradient(
+    135deg,
+    rgb(8, 145, 170),
+    rgb(30, 86, 175) 54%,
+    rgb(87, 48, 166)
+  ) !important;
+  color: #ffffff !important;
+  box-shadow:
+    0 0 0 2px rgba(207, 250, 254, 0.9),
+    0 0 0 7px rgba(34, 211, 238, 0.12),
+    0 0 36px rgba(34, 211, 238, 0.65),
+    0 0 72px rgba(99, 102, 241, 0.38),
+    0 18px 42px rgba(0, 0, 0, 0.46) !important;
+}
+
+html.clara-guide-learning-hub-await-active
+#root [data-clara-guide-learning-hub-toggle='true'] span,
+html.clara-guide-learning-hub-await-active
+#root [data-clara-guide-learning-hub-toggle='true'] svg {
+  color: #ffffff !important;
+  opacity: 1 !important;
+  filter: none !important;
+  mix-blend-mode: normal !important;
+}
+
+html.clara-guide-learning-hub-await-active
+#root [data-clara-guide-learning-hub-toggle='true'] > span.pointer-events-none.absolute.inset-0 {
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.12),
+    transparent 58%,
+    rgba(0, 0, 0, 0.08)
+  ) !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
+html.clara-guide-learning-hub-preview-active
+#root [data-clara-guide-learning-hub-preview='true'] {
+  filter: none !important;
+  mix-blend-mode: normal !important;
+}

--- a/src/guide-mode-learning-hub-polish.css
+++ b/src/guide-mode-learning-hub-polish.css
@@ -1,21 +1,6 @@
 @import "./guide-mode-learning-hub-crisp.css";
 
-html.clara-guide-learning-hub-await-active #root [data-clara-guide-learning-hub-toggle='true'] {
-  opacity: 1 !important;
-  filter: brightness(1.35) saturate(1.25) !important;
-  transform: scale(1.06) !important;
-  border-color: rgba(207, 250, 254, 0.95) !important;
-  background: linear-gradient(135deg, rgba(8, 145, 170, 0.98), rgba(30, 86, 175, 0.98), rgba(87, 48, 166, 0.98)) !important;
-  color: white !important;
-  box-shadow: 0 0 0 2px rgba(207, 250, 254, 0.9), 0 0 36px rgba(34, 211, 238, 0.65), 0 0 72px rgba(99, 102, 241, 0.38) !important;
-}
-
-html.clara-guide-learning-hub-await-active #root [data-clara-guide-learning-hub-toggle='true'] span,
-html.clara-guide-learning-hub-await-active #root [data-clara-guide-learning-hub-toggle='true'] svg {
-  color: white !important;
-  opacity: 1 !important;
-}
-
-html:is(.clara-guide-learning-hub-await-active, .clara-guide-learning-hub-preview-active) [data-clara-guide-learning-hub-bubble='true'] {
+html:is(.clara-guide-learning-hub-await-active, .clara-guide-learning-hub-preview-active)
+[data-clara-guide-learning-hub-bubble='true'] {
   z-index: 240 !important;
 }


### PR DESCRIPTION
Removes the internal blurred veil from the Learning Hub Guide layer and lets the real target render crisply above one plain dark Guide backdrop. Also removes duplicate brightness overrides. No Guide flow, Learning Hub data, or finance logic changed.