### PR TITLE
Lift Learning Hub guide preview

### DIFF
--- a/src/components/fresh/main-dashboard/guide/ClaraGuideLearningHubInlineBubble.jsx
+++ b/src/components/fresh/main-dashboard/guide/ClaraGuideLearningHubInlineBubble.jsx
@@ -1,6 +1,107 @@
+import { useEffect, useRef } from "react";
+
+const DASHBOARD_SCROLL_ROOT_SELECTOR =
+  "[data-clara-dashboard-scroll-root='true']";
+const PREVIEW_STACK_SELECTOR =
+  "[data-clara-guide-learning-hub-preview-stack='true']";
+const GUIDE_BUBBLE_SAFE_BOTTOM_PX = 18;
+
+function getVisibleDashboardBottom(scrollerRect) {
+  if (typeof window === "undefined") return scrollerRect.bottom;
+
+  const visualViewport = window.visualViewport;
+  const viewportBottom = visualViewport
+    ? visualViewport.offsetTop + visualViewport.height
+    : window.innerHeight;
+
+  return Math.min(scrollerRect.bottom, viewportBottom);
+}
+
 export default function ClaraGuideLearningHubInlineBubble({ onNext }) {
+  const bubbleRef = useRef(null);
+  const didApplyPreviewLiftRef = useRef(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return undefined;
+    }
+
+    const bubble = bubbleRef.current;
+    const dashboardScroller = document.querySelector(
+      DASHBOARD_SCROLL_ROOT_SELECTOR,
+    );
+    const previewStack = bubble?.closest?.(PREVIEW_STACK_SELECTOR);
+
+    if (
+      !bubble ||
+      !dashboardScroller ||
+      !previewStack ||
+      !dashboardScroller.contains(previewStack)
+    ) {
+      return undefined;
+    }
+
+    let firstFrame = 0;
+    let secondFrame = 0;
+
+    firstFrame = window.requestAnimationFrame(() => {
+      secondFrame = window.requestAnimationFrame(() => {
+        if (
+          didApplyPreviewLiftRef.current ||
+          !bubble.isConnected ||
+          !dashboardScroller.isConnected
+        ) {
+          return;
+        }
+
+        didApplyPreviewLiftRef.current = true;
+
+        const scrollerRect = dashboardScroller.getBoundingClientRect();
+        const bubbleRect = bubble.getBoundingClientRect();
+        const visibleBottom = getVisibleDashboardBottom(scrollerRect);
+        const requiredLift = Math.ceil(
+          bubbleRect.bottom + GUIDE_BUBBLE_SAFE_BOTTOM_PX - visibleBottom,
+        );
+
+        if (requiredLift <= 0) return;
+
+        const currentScrollTop = Number(dashboardScroller.scrollTop) || 0;
+        const maxScrollTop = Math.max(
+          0,
+          dashboardScroller.scrollHeight - dashboardScroller.clientHeight,
+        );
+        const targetScrollTop = Math.min(
+          maxScrollTop,
+          currentScrollTop + requiredLift,
+        );
+
+        if (targetScrollTop <= currentScrollTop) return;
+
+        const reduceMotion = window.matchMedia?.(
+          "(prefers-reduced-motion: reduce)",
+        )?.matches;
+
+        if (typeof dashboardScroller.scrollTo === "function") {
+          dashboardScroller.scrollTo({
+            top: targetScrollTop,
+            behavior: reduceMotion ? "auto" : "smooth",
+          });
+          return;
+        }
+
+        dashboardScroller.scrollTop = targetScrollTop;
+      });
+    });
+
+    return () => {
+      if (firstFrame) window.cancelAnimationFrame(firstFrame);
+      if (secondFrame) window.cancelAnimationFrame(secondFrame);
+    };
+  }, []);
+
   return (
     <div
+      ref={bubbleRef}
       data-clara-guide-learning-hub-inline-bubble="true"
       className="mt-4 w-full"
     >

--- a/src/components/fresh/main-dashboard/guide/ClaraGuideLearningHubInlineBubble.jsx
+++ b/src/components/fresh/main-dashboard/guide/ClaraGuideLearningHubInlineBubble.jsx
@@ -4,6 +4,8 @@ const DASHBOARD_SCROLL_ROOT_SELECTOR =
   "[data-clara-dashboard-scroll-root='true']";
 const PREVIEW_STACK_SELECTOR =
   "[data-clara-guide-learning-hub-preview-stack='true']";
+const GUIDE_EXIT_SELECTOR = "[data-clara-guide-exit='true']";
+const DASHBOARD_TOP_NAV_ATTRIBUTE = "data-clara-dashboard-top-nav";
 const GUIDE_BUBBLE_SAFE_BOTTOM_PX = 18;
 
 function getVisibleDashboardBottom(scrollerRect) {
@@ -15,6 +17,22 @@ function getVisibleDashboardBottom(scrollerRect) {
     : window.innerHeight;
 
   return Math.min(scrollerRect.bottom, viewportBottom);
+}
+
+function getDashboardTopNav(dashboardScroller) {
+  const guideExitButton = document.querySelector(GUIDE_EXIT_SELECTOR);
+  let currentElement = guideExitButton;
+
+  while (
+    currentElement?.parentElement &&
+    currentElement.parentElement !== dashboardScroller
+  ) {
+    currentElement = currentElement.parentElement;
+  }
+
+  return currentElement?.parentElement === dashboardScroller
+    ? currentElement
+    : null;
 }
 
 export default function ClaraGuideLearningHubInlineBubble({ onNext }) {
@@ -39,6 +57,15 @@ export default function ClaraGuideLearningHubInlineBubble({ onNext }) {
       !dashboardScroller.contains(previewStack)
     ) {
       return undefined;
+    }
+
+    const dashboardTopNav = getDashboardTopNav(dashboardScroller);
+    const topNavAlreadyMarked = dashboardTopNav?.hasAttribute(
+      DASHBOARD_TOP_NAV_ATTRIBUTE,
+    );
+
+    if (dashboardTopNav && !topNavAlreadyMarked) {
+      dashboardTopNav.setAttribute(DASHBOARD_TOP_NAV_ATTRIBUTE, "true");
     }
 
     let firstFrame = 0;
@@ -96,6 +123,10 @@ export default function ClaraGuideLearningHubInlineBubble({ onNext }) {
     return () => {
       if (firstFrame) window.cancelAnimationFrame(firstFrame);
       if (secondFrame) window.cancelAnimationFrame(secondFrame);
+
+      if (dashboardTopNav && !topNavAlreadyMarked) {
+        dashboardTopNav.removeAttribute(DASHBOARD_TOP_NAV_ATTRIBUTE);
+      }
     };
   }, []);
 

--- a/src/guide-mode-learning-hub-lift.css
+++ b/src/guide-mode-learning-hub-lift.css
@@ -1,0 +1,14 @@
+/* One-time Learning Hub Guide lift support. */
+
+html.clara-guide-learning-hub-preview-active
+#root [data-clara-dashboard-top-nav='true'] {
+  position: sticky !important;
+  top: 0;
+  z-index: 260 !important;
+  isolation: isolate;
+}
+
+html.clara-guide-learning-hub-preview-active
+#root [data-clara-guide-learning-hub-preview-stack='true'] {
+  padding-bottom: max(18px, env(safe-area-inset-bottom));
+}

--- a/src/guide-mode-me-bubble-spacing.css
+++ b/src/guide-mode-me-bubble-spacing.css
@@ -1,5 +1,6 @@
 @import "./guide-mode-learning-hub.css";
 @import "./guide-mode-learning-hub-polish.css";
+@import "./guide-mode-learning-hub-lift.css";
 
 /* Me Page Guide bubble spacing refinement. */
 #root#root [data-clara-guide-me-bubble='true'] {


### PR DESCRIPTION
Adds a one-time calculated dashboard lift so the full Learning Hub guide bubble is visible while keeping the Guide top navigation sticky. Existing NEXT scroll restoration remains unchanged.