### PR TITLE
Fix Learning Hub preview bubble placement

### DIFF
--- a/src/components/fresh/main-dashboard/guide/ClaraGuideLearningHubOverlay.jsx
+++ b/src/components/fresh/main-dashboard/guide/ClaraGuideLearningHubOverlay.jsx
@@ -29,6 +29,10 @@ function getSafeTop() {
   return Math.max(12, navBottom + 12);
 }
 
+function getDashboardScroller(target) {
+  return target?.closest?.("main") || document.scrollingElement || null;
+}
+
 export default function ClaraGuideLearningHubOverlay({ phase = "await-open", onNext }) {
   const bubbleRef = useRef(null);
   const [top, setTop] = useState(null);
@@ -41,14 +45,44 @@ export default function ClaraGuideLearningHubOverlay({ phase = "await-open", onN
     const target = document.querySelector(TARGET_SELECTORS[phase] || TARGET_SELECTORS["await-open"]);
     if (!bubble || !target) return;
 
-    const targetRect = target.getBoundingClientRect();
+    let targetRect = target.getBoundingClientRect();
     const bubbleRect = bubble.getBoundingClientRect();
-    const gap = 12;
+    const gap = phase === "preview" ? 16 : 12;
     const safeTop = getSafeTop();
     const safeBottom = window.innerHeight - 12;
+    const maxTop = Math.max(safeTop, safeBottom - bubbleRect.height);
+
+    if (phase === "preview") {
+      let belowTarget = targetRect.bottom + gap;
+      const overflow = belowTarget + bubbleRect.height - safeBottom;
+
+      // The preview explanation belongs after the Learning Hub, never on top of it.
+      // Open enough space below the real carousel before positioning the portal.
+      if (overflow > 1) {
+        const scroller = getDashboardScroller(target);
+        if (scroller) {
+          const currentScrollTop = Number(scroller.scrollTop) || 0;
+          const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+          const nextScrollTop = Math.min(
+            maxScrollTop,
+            currentScrollTop + overflow + 24,
+          );
+
+          if (nextScrollTop > currentScrollTop + 1) {
+            scroller.scrollTop = nextScrollTop;
+            targetRect = target.getBoundingClientRect();
+            belowTarget = targetRect.bottom + gap;
+          }
+        }
+      }
+
+      setArrowPlacement("top");
+      setTop(Math.max(safeTop, Math.min(maxTop, belowTarget)));
+      return;
+    }
+
     const belowTarget = targetRect.bottom + gap;
     const aboveTarget = targetRect.top - bubbleRect.height - gap;
-    const maxTop = Math.max(safeTop, safeBottom - bubbleRect.height);
 
     if (belowTarget + bubbleRect.height <= safeBottom) {
       setArrowPlacement("top");
@@ -144,8 +178,9 @@ export default function ClaraGuideLearningHubOverlay({ phase = "await-open", onN
         {hasNext ? (
           <button
             type="button"
+            data-clara-guide-learning-hub-next="true"
             onClick={onNext}
-            className="clara-guide-learning-hub-next pointer-events-auto relative z-20 mt-4 min-h-[44px] w-full touch-manipulation select-none cursor-pointer rounded-full border border-cyan-100/30 bg-cyan-100/15 px-4 py-3 text-[11px] font-black uppercase tracking-[0.18em] text-cyan-50 shadow-[0_12px_34px_rgba(34,211,238,0.16),inset_0_1px_0_rgba(255,255,255,0.12)] transition hover:bg-cyan-100/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 active:scale-[0.99]"
+            className="clara-guide-learning-hub-next pointer-events-auto relative z-20 mt-4 flex min-h-[48px] w-full touch-manipulation select-none cursor-pointer items-center justify-center rounded-full border border-cyan-100/30 bg-[linear-gradient(135deg,rgba(207,250,254,0.18),rgba(103,232,249,0.10)_48%,rgba(129,140,248,0.13))] px-5 py-3 text-[11px] font-black uppercase tracking-[0.18em] text-cyan-50 shadow-[0_12px_34px_rgba(34,211,238,0.16),inset_0_1px_0_rgba(255,255,255,0.14)] transition hover:bg-cyan-100/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 active:scale-[0.99]"
           >
             NEXT
           </button>

--- a/src/guide-mode-learning-hub-crisp.css
+++ b/src/guide-mode-learning-hub-crisp.css
@@ -72,3 +72,53 @@ html.clara-guide-learning-hub-preview-active
   filter: none !important;
   mix-blend-mode: normal !important;
 }
+
+html body [data-clara-guide-learning-hub-bubble='true']
+button[data-clara-guide-learning-hub-next='true'] {
+  box-sizing: border-box !important;
+  position: relative !important;
+  inset: auto !important;
+  display: flex !important;
+  width: 100% !important;
+  min-width: 0 !important;
+  max-width: none !important;
+  min-height: 48px !important;
+  height: auto !important;
+  aspect-ratio: auto !important;
+  margin: 16px 0 0 !important;
+  padding: 12px 20px !important;
+  float: none !important;
+  transform: none !important;
+  align-items: center !important;
+  justify-content: center !important;
+  border: 1px solid rgba(186, 242, 255, 0.34) !important;
+  border-radius: 999px !important;
+  background: linear-gradient(
+    135deg,
+    rgba(207, 250, 254, 0.22),
+    rgba(103, 232, 249, 0.13) 48%,
+    rgba(129, 140, 248, 0.18)
+  ) !important;
+  color: rgba(236, 254, 255, 0.98) !important;
+  box-shadow:
+    0 12px 34px rgba(2, 8, 23, 0.42),
+    0 0 24px rgba(34, 211, 238, 0.14),
+    inset 0 1px 0 rgba(255, 255, 255, 0.16) !important;
+  backdrop-filter: blur(18px) saturate(135%) !important;
+  -webkit-backdrop-filter: blur(18px) saturate(135%) !important;
+  font-size: 11px !important;
+  font-weight: 900 !important;
+  line-height: 1 !important;
+  letter-spacing: 0.18em !important;
+  text-align: center !important;
+  text-transform: uppercase !important;
+  white-space: nowrap !important;
+  pointer-events: auto !important;
+  touch-action: manipulation !important;
+  cursor: pointer !important;
+}
+
+html body [data-clara-guide-learning-hub-bubble='true']
+button[data-clara-guide-learning-hub-next='true']:active {
+  transform: scale(0.985) !important;
+}


### PR DESCRIPTION
Moves the Learning Hub preview explanation below the expanded carousel and forces its NEXT button to remain a full-width premium Guide control.