### PR TITLE
Add premium Daily Money Tip flip sound

### DIFF
--- a/src/lib/dailyTipFlipSound.js
+++ b/src/lib/dailyTipFlipSound.js
@@ -1,0 +1,139 @@
+const CLARA_SOUND_STORAGE_KEY = "clara:sound-enabled";
+const CLARA_SOUND_VOLUME_KEY = "clara:sound-volume";
+
+let audioContext = null;
+let flipNoiseBuffer = null;
+let lastPlayedAt = 0;
+
+function getAudioContext() {
+  if (typeof window === "undefined") return null;
+
+  const AudioCtx = window.AudioContext || window.webkitAudioContext;
+  if (!AudioCtx) return null;
+
+  if (!audioContext) {
+    audioContext = new AudioCtx();
+  }
+
+  return audioContext;
+}
+
+function isSoundEnabled() {
+  try {
+    return window.localStorage?.getItem(CLARA_SOUND_STORAGE_KEY) !== "false";
+  } catch {
+    return true;
+  }
+}
+
+function getSoundVolume() {
+  try {
+    const saved = Number(window.localStorage?.getItem(CLARA_SOUND_VOLUME_KEY));
+    if (Number.isFinite(saved)) {
+      return Math.max(0, Math.min(saved, 1));
+    }
+  } catch {}
+
+  return 1;
+}
+
+function getFlipNoiseBuffer(context) {
+  if (flipNoiseBuffer?.sampleRate === context.sampleRate) {
+    return flipNoiseBuffer;
+  }
+
+  const duration = 0.24;
+  const frameCount = Math.max(1, Math.floor(context.sampleRate * duration));
+  const buffer = context.createBuffer(1, frameCount, context.sampleRate);
+  const samples = buffer.getChannelData(0);
+  let smoothedNoise = 0;
+
+  for (let index = 0; index < frameCount; index += 1) {
+    const progress = index / frameCount;
+    const whiteNoise = Math.random() * 2 - 1;
+    smoothedNoise = smoothedNoise * 0.78 + whiteNoise * 0.22;
+
+    const envelope = Math.sin(Math.PI * progress);
+    samples[index] = (whiteNoise * 0.52 + smoothedNoise * 0.48) * envelope;
+  }
+
+  flipNoiseBuffer = buffer;
+  return flipNoiseBuffer;
+}
+
+function startFlipSound(context, direction) {
+  const opening = direction !== "close";
+  const start = context.currentTime;
+  const duration = opening ? 0.22 : 0.18;
+  const masterVolume = getSoundVolume();
+
+  if (masterVolume <= 0) return;
+
+  const source = context.createBufferSource();
+  const filter = context.createBiquadFilter();
+  const gain = context.createGain();
+
+  source.buffer = getFlipNoiseBuffer(context);
+
+  filter.type = "bandpass";
+  filter.Q.setValueAtTime(0.85, start);
+  filter.frequency.setValueAtTime(opening ? 820 : 2200, start);
+  filter.frequency.exponentialRampToValueAtTime(opening ? 2500 : 900, start + duration);
+
+  gain.gain.setValueAtTime(0.0001, start);
+  gain.gain.exponentialRampToValueAtTime(
+    Math.max(0.0001, masterVolume * (opening ? 0.13 : 0.085)),
+    start + 0.018
+  );
+  gain.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+
+  source.connect(filter);
+  filter.connect(gain);
+  gain.connect(context.destination);
+
+  source.start(start);
+  source.stop(start + duration + 0.02);
+
+  if (!opening) return;
+
+  const shimmer = context.createOscillator();
+  const shimmerGain = context.createGain();
+
+  shimmer.type = "sine";
+  shimmer.frequency.setValueAtTime(780, start + 0.06);
+  shimmer.frequency.exponentialRampToValueAtTime(1160, start + 0.17);
+
+  shimmerGain.gain.setValueAtTime(0.0001, start + 0.055);
+  shimmerGain.gain.exponentialRampToValueAtTime(
+    Math.max(0.0001, masterVolume * 0.025),
+    start + 0.09
+  );
+  shimmerGain.gain.exponentialRampToValueAtTime(0.0001, start + 0.2);
+
+  shimmer.connect(shimmerGain);
+  shimmerGain.connect(context.destination);
+  shimmer.start(start + 0.055);
+  shimmer.stop(start + 0.22);
+}
+
+export function playDailyTipFlipSound({ direction = "open" } = {}) {
+  if (!isSoundEnabled()) return;
+
+  const now = Date.now();
+  if (now - lastPlayedAt < 120) return;
+  lastPlayedAt = now;
+
+  const context = getAudioContext();
+  if (!context) return;
+
+  const play = () => startFlipSound(context, direction);
+
+  if (context.state === "suspended") {
+    context.resume().then(play).catch((error) => {
+      console.warn("Daily Tip flip sound was blocked:", error?.message || error);
+    });
+    return;
+  }
+
+  play();
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,6 +7,7 @@ import { queryClientInstance } from "@/lib/query-client";
 import { ThemeProvider } from "@/theme/ThemeProvider";
 import { installClaraGlobalClickSound } from "@/lib/claraSoundSystem";
 import { installNativeNotificationListeners } from "@/lib/notifications/nativePushNotifications";
+import { installDailyTipFlipSound } from "./runtime/installDailyTipFlipSound";
 import { installClaraGuideDemoPatches } from "./runtime/installClaraGuideDemoPatches";
 import {
   clearClaraGuideFeatureClasses,
@@ -47,6 +48,12 @@ window.CLARA_BILLING = window.CLARA_BILLING || {};
     console.warn("Billing auto-init failed:", error);
   }
 })();
