### PR TITLE
Refine Guide Mode CLARA chat bubbles

### DIFF
--- a/src/components/fresh/main-dashboard/assistant/ClaraAiEnvironmentOverlay.jsx
+++ b/src/components/fresh/main-dashboard/assistant/ClaraAiEnvironmentOverlay.jsx
@@ -89,12 +89,14 @@ export default function ClaraAiEnvironmentOverlay({
   isActive = false,
   messages = [],
   onClose,
+  layoutVariant = "default",
 }) {
   const [draft, setDraft] = useState("");
   const [localMessages, setLocalMessages] = useState([]);
   const [selectedFeature, setSelectedFeature] = useState("buy-check");
   const inputRef = useRef(null);
   const messagesEndRef = useRef(null);
+  const isGuidePreview = layoutVariant === "guide-preview";
 
   const visibleMessages = useMemo(
     () => [...(Array.isArray(messages) ? messages : []), ...localMessages].filter(Boolean),
@@ -161,24 +163,55 @@ export default function ClaraAiEnvironmentOverlay({
     setDraft("");
   };
 
+  const messageStackClassName = isGuidePreview
+    ? "flex min-h-full min-w-0 flex-col justify-start gap-4 px-2 pb-32 pt-0"
+    : "flex min-h-full flex-col justify-start gap-3 px-2 pb-28 pt-12";
+
+  const userBubbleClassName = isGuidePreview
+    ? "w-fit max-w-[78%] rounded-[22px] bg-emerald-300 px-4 py-2.5 text-[13px] font-semibold leading-5 text-slate-950"
+    : "max-w-[86%] rounded-[24px] bg-emerald-300 px-4 py-3 text-[13px] font-semibold leading-5 text-slate-950";
+
+  const claraBubbleClassName = isGuidePreview
+    ? "w-fit max-w-[86%] rounded-[22px] border border-white/10 bg-white/[0.075] px-4 py-3 text-[13.5px] leading-[1.55] text-white/90 shadow-[0_18px_44px_rgba(0,0,0,0.20),inset_0_1px_0_rgba(255,255,255,0.075)] backdrop-blur-xl"
+    : "w-[94%] max-w-[94%] rounded-[26px] border border-white/10 bg-white/[0.075] px-4 py-4 text-[13.5px] leading-6 text-white/90 shadow-[0_18px_44px_rgba(0,0,0,0.20),inset_0_1px_0_rgba(255,255,255,0.075)] backdrop-blur-xl";
+
   return (
     <div
       className="fixed inset-0 z-[250] mx-auto flex w-full max-w-[430px] flex-col overflow-hidden bg-slate-950/78 px-2 pb-[max(env(safe-area-inset-bottom),14px)] pt-[max(env(safe-area-inset-top),18px)] text-white backdrop-blur-[2px]"
       data-clara-ai-brain-version={CLARA_AI_BRAIN_VERSION}
+      data-clara-ai-layout-variant={layoutVariant}
     >
       <style>{FINAL_AI_TAB_ICON_KILL_SWITCH}</style>
       <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_18%_10%,rgba(45,212,191,0.26),transparent_34%),radial-gradient(circle_at_88%_12%,rgba(124,58,237,0.32),transparent_38%),linear-gradient(180deg,rgba(2,6,23,0.68),rgba(2,6,23,0.94))]" />
 
-      <main className="min-h-0 flex-1 overflow-y-auto px-0 py-3 [scrollbar-width:none] [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden">
+      <main
+        data-clara-ai-message-viewport="true"
+        className="min-h-0 flex-1 overflow-y-auto px-0 py-3 [scrollbar-width:none] [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden"
+      >
         {visibleMessages.length ? (
-          <div className="flex min-h-full flex-col justify-start gap-3 px-2 pb-28 pt-12">
+          <div
+            data-clara-ai-message-stack="true"
+            className={messageStackClassName}
+          >
             <FloatingCloseButton onClose={onClose} />
             {visibleMessages.map((message, index) => {
               const isUser = message.role === "user";
+              const role = isUser ? "user" : "clara";
               const text = message.text || message.content || "";
               return (
-                <div key={message.id || `${message.role || "message"}-${index}`} className={`flex w-full ${isUser ? "justify-end" : "justify-start"}`}>
-                  <div className={`break-words shadow-[0_14px_34px_rgba(0,0,0,0.16)] [overflow-wrap:break-word] ${isUser ? "max-w-[86%] rounded-[24px] bg-emerald-300 px-4 py-3 text-[13px] font-semibold leading-5 text-slate-950" : "w-[94%] max-w-[94%] rounded-[26px] border border-white/10 bg-white/[0.075] px-4 py-4 text-[13.5px] leading-6 text-white/90 shadow-[0_18px_44px_rgba(0,0,0,0.20),inset_0_1px_0_rgba(255,255,255,0.075)] backdrop-blur-xl"}`}>
+                <div
+                  key={message.id || `${message.role || "message"}-${index}`}
+                  data-clara-ai-message-row="true"
+                  data-clara-ai-message-role={role}
+                  className={`flex min-w-0 w-full ${isUser ? "justify-end" : "justify-start"}`}
+                >
+                  <div
+                    data-clara-ai-message-bubble="true"
+                    data-clara-ai-message-role={role}
+                    className={`min-w-0 break-words shadow-[0_14px_34px_rgba(0,0,0,0.16)] [overflow-wrap:break-word] ${
+                      isUser ? userBubbleClassName : claraBubbleClassName
+                    }`}
+                  >
                     <MessageText text={text} />
                   </div>
                 </div>

--- a/src/components/fresh/main-dashboard/guide/ClaraGuideClaraAiChatPreview.jsx
+++ b/src/components/fresh/main-dashboard/guide/ClaraGuideClaraAiChatPreview.jsx
@@ -6,6 +6,7 @@ import ClaraAiEnvironmentOverlay from "@/components/fresh/main-dashboard/assista
 const LIVE_AI_SELECTOR = "[data-clara-ai-brain-version]";
 const LIVE_AI_CLOSE_SELECTOR = 'button[aria-label="Close CLARA AI mode"]';
 const GUIDE_ACTION_ARM_DELAY = 680;
+const GUIDE_MESSAGE_PANEL_GAP = 20;
 const GUIDE_CHAT_MESSAGES = [
   {
     id: "guide-clara-welcome",
@@ -26,6 +27,7 @@ const GUIDE_CHAT_MESSAGES = [
 
 export default function ClaraGuideClaraAiChatPreview({ onNext }) {
   const shellRef = useRef(null);
+  const guidePanelRef = useRef(null);
   const [actionsArmed, setActionsArmed] = useState(false);
 
   useLayoutEffect(() => {
@@ -38,6 +40,46 @@ export default function ClaraGuideClaraAiChatPreview({ onNext }) {
     return () => {
       guideOverlay.removeAttribute("inert");
       guideOverlay.removeAttribute("aria-disabled");
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    if (typeof window === "undefined") return undefined;
+
+    const shell = shellRef.current;
+    const guidePanel = guidePanelRef.current;
+    const messageStack = shell?.querySelector?.('[data-clara-ai-message-stack="true"]');
+
+    if (!shell || !guidePanel || !messageStack) return undefined;
+
+    const updateMessageOffset = () => {
+      const panelRect = guidePanel.getBoundingClientRect();
+      const stackRect = messageStack.getBoundingClientRect();
+      const topOffset = Math.max(
+        0,
+        Math.ceil(panelRect.bottom - stackRect.top + GUIDE_MESSAGE_PANEL_GAP)
+      );
+
+      shell.style.setProperty("--clara-guide-message-top-offset", `${topOffset}px`);
+    };
+
+    updateMessageOffset();
+    const animationFrame = window.requestAnimationFrame(updateMessageOffset);
+    const resizeObserver =
+      typeof ResizeObserver === "function"
+        ? new ResizeObserver(updateMessageOffset)
+        : null;
+
+    resizeObserver?.observe(guidePanel);
+    window.addEventListener("resize", updateMessageOffset);
+    window.visualViewport?.addEventListener?.("resize", updateMessageOffset);
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame);
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", updateMessageOffset);
+      window.visualViewport?.removeEventListener?.("resize", updateMessageOffset);
+      shell.style.removeProperty("--clara-guide-message-top-offset");
     };
   }, []);
 
@@ -97,14 +139,19 @@ export default function ClaraGuideClaraAiChatPreview({ onNext }) {
       aria-labelledby="clara-guide-ai-preview-title"
     >
       <style>{`
+        [data-clara-guide-ai-preview-shell="true"]
+        [data-clara-ai-layout-variant="guide-preview"]
+        [data-clara-ai-message-stack="true"] {
+          padding-top: var(
+            --clara-guide-message-top-offset,
+            calc(env(safe-area-inset-top) + 246px)
+          ) !important;
+          padding-bottom: 128px !important;
+        }
+
         [data-clara-guide-ai-preview-shell="true"] [data-clara-ai-brain-version] {
           z-index: 10 !important;
           pointer-events: none !important;
-        }
-
-        [data-clara-guide-ai-preview-shell="true"] [data-clara-ai-brain-version] main > div {
-          padding-top: calc(env(safe-area-inset-top) + 218px) !important;
-          padding-bottom: 118px !important;
         }
 
         [data-clara-guide-ai-preview-shell="true"] [data-clara-ai-brain-version]
@@ -122,9 +169,13 @@ export default function ClaraGuideClaraAiChatPreview({ onNext }) {
         isActive
         messages={GUIDE_CHAT_MESSAGES}
         onClose={() => {}}
+        layoutVariant="guide-preview"
       />
 
-      <section className="pointer-events-auto absolute inset-x-4 top-[calc(env(safe-area-inset-top)+14px)] z-30 rounded-[28px] border border-cyan-100/22 bg-[linear-gradient(145deg,rgba(5,18,36,0.985),rgba(10,22,54,0.985)_52%,rgba(27,18,65,0.985))] px-5 py-4 shadow-[0_22px_70px_rgba(0,0,0,0.68),0_0_38px_rgba(34,211,238,0.15)] backdrop-blur-2xl">
+      <section
+        ref={guidePanelRef}
+        className="pointer-events-auto absolute inset-x-4 top-[calc(env(safe-area-inset-top)+14px)] z-30 rounded-[28px] border border-cyan-100/22 bg-[linear-gradient(145deg,rgba(5,18,36,0.985),rgba(10,22,54,0.985)_52%,rgba(27,18,65,0.985))] px-5 py-4 shadow-[0_22px_70px_rgba(0,0,0,0.68),0_0_38px_rgba(34,211,238,0.15)] backdrop-blur-2xl"
+      >
         <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-[28px] bg-[radial-gradient(circle_at_12%_0%,rgba(45,212,191,0.17),transparent_38%),radial-gradient(circle_at_92%_14%,rgba(124,58,237,0.22),transparent_40%)]" />
 
         <div className="relative pr-10">


### PR DESCRIPTION
## Summary
- add a Guide-preview-only layout variant to the shared CLARA AI overlay
- add stable data selectors for the message viewport, stack, rows, and bubbles
- make Guide preview bubbles use natural content width and improved spacing
- dynamically position the message stack below the Guide instruction panel using its measured height
- preserve the live CLARA AI layout and all Guide Mode logic

## Scope protection
- no Financial Carousel or dashboard-card changes
- no background visibility changes
- no Money Left changes
- no input-bar behavior changes
- no message-content or progression changes

## Verification targets
- 360×800
- 375×812
- 390×844
- 412×915
- 430×932