### PR TITLE
Fix Learning Hub Guide scroll jump and clipped top navigation

### DIFF
--- a/src/components/fresh/main-dashboard/guide/ClaraGuideLearningHubInlineBubble.jsx
+++ b/src/components/fresh/main-dashboard/guide/ClaraGuideLearningHubInlineBubble.jsx
@@ -1,0 +1,43 @@
+export default function ClaraGuideLearningHubInlineBubble({ onNext }) {
+  return (
+    <div
+      data-clara-guide-learning-hub-inline-bubble="true"
+      className="mt-4 w-full"
+    >
+      <div
+        role="dialog"
+        aria-live="polite"
+        aria-labelledby="clara-guide-learning-hub-inline-title"
+        className="w-full rounded-[30px] border border-cyan-100/24 bg-[linear-gradient(145deg,rgba(5,18,36,0.98),rgba(10,22,54,0.98)_52%,rgba(27,18,65,0.98))] px-6 py-5 text-white shadow-[0_22px_70px_rgba(0,0,0,0.58),0_0_44px_rgba(34,211,238,0.16)] backdrop-blur-2xl"
+      >
+        <p
+          id="clara-guide-learning-hub-inline-title"
+          className="text-[10px] font-black uppercase tracking-[0.22em] text-cyan-100"
+        >
+          LEARN • PLAY • APPLY
+        </p>
+
+        <p className="mt-3 text-[14px] font-bold leading-relaxed text-white">
+          Explore lessons, money games, videos, and practical tools designed to strengthen your financial habits.
+        </p>
+
+        <p className="mt-2 text-[12px] font-semibold leading-relaxed text-white/70">
+          Swipe through the Learning Hub to see what is available.
+        </p>
+
+        <p className="mt-4 border-t border-cyan-100/15 pt-4 text-[12px] font-black uppercase leading-relaxed tracking-[0.08em] text-cyan-100/90">
+          LEARNING BECOMES POWERFUL WHEN YOU APPLY IT.
+        </p>
+
+        <button
+          type="button"
+          data-clara-guide-learning-hub-next="true"
+          onClick={onNext}
+          className="clara-guide-learning-hub-next mt-4 flex min-h-[48px] w-full touch-manipulation select-none items-center justify-center rounded-full border border-cyan-100/30 bg-[linear-gradient(135deg,rgba(207,250,254,0.18),rgba(103,232,249,0.10)_48%,rgba(129,140,248,0.13))] px-5 py-3 text-[11px] font-black uppercase tracking-[0.18em] text-cyan-50 shadow-[0_12px_34px_rgba(34,211,238,0.16),inset_0_1px_0_rgba(255,255,255,0.14)] transition hover:bg-cyan-100/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 active:scale-[0.99]"
+        >
+          NEXT
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/fresh/main-dashboard/guide/ClaraGuideLearningHubOverlay.jsx
+++ b/src/components/fresh/main-dashboard/guide/ClaraGuideLearningHubOverlay.jsx
@@ -2,24 +2,12 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 import { createPortal } from "react-dom";
 
 const COPY = {
-  "await-open": {
-    title: "LEARNING HUB",
-    body: "This is where CLARA turns money lessons into practical learning, games, and guided activities.",
-    supporting: "",
-    footer: "TAP LEARNING HUB NOW.",
-  },
-  preview: {
-    title: "LEARN • PLAY • APPLY",
-    body: "Explore lessons, money games, videos, and practical tools designed to strengthen your financial habits.",
-    supporting: "Swipe through the Learning Hub to see what is available.",
-    footer: "LEARNING BECOMES POWERFUL WHEN YOU APPLY IT.",
-  },
+  title: "LEARNING HUB",
+  body: "This is where CLARA turns money lessons into practical learning, games, and guided activities.",
+  footer: "TAP LEARNING HUB NOW.",
 };
 
-const TARGET_SELECTORS = {
-  "await-open": "[data-clara-guide-learning-hub-toggle='true']",
-  preview: "[data-clara-guide-learning-hub-preview='true']",
-};
+const TARGET_SELECTOR = "[data-clara-guide-learning-hub-toggle='true']";
 
 function getSafeTop() {
   const navTarget = document.querySelector(
@@ -29,58 +17,24 @@ function getSafeTop() {
   return Math.max(12, navBottom + 12);
 }
 
-function getDashboardScroller(target) {
-  return target?.closest?.("main") || document.scrollingElement || null;
-}
-
-export default function ClaraGuideLearningHubOverlay({ phase = "await-open", onNext }) {
+export default function ClaraGuideLearningHubOverlay({ phase = "await-open" }) {
   const bubbleRef = useRef(null);
   const [top, setTop] = useState(null);
   const [arrowPlacement, setArrowPlacement] = useState("top");
-  const copy = COPY[phase] || COPY["await-open"];
-  const hasNext = phase === "preview" && typeof onNext === "function";
 
   const updatePosition = useCallback(() => {
+    if (phase !== "await-open") return;
+
     const bubble = bubbleRef.current;
-    const target = document.querySelector(TARGET_SELECTORS[phase] || TARGET_SELECTORS["await-open"]);
+    const target = document.querySelector(TARGET_SELECTOR);
     if (!bubble || !target) return;
 
-    let targetRect = target.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
     const bubbleRect = bubble.getBoundingClientRect();
-    const gap = phase === "preview" ? 16 : 12;
+    const gap = 12;
     const safeTop = getSafeTop();
     const safeBottom = window.innerHeight - 12;
     const maxTop = Math.max(safeTop, safeBottom - bubbleRect.height);
-
-    if (phase === "preview") {
-      let belowTarget = targetRect.bottom + gap;
-      const overflow = belowTarget + bubbleRect.height - safeBottom;
-
-      // The preview explanation belongs after the Learning Hub, never on top of it.
-      // Open enough space below the real carousel before positioning the portal.
-      if (overflow > 1) {
-        const scroller = getDashboardScroller(target);
-        if (scroller) {
-          const currentScrollTop = Number(scroller.scrollTop) || 0;
-          const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
-          const nextScrollTop = Math.min(
-            maxScrollTop,
-            currentScrollTop + overflow + 24,
-          );
-
-          if (nextScrollTop > currentScrollTop + 1) {
-            scroller.scrollTop = nextScrollTop;
-            targetRect = target.getBoundingClientRect();
-            belowTarget = targetRect.bottom + gap;
-          }
-        }
-      }
-
-      setArrowPlacement("top");
-      setTop(Math.max(safeTop, Math.min(maxTop, belowTarget)));
-      return;
-    }
-
     const belowTarget = targetRect.bottom + gap;
     const aboveTarget = targetRect.top - bubbleRect.height - gap;
 
@@ -104,18 +58,22 @@ export default function ClaraGuideLearningHubOverlay({ phase = "await-open", onN
   }, [phase]);
 
   useLayoutEffect(() => {
+    if (phase !== "await-open") return undefined;
+
     updatePosition();
     const frame = window.requestAnimationFrame(updatePosition);
     return () => window.cancelAnimationFrame(frame);
-  }, [updatePosition]);
+  }, [phase, updatePosition]);
 
   useEffect(() => {
+    if (phase !== "await-open") return undefined;
+
     const handleChange = () => updatePosition();
     window.addEventListener("resize", handleChange);
     window.addEventListener("orientationchange", handleChange);
     window.addEventListener("scroll", handleChange, true);
 
-    const target = document.querySelector(TARGET_SELECTORS[phase] || TARGET_SELECTORS["await-open"]);
+    const target = document.querySelector(TARGET_SELECTOR);
     const observer =
       typeof ResizeObserver !== "undefined" && target
         ? new ResizeObserver(handleChange)
@@ -131,7 +89,7 @@ export default function ClaraGuideLearningHubOverlay({ phase = "await-open", onN
     };
   }, [phase, updatePosition]);
 
-  if (typeof document === "undefined") return null;
+  if (phase !== "await-open" || typeof document === "undefined") return null;
 
   return createPortal(
     <div
@@ -158,33 +116,16 @@ export default function ClaraGuideLearningHubOverlay({ phase = "await-open", onN
           id="clara-guide-learning-hub-title"
           className="relative z-10 text-[10px] font-black uppercase tracking-[0.22em] text-cyan-100"
         >
-          {copy.title}
+          {COPY.title}
         </p>
 
         <p className="relative z-10 mt-3 text-[14px] font-bold leading-relaxed text-white">
-          {copy.body}
+          {COPY.body}
         </p>
-
-        {copy.supporting ? (
-          <p className="relative z-10 mt-2 text-[12px] font-semibold leading-relaxed text-white/70">
-            {copy.supporting}
-          </p>
-        ) : null}
 
         <p className="relative z-10 mt-3 border-t border-cyan-100/15 pt-3 text-[12px] font-black uppercase leading-relaxed tracking-[0.08em] text-cyan-100/90">
-          {copy.footer}
+          {COPY.footer}
         </p>
-
-        {hasNext ? (
-          <button
-            type="button"
-            data-clara-guide-learning-hub-next="true"
-            onClick={onNext}
-            className="clara-guide-learning-hub-next pointer-events-auto relative z-20 mt-4 flex min-h-[48px] w-full touch-manipulation select-none cursor-pointer items-center justify-center rounded-full border border-cyan-100/30 bg-[linear-gradient(135deg,rgba(207,250,254,0.18),rgba(103,232,249,0.10)_48%,rgba(129,140,248,0.13))] px-5 py-3 text-[11px] font-black uppercase tracking-[0.18em] text-cyan-50 shadow-[0_12px_34px_rgba(34,211,238,0.16),inset_0_1px_0_rgba(255,255,255,0.14)] transition hover:bg-cyan-100/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 active:scale-[0.99]"
-          >
-            NEXT
-          </button>
-        ) : null}
       </div>
     </div>,
     document.body,

--- a/src/components/fresh/main-dashboard/learning-hub/LearningHub.jsx
+++ b/src/components/fresh/main-dashboard/learning-hub/LearningHub.jsx
@@ -1,7 +1,8 @@
-import { Suspense, lazy, useEffect, useState } from "react";
+import { Suspense, lazy, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { CalendarClock, ScrollText } from "lucide-react";
 import DailyTipCard from "../daily-tip";
+import ClaraGuideLearningHubInlineBubble from "../guide/ClaraGuideLearningHubInlineBubble";
 import ClaraGuideLearningHubOverlay from "../guide/ClaraGuideLearningHubOverlay";
 import ClaraGuideLearningHubPreview from "../guide/ClaraGuideLearningHubPreview";
 import {
@@ -16,6 +17,30 @@ const LEARNING_HUB_PHASE_EVENT = "clara:guide-learning-hub-phase";
 const GUIDE_MODE_CHANGE_EVENT = "clara:guide-mode-change";
 const GUIDE_EXIT_EVENT = "clara:guide-exit";
 const GUIDE_TARGET_CHANGE_EVENT = "clara:guide-target-change";
+
+function getDashboardScrollRoot() {
+  if (typeof document === "undefined") return null;
+
+  return document.querySelector(
+    "[data-clara-dashboard-scroll-root='true']",
+  );
+}
+
+function restoreDashboardScrollPosition(scroller, scrollTop) {
+  if (!scroller || typeof window === "undefined") return;
+
+  const restore = () => {
+    scroller.scrollTop = scrollTop;
+  };
+
+  window.requestAnimationFrame(() => {
+    restore();
+
+    window.requestAnimationFrame(() => {
+      restore();
+    });
+  });
+}
 
 function ClaraGuideButton({ hasNewGuide = false, onClick }) {
   return (
@@ -92,6 +117,7 @@ export default function LearningHub({
   const navigate = useNavigate();
   const [shouldLoadHub, setShouldLoadHub] = useState(false);
   const [learningHubGuidePhase, setLearningHubGuidePhase] = useState("inactive");
+  const learningHubGuideEntryScrollRef = useRef(null);
   const realHasCommittedAccess = useCommittedFeatureAccess();
   const hasCommittedAccess = isGuideMode ? true : realHasCommittedAccess;
   const isLocked = !hasCommittedAccess;
@@ -108,6 +134,7 @@ export default function LearningHub({
     if (typeof window === "undefined") return undefined;
 
     const resetGuidePreview = () => {
+      learningHubGuideEntryScrollRef.current = null;
       setLearningHubGuidePhase("inactive");
       setShouldLoadHub(false);
     };
@@ -115,6 +142,7 @@ export default function LearningHub({
     const handleLearningHubPhase = (event) => {
       const phase = event?.detail?.phase;
       if (phase === "await-open") {
+        learningHubGuideEntryScrollRef.current = null;
         setShouldLoadHub(false);
         setLearningHubGuidePhase("await-open");
         return;
@@ -145,6 +173,7 @@ export default function LearningHub({
     window.addEventListener(GUIDE_TARGET_CHANGE_EVENT, handleTargetChange);
 
     return () => {
+      learningHubGuideEntryScrollRef.current = null;
       window.removeEventListener(LEARNING_HUB_PHASE_EVENT, handleLearningHubPhase);
       window.removeEventListener(GUIDE_MODE_CHANGE_EVENT, handleGuideModeChange);
       window.removeEventListener(GUIDE_EXIT_EVENT, resetGuidePreview);
@@ -155,6 +184,11 @@ export default function LearningHub({
   const handleOpenHub = () => {
     if (isGuideMode) {
       if (isLearningHubGuideAwaitOpen) {
+        const dashboardScroller = getDashboardScrollRoot();
+
+        learningHubGuideEntryScrollRef.current =
+          Number(dashboardScroller?.scrollTop) || 0;
+
         setShouldLoadHub(true);
         setLearningHubGuidePhase("preview");
         emitLearningHubPhase("preview");
@@ -171,7 +205,16 @@ export default function LearningHub({
   };
 
   const handleGuideLearningHubNext = () => {
-    if (!isLearningHubGuidePreview || typeof window === "undefined") return;
+    if (!isLearningHubGuidePreview || typeof window === "undefined") {
+      return;
+    }
+
+    const dashboardScroller = getDashboardScrollRoot();
+    const savedScrollTop = learningHubGuideEntryScrollRef.current;
+    const restoreScrollTop =
+      savedScrollTop === null
+        ? Number(dashboardScroller?.scrollTop) || 0
+        : Number(savedScrollTop) || 0;
 
     setShouldLoadHub(false);
     setLearningHubGuidePhase("inactive");
@@ -179,16 +222,18 @@ export default function LearningHub({
 
     window.dispatchEvent(
       new CustomEvent(GUIDE_TARGET_CHANGE_EVENT, {
-        detail: { feature: "finance-carousel" },
+        detail: {
+          feature: "finance-carousel",
+        },
       }),
     );
 
-    window.setTimeout(() => {
-      document.querySelector(".clara-guide-carousel-anchor")?.scrollIntoView?.({
-        block: "center",
-        behavior: "smooth",
-      });
-    }, 80);
+    restoreDashboardScrollPosition(
+      dashboardScroller,
+      restoreScrollTop,
+    );
+
+    learningHubGuideEntryScrollRef.current = null;
   };
 
   return (
@@ -251,18 +296,24 @@ export default function LearningHub({
             )}
           </div>
         ) : isLearningHubGuidePreview ? (
-          <ClaraGuideLearningHubPreview flushSpacing />
+          <div
+            data-clara-guide-learning-hub-preview-stack="true"
+            className="flex w-full flex-col"
+          >
+            <ClaraGuideLearningHubPreview flushSpacing />
+
+            <ClaraGuideLearningHubInlineBubble
+              onNext={handleGuideLearningHubNext}
+            />
+          </div>
         ) : (
           <Suspense fallback={null}>
             <LearningHubLoaded initialExpanded flushSpacing={true} />
           </Suspense>
         )}
 
-        {isLearningHubGuideActive ? (
-          <ClaraGuideLearningHubOverlay
-            phase={learningHubGuidePhase}
-            onNext={isLearningHubGuidePreview ? handleGuideLearningHubNext : undefined}
-          />
+        {isLearningHubGuideAwaitOpen ? (
+          <ClaraGuideLearningHubOverlay phase="await-open" />
         ) : null}
       </div>
     </section>

--- a/src/components/fresh/main-dashboard/shell/DashboardShell.jsx
+++ b/src/components/fresh/main-dashboard/shell/DashboardShell.jsx
@@ -22,7 +22,12 @@ const DashboardShell = forwardRef(function DashboardShell(
     .join(" ");
 
   return (
-    <Component ref={ref} className={resolvedClassName} style={style}>
+    <Component
+      ref={ref}
+      data-clara-dashboard-scroll-root="true"
+      className={resolvedClassName}
+      style={style}
+    >
       {children}
     </Component>
   );

--- a/src/guide-mode-learning-hub-crisp.css
+++ b/src/guide-mode-learning-hub-crisp.css
@@ -9,6 +9,8 @@ html:is(.clara-guide-learning-hub-await-active, .clara-guide-learning-hub-previe
 html.clara-guide-learning-hub-await-active
 #root [data-clara-learning-hub-bridge='true'],
 html.clara-guide-learning-hub-preview-active
+#root [data-clara-guide-learning-hub-preview-stack='true'],
+html.clara-guide-learning-hub-preview-active
 #root [data-clara-guide-learning-hub-preview='true'] {
   position: relative;
   z-index: 220 !important;
@@ -30,12 +32,7 @@ html.clara-guide-learning-hub-await-active
   -webkit-backdrop-filter: none !important;
   transform: translate3d(0, 0, 0) scale(1.06) !important;
   border-color: rgba(207, 250, 254, 0.95) !important;
-  background: linear-gradient(
-    135deg,
-    rgb(8, 145, 170),
-    rgb(30, 86, 175) 54%,
-    rgb(87, 48, 166)
-  ) !important;
+  background: linear-gradient(135deg, rgb(8, 145, 170), rgb(30, 86, 175) 54%, rgb(87, 48, 166)) !important;
   color: #ffffff !important;
   box-shadow:
     0 0 0 2px rgba(207, 250, 254, 0.9),
@@ -57,12 +54,7 @@ html.clara-guide-learning-hub-await-active
 
 html.clara-guide-learning-hub-await-active
 #root [data-clara-guide-learning-hub-toggle='true'] > span.pointer-events-none.absolute.inset-0 {
-  background: linear-gradient(
-    to bottom,
-    rgba(255, 255, 255, 0.12),
-    transparent 58%,
-    rgba(0, 0, 0, 0.08)
-  ) !important;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.12), transparent 58%, rgba(0, 0, 0, 0.08)) !important;
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
 }
@@ -73,8 +65,8 @@ html.clara-guide-learning-hub-preview-active
   mix-blend-mode: normal !important;
 }
 
-html body [data-clara-guide-learning-hub-bubble='true']
-button[data-clara-guide-learning-hub-next='true'] {
+html body [data-clara-guide-learning-hub-bubble='true'] button[data-clara-guide-learning-hub-next='true'],
+html body [data-clara-guide-learning-hub-inline-bubble='true'] button[data-clara-guide-learning-hub-next='true'] {
   box-sizing: border-box !important;
   position: relative !important;
   inset: auto !important;
@@ -93,12 +85,7 @@ button[data-clara-guide-learning-hub-next='true'] {
   justify-content: center !important;
   border: 1px solid rgba(186, 242, 255, 0.34) !important;
   border-radius: 999px !important;
-  background: linear-gradient(
-    135deg,
-    rgba(207, 250, 254, 0.22),
-    rgba(103, 232, 249, 0.13) 48%,
-    rgba(129, 140, 248, 0.18)
-  ) !important;
+  background: linear-gradient(135deg, rgba(207, 250, 254, 0.22), rgba(103, 232, 249, 0.13) 48%, rgba(129, 140, 248, 0.18)) !important;
   color: rgba(236, 254, 255, 0.98) !important;
   box-shadow:
     0 12px 34px rgba(2, 8, 23, 0.42),
@@ -118,7 +105,7 @@ button[data-clara-guide-learning-hub-next='true'] {
   cursor: pointer !important;
 }
 
-html body [data-clara-guide-learning-hub-bubble='true']
-button[data-clara-guide-learning-hub-next='true']:active {
+html body [data-clara-guide-learning-hub-bubble='true'] button[data-clara-guide-learning-hub-next='true']:active,
+html body [data-clara-guide-learning-hub-inline-bubble='true'] button[data-clara-guide-learning-hub-next='true']:active {
   transform: scale(0.985) !important;
 }

--- a/src/guide-mode-learning-hub.css
+++ b/src/guide-mode-learning-hub.css
@@ -41,6 +41,13 @@ html.clara-guide-learning-hub-await-active
 }
 
 html.clara-guide-learning-hub-preview-active
+#root [data-clara-guide-learning-hub-preview-stack='true'],
+html.clara-guide-learning-hub-preview-active
+#root [data-clara-guide-learning-hub-inline-bubble='true'] {
+  overflow-anchor: none;
+}
+
+html.clara-guide-learning-hub-preview-active
 #root [data-clara-guide-learning-hub-preview='true'] {
   position: relative;
   z-index: 190 !important;


### PR DESCRIPTION
## Summary
- limit the Learning Hub portal overlay to the collapsed `await-open` step
- render the expanded Learning Hub explanation inline below the real carousel
- capture the actual dashboard shell scroll position before expansion
- collapse the Hub and restore the saved scroll position with two animation frames
- remove the Financial Carousel `scrollIntoView()` centering transition
- disable scroll anchoring only for the temporary Learning Hub preview stack
- reset the saved scroll reference on Guide reset, exit, target change, and unmount

## Scroll-root note
`DashboardShell` currently does not forward unknown props, so adding the requested `data-*` prop in `Dashboard.jsx` would not reach the DOM. The marker is therefore applied directly by `DashboardShell`, which has only one rendered usage in the app, and the Learning Hub helper queries that marker without any `main`, `window`, or `document.scrollingElement` fallback.

## Scope protection
No changes to Learning Hub content, card data, swipe mechanics, Guide copy/order, finance logic, routing, membership, billing, Supabase, or normal non-Guide behavior.

## Verification targets
- no portal bubble during expanded preview
- no scroll writes from overlay resize/scroll/orientation observers
- no automatic Financial Carousel centering
- top navigation remains visible after NEXT
- real Learning Hub carousel remains horizontally swipeable while activations stay blocked