+
+try {
+  installDailyTipFlipSound();
+} catch (error) {
+  console.warn("Daily Tip flip sound failed to init:", error);
+}
 
 try {
   installClaraGlobalClickSound();

--- a/src/runtime/installDailyTipFlipSound.js
+++ b/src/runtime/installDailyTipFlipSound.js
@@ -1,7 +1,7 @@
 import { playDailyTipFlipSound } from "@/lib/dailyTipFlipSound";
 
 const DAILY_TIP_CARD_SELECTOR = "[data-clara-daily-tip-card='true']";
-const FLIP_SOUND_LOCK_MS = 650;
+const FLIP_SOUND_LOCK_MS = 180;
 
 let installed = false;
 const lastPlayedByCard = new WeakMap();

--- a/src/runtime/installDailyTipFlipSound.js
+++ b/src/runtime/installDailyTipFlipSound.js
@@ -1,0 +1,71 @@
+import { playDailyTipFlipSound } from "@/lib/dailyTipFlipSound";
+
+const DAILY_TIP_CARD_SELECTOR = "[data-clara-daily-tip-card='true']";
+const FLIP_SOUND_LOCK_MS = 650;
+
+let installed = false;
+const lastPlayedByCard = new WeakMap();
+
+function findInteractiveCard(target) {
+  const card = target?.closest?.(DAILY_TIP_CARD_SELECTOR);
+  if (!card) return null;
+
+  const interactive = target?.closest?.("[role='button']");
+  if (!interactive || !card.contains(interactive)) return null;
+
+  return interactive;
+}
+
+function shouldSkipFlipSound(interactive) {
+  if (!interactive) return true;
+  if (interactive.getAttribute("aria-disabled") === "true") return true;
+
+  const label = String(interactive.getAttribute("aria-label") || "").toLowerCase();
+  if (label.includes("guide step") || label.includes("unlock")) return true;
+
+  const now = Date.now();
+  const lastPlayedAt = lastPlayedByCard.get(interactive) || 0;
+  if (now - lastPlayedAt < FLIP_SOUND_LOCK_MS) return true;
+
+  lastPlayedByCard.set(interactive, now);
+  return false;
+}
+
+function playForCard(interactive) {
+  if (shouldSkipFlipSound(interactive)) return;
+
+  // Suppress CLARA's generic global click sound for this specific interaction.
+  interactive.setAttribute("data-clara-no-sound", "true");
+
+  const isCurrentlyRevealed = interactive.getAttribute("aria-pressed") === "true";
+  playDailyTipFlipSound({ direction: isCurrentlyRevealed ? "close" : "open" });
+}
+
+export function installDailyTipFlipSound() {
+  if (installed || typeof document === "undefined") return () => {};
+  installed = true;
+
+  const handleClick = (event) => {
+    const interactive = findInteractiveCard(event.target);
+    if (!interactive) return;
+    playForCard(interactive);
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.repeat || (event.key !== "Enter" && event.key !== " ")) return;
+
+    const interactive = findInteractiveCard(event.target);
+    if (!interactive) return;
+    playForCard(interactive);
+  };
+
+  // Install before the generic global sound listener so this interaction can opt out.
+  document.addEventListener("click", handleClick, true);
+  document.addEventListener("keydown", handleKeyDown, true);
+
+  return () => {
+    document.removeEventListener("click", handleClick, true);
+    document.removeEventListener("keydown", handleKeyDown, true);
+    installed = false;
+  };
+}


### PR DESCRIPTION
## What changed
- Adds a synthesized, license-free flip sound using Web Audio
- Uses a brighter reveal sound and a quieter flip-back sound
- Hooks only into the active Daily Money Tip card
- Suppresses the existing generic global click sound for the flip
- Prevents duplicate playback during the card's animation lock
- Skips the custom flip sound for Guide Mode and locked Committed Version behavior
- Supports mouse, touch-generated clicks, Enter, and Space

## No manual asset needed
There is no MP3/WAV file to download or maintain. The micro-sound is generated locally at runtime and follows CLARA's existing sound enabled/volume settings.

## Validation
- New JavaScript modules pass `node --check`
- Branch is based directly on current `main` with no divergence