### PR TITLE
Fix Daily Tip flip sound

### DIFF
--- a/src/lib/dailyTipFlipSound.js
+++ b/src/lib/dailyTipFlipSound.js
@@ -1,6 +1,3 @@
-const CLARA_SOUND_STORAGE_KEY = "clara:sound-enabled";
-const CLARA_SOUND_VOLUME_KEY = "clara:sound-volume";
-
 let audioContext = null;
 let flipNoiseBuffer = null;
 let lastPlayedAt = 0;
@@ -18,25 +15,6 @@ function getAudioContext() {
   return audioContext;
 }
 
-function isSoundEnabled() {
-  try {
-    return window.localStorage?.getItem(CLARA_SOUND_STORAGE_KEY) !== "false";
-  } catch {
-    return true;
-  }
-}
-
-function getSoundVolume() {
-  try {
-    const saved = Number(window.localStorage?.getItem(CLARA_SOUND_VOLUME_KEY));
-    if (Number.isFinite(saved)) {
-      return Math.max(0, Math.min(saved, 1));
-    }
-  } catch {}
-
-  return 1;
-}
-
 function getFlipNoiseBuffer(context) {
   if (flipNoiseBuffer?.sampleRate === context.sampleRate) {
     return flipNoiseBuffer;
@@ -51,48 +29,71 @@ function getFlipNoiseBuffer(context) {
   for (let index = 0; index < frameCount; index += 1) {
     const progress = index / frameCount;
     const whiteNoise = Math.random() * 2 - 1;
-    smoothedNoise = smoothedNoise * 0.78 + whiteNoise * 0.22;
+    smoothedNoise = smoothedNoise * 0.72 + whiteNoise * 0.28;
 
     const envelope = Math.sin(Math.PI * progress);
-    samples[index] = (whiteNoise * 0.52 + smoothedNoise * 0.48) * envelope;
+    samples[index] = (whiteNoise * 0.38 + smoothedNoise * 0.62) * envelope;
   }
 
   flipNoiseBuffer = buffer;
   return flipNoiseBuffer;
 }
 
+function connectToOutput(context, node, gainValue) {
+  const output = context.createGain();
+  output.gain.setValueAtTime(gainValue, context.currentTime);
+  node.connect(output);
+  output.connect(context.destination);
+  return output;
+}
+
 function startFlipSound(context, direction) {
   const opening = direction !== "close";
   const start = context.currentTime;
-  const duration = opening ? 0.22 : 0.18;
-  const masterVolume = getSoundVolume();
-
-  if (masterVolume <= 0) return;
+  const duration = opening ? 0.24 : 0.2;
 
   const source = context.createBufferSource();
-  const filter = context.createBiquadFilter();
-  const gain = context.createGain();
+  const highPass = context.createBiquadFilter();
+  const lowPass = context.createBiquadFilter();
+  const noiseGain = context.createGain();
 
   source.buffer = getFlipNoiseBuffer(context);
 
-  filter.type = "bandpass";
-  filter.Q.setValueAtTime(0.85, start);
-  filter.frequency.setValueAtTime(opening ? 820 : 2200, start);
-  filter.frequency.exponentialRampToValueAtTime(opening ? 2500 : 900, start + duration);
+  highPass.type = "highpass";
+  highPass.frequency.setValueAtTime(420, start);
 
-  gain.gain.setValueAtTime(0.0001, start);
-  gain.gain.exponentialRampToValueAtTime(
-    Math.max(0.0001, masterVolume * (opening ? 0.13 : 0.085)),
-    start + 0.018
-  );
-  gain.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+  lowPass.type = "lowpass";
+  lowPass.Q.setValueAtTime(0.7, start);
+  lowPass.frequency.setValueAtTime(opening ? 1100 : 2600, start);
+  lowPass.frequency.exponentialRampToValueAtTime(opening ? 3200 : 900, start + duration);
 
-  source.connect(filter);
-  filter.connect(gain);
-  gain.connect(context.destination);
+  noiseGain.gain.setValueAtTime(0.0001, start);
+  noiseGain.gain.exponentialRampToValueAtTime(opening ? 0.16 : 0.12, start + 0.015);
+  noiseGain.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+
+  source.connect(highPass);
+  highPass.connect(lowPass);
+  lowPass.connect(noiseGain);
+  connectToOutput(context, noiseGain, 0.9);
 
   source.start(start);
-  source.stop(start + duration + 0.02);
+  source.stop(start + duration + 0.03);
+
+  const bodyTone = context.createOscillator();
+  const bodyGain = context.createGain();
+
+  bodyTone.type = "triangle";
+  bodyTone.frequency.setValueAtTime(opening ? 520 : 980, start);
+  bodyTone.frequency.exponentialRampToValueAtTime(opening ? 980 : 520, start + duration * 0.82);
+
+  bodyGain.gain.setValueAtTime(0.0001, start);
+  bodyGain.gain.exponentialRampToValueAtTime(opening ? 0.14 : 0.1, start + 0.012);
+  bodyGain.gain.exponentialRampToValueAtTime(0.0001, start + duration * 0.88);
+
+  bodyTone.connect(bodyGain);
+  connectToOutput(context, bodyGain, 0.8);
+  bodyTone.start(start);
+  bodyTone.stop(start + duration);
 
   if (!opening) return;
 
@@ -100,25 +101,20 @@ function startFlipSound(context, direction) {
   const shimmerGain = context.createGain();
 
   shimmer.type = "sine";
-  shimmer.frequency.setValueAtTime(780, start + 0.06);
-  shimmer.frequency.exponentialRampToValueAtTime(1160, start + 0.17);
+  shimmer.frequency.setValueAtTime(1180, start + 0.055);
+  shimmer.frequency.exponentialRampToValueAtTime(1540, start + 0.18);
 
-  shimmerGain.gain.setValueAtTime(0.0001, start + 0.055);
-  shimmerGain.gain.exponentialRampToValueAtTime(
-    Math.max(0.0001, masterVolume * 0.025),
-    start + 0.09
-  );
-  shimmerGain.gain.exponentialRampToValueAtTime(0.0001, start + 0.2);
+  shimmerGain.gain.setValueAtTime(0.0001, start + 0.05);
+  shimmerGain.gain.exponentialRampToValueAtTime(0.055, start + 0.085);
+  shimmerGain.gain.exponentialRampToValueAtTime(0.0001, start + 0.22);
 
   shimmer.connect(shimmerGain);
-  shimmerGain.connect(context.destination);
-  shimmer.start(start + 0.055);
-  shimmer.stop(start + 0.22);
+  connectToOutput(context, shimmerGain, 0.75);
+  shimmer.start(start + 0.05);
+  shimmer.stop(start + 0.23);
 }
 
 export function playDailyTipFlipSound({ direction = "open" } = {}) {
-  if (!isSoundEnabled()) return;
-
   const now = Date.now();
   if (now - lastPlayedAt < 120) return;
   lastPlayedAt = now;
@@ -126,14 +122,11 @@ export function playDailyTipFlipSound({ direction = "open" } = {}) {
   const context = getAudioContext();
   if (!context) return;
 
-  const play = () => startFlipSound(context, direction);
-
   if (context.state === "suspended") {
-    context.resume().then(play).catch((error) => {
+    context.resume().catch((error) => {
       console.warn("Daily Tip flip sound was blocked:", error?.message || error);
     });
-    return;
   }
 
-  play();
+  startFlipSound(context, direction);
 }


### PR DESCRIPTION
Makes the Daily Money Tip flip sound reliably audible on phone speakers and starts it directly from the user tap. Removes dependence on stale hidden sound preferences that could keep the interaction silent.