### PR TITLE
Remove Daily Tip sound limits

### DIFF
--- a/src/lib/dailyTipFlipSound.js
+++ b/src/lib/dailyTipFlipSound.js
@@ -3,7 +3,6 @@ let openFlipBuffer = null;
 let closeFlipBuffer = null;
 let resumePromise = null;
 let activeSource = null;
-let lastPlayedAt = 0;
 
 function getAudioContext() {
   if (typeof window === "undefined") return null;
@@ -191,10 +190,6 @@ function startFlipSound(context, direction) {
 }
 
 export function playDailyTipFlipSound({ direction = "open" } = {}) {
-  const now = Date.now();
-  if (now - lastPlayedAt < 140) return;
-  lastPlayedAt = now;
-
   const context = primeDailyTipFlipSound();
   if (!context) return;
 

--- a/src/runtime/installDailyTipFlipSound.js
+++ b/src/runtime/installDailyTipFlipSound.js
@@ -4,10 +4,8 @@ import {
 } from "@/lib/dailyTipFlipSound";
 
 const DAILY_TIP_CARD_SELECTOR = "[data-clara-daily-tip-card='true']";
-const FLIP_SOUND_LOCK_MS = 180;
 
 let installed = false;
-const lastPlayedByCard = new WeakMap();
 
 function findInteractiveCard(target) {
   const card = target?.closest?.(DAILY_TIP_CARD_SELECTOR);
@@ -27,29 +25,16 @@ function isNonFlipInteraction(interactive) {
   return label.includes("guide step") || label.includes("unlock");
 }
 
-function shouldSkipFlipSound(interactive) {
-  if (isNonFlipInteraction(interactive)) return true;
-
-  const now = Date.now();
-  const lastPlayedAt = lastPlayedByCard.get(interactive) || 0;
-  if (now - lastPlayedAt < FLIP_SOUND_LOCK_MS) return true;
-
-  lastPlayedByCard.set(interactive, now);
-  return false;
-}
-
 function prepareCardSound(interactive) {
   if (isNonFlipInteraction(interactive)) return;
 
-  // Wake the low-latency audio context during the earliest user gesture.
   interactive.setAttribute("data-clara-no-sound", "true");
   primeDailyTipFlipSound({ resume: true });
 }
 
 function playForCard(interactive) {
-  if (shouldSkipFlipSound(interactive)) return;
+  if (isNonFlipInteraction(interactive)) return;
 
-  // Suppress CLARA's generic global click sound for this specific interaction.
   interactive.setAttribute("data-clara-no-sound", "true");
 
   const isCurrentlyRevealed = interactive.getAttribute("aria-pressed") === "true";
@@ -60,7 +45,6 @@ export function installDailyTipFlipSound() {
   if (installed || typeof document === "undefined") return () => {};
   installed = true;
 
-  // Build the sound buffer during app startup so the first flip has less work to do.
   primeDailyTipFlipSound();
 
   const handlePointerDown = (event) => {
@@ -87,7 +71,6 @@ export function installDailyTipFlipSound() {
     playForCard(interactive);
   };
 
-  // Install before the generic global sound listener so this interaction can opt out.
   document.addEventListener("pointerdown", handlePointerDown, true);
   document.addEventListener("click", handleClick, true);
   document.addEventListener("keydown", handleKeyDown, true);


### PR DESCRIPTION
Removes both hidden cooldown layers so every valid Daily Tip open or close flip can play its sound indefinitely. The card animation lock remains the only guard against duplicate taps during an active flip.