### PR TITLE
Redesign expanded budget category cards

### DIFF
--- a/src/components/financial-carousel/cards/budget/logic/useBudgetCardLogic.js
+++ b/src/components/financial-carousel/cards/budget/logic/useBudgetCardLogic.js
@@ -183,23 +183,40 @@ export default function useBudgetCardLogic({
 
   const categories = useMemo(() => {
     return [...rawCategories]
-      .map((item) => ({ ...item, risk: getCategoryRisk(item) }))
+      .map((item, sourceIndex) => ({
+        ...item,
+        risk: getCategoryRisk(item),
+        __sourceIndex: sourceIndex,
+      }))
       .sort((a, b) => {
         const aProtected = isProtectedBudgetCommitment(a);
         const bProtected = isProtectedBudgetCommitment(b);
 
         if (aProtected !== bProtected) return aProtected ? -1 : 1;
-        if (aProtected && bProtected) return 0;
 
-        const aAllocated = safeNumber(a?.allocated ?? a?.allocated_amount);
-        const bAllocated = safeNumber(b?.allocated ?? b?.allocated_amount);
-        const aSpent = safeNumber(a?.spent ?? a?.spent_amount ?? a?.used);
-        const bSpent = safeNumber(b?.spent ?? b?.spent_amount ?? b?.used);
-        const aPct = aAllocated > 0 ? aSpent / aAllocated : 0;
-        const bPct = bAllocated > 0 ? bSpent / bAllocated : 0;
+        const aOrderValue =
+          a?.sortOrder ??
+          a?.sort_order ??
+          a?.displayOrder ??
+          a?.display_order ??
+          a?.position;
+        const bOrderValue =
+          b?.sortOrder ??
+          b?.sort_order ??
+          b?.displayOrder ??
+          b?.display_order ??
+          b?.position;
+        const aHasOrder = hasValue(aOrderValue) && Number.isFinite(Number(aOrderValue));
+        const bHasOrder = hasValue(bOrderValue) && Number.isFinite(Number(bOrderValue));
 
-        return bPct - aPct || bSpent - aSpent;
-      });
+        if (aHasOrder && bHasOrder && Number(aOrderValue) !== Number(bOrderValue)) {
+          return Number(aOrderValue) - Number(bOrderValue);
+        }
+        if (aHasOrder !== bHasOrder) return aHasOrder ? -1 : 1;
+
+        return a.__sourceIndex - b.__sourceIndex;
+      })
+      .map(({ __sourceIndex, ...item }) => item);
   }, [rawCategories]);
 
   const categorySpent = categories.reduce(
@@ -231,6 +248,16 @@ export default function useBudgetCardLogic({
   const allocated = categories.length > 0
     ? categories.reduce((sum, item) => sum + safeNumber(item?.allocated ?? item?.allocated_amount), 0)
     : safeNumber(activeBudget?.allocated ?? activeBudget?.allocated_amount ?? activeBudget?.allocated_total ?? activeBudget?.totalAllocated);
+  const reserveDenominator = declared > 0 ? declared : allocated;
+  const displayCategories = categories.map((item) => {
+    const categoryAllocated = safeNumber(item?.allocated ?? item?.allocated_amount);
+    return {
+      ...item,
+      declaredBudget: declared,
+      totalAllocated: allocated,
+      reserveShare: reserveDenominator > 0 ? categoryAllocated / reserveDenominator : 0,
+    };
+  });
   const spent = activeBudgetSpent;
   const protectedCommitments = safeNumber(
     activeBudget?.totalProtectedCommitments ??
@@ -279,7 +306,7 @@ export default function useBudgetCardLogic({
   return {
     showModal,
     setShowModal,
-    categories,
+    categories: displayCategories,
     declared,
     allocated,
     spent,

--- a/src/components/financial-carousel/cards/budget/ui/BudgetCategoryItem.jsx
+++ b/src/components/financial-carousel/cards/budget/ui/BudgetCategoryItem.jsx
@@ -1,14 +1,131 @@
-import { Edit3, Trash2 } from "lucide-react";
+import { useState } from "react";
+import {
+  Car,
+  CreditCard,
+  Edit3,
+  Film,
+  Fuel,
+  GraduationCap,
+  HeartPulse,
+  Home,
+  MoreHorizontal,
+  Receipt,
+  ShieldCheck,
+  ShoppingBag,
+  ShoppingCart,
+  Trash2,
+  Utensils,
+  Wallet,
+  Zap,
+} from "lucide-react";
 import {
   fmt,
   safeNumber,
 } from "@/components/financial-carousel/cards/budget/logic/useBudgetCardLogic";
 
-const glassPanel =
-  "relative overflow-hidden border border-white/[0.075] bg-[linear-gradient(135deg,rgba(255,255,255,0.065),rgba(255,255,255,0.035)_46%,rgba(0,0,0,0.055))] shadow-[inset_0_1px_0_rgba(255,255,255,0.07),0_10px_22px_rgba(0,0,0,0.12)] backdrop-blur-sm";
+const RESERVE_TONES = {
+  neutral: { name: "Neutral Slate", rgb: "148 163 184" },
+  frost: { name: "Frost Blue", rgb: "125 211 252" },
+  cyan: { name: "Cyan", rgb: "34 211 238" },
+  teal: { name: "Aqua Teal", rgb: "45 212 191" },
+  sapphire: { name: "Sapphire", rgb: "96 165 250" },
+  violet: { name: "Royal Violet", rgb: "167 139 250" },
+  gold: { name: "Premium Gold", rgb: "232 201 122" },
+};
 
-const softButton =
-  "rounded-xl border border-white/[0.075] bg-white/[0.055] text-white/76 transition hover:border-cyan-100/20 hover:bg-white/[0.09] hover:text-white disabled:opacity-50";
+const STATUS_STYLES = {
+  healthy: "border-emerald-300/18 bg-emerald-400/[0.09] text-emerald-100/90",
+  warning: "border-amber-300/22 bg-amber-400/[0.11] text-amber-100",
+  danger: "border-rose-300/22 bg-rose-400/[0.11] text-rose-100",
+  protected: "border-white/[0.09] bg-white/[0.045] text-white/66",
+};
+
+function getReserveTone(item, allocated) {
+  const explicitShare = safeNumber(item?.reserveShare ?? item?.reserve_share);
+  const declared = safeNumber(
+    item?.declaredBudget ??
+      item?.declared_budget ??
+      item?.cycleBudget ??
+      item?.cycle_budget
+  );
+  const totalAllocated = safeNumber(item?.totalAllocated ?? item?.total_allocated);
+  const denominator = declared > 0 ? declared : totalAllocated;
+  const share = explicitShare > 0
+    ? explicitShare
+    : denominator > 0
+      ? allocated / denominator
+      : 0;
+
+  if (allocated <= 0 || share <= 0) return { ...RESERVE_TONES.neutral, share: 0 };
+  if (share <= 0.05) return { ...RESERVE_TONES.frost, share };
+  if (share <= 0.10) return { ...RESERVE_TONES.cyan, share };
+  if (share <= 0.20) return { ...RESERVE_TONES.teal, share };
+  if (share <= 0.35) return { ...RESERVE_TONES.sapphire, share };
+  if (share <= 0.50) return { ...RESERVE_TONES.violet, share };
+  return { ...RESERVE_TONES.gold, share };
+}
+
+function getCategoryIcon(title = "", isProtected = false) {
+  if (isProtected) return ShieldCheck;
+
+  const value = String(title).trim().toLowerCase();
+  if (/food|meal|dining|restaurant/.test(value)) return Utensils;
+  if (/grocery|groceries|market/.test(value)) return ShoppingCart;
+  if (/bill|utility|internet|phone|subscription/.test(value)) return Receipt;
+  if (/electric|power|water/.test(value)) return Zap;
+  if (/rent|house|home|housing/.test(value)) return Home;
+  if (/transport|commute|car|jeep|taxi|grab|fare/.test(value)) return Car;
+  if (/gas|fuel/.test(value)) return Fuel;
+  if (/health|medical|medicine|doctor/.test(value)) return HeartPulse;
+  if (/school|education|tuition|study/.test(value)) return GraduationCap;
+  if (/movie|entertainment|fun|leisure/.test(value)) return Film;
+  if (/shopping|clothes|clothing/.test(value)) return ShoppingBag;
+  if (/debt|loan|credit/.test(value)) return CreditCard;
+  if (/saving|emergency|reserve/.test(value)) return ShieldCheck;
+  return Wallet;
+}
+
+function getHealthState({ allocated, spent, isProtected }) {
+  if (isProtected) {
+    return {
+      state: "protected",
+      label: "Protected",
+      progressRgb: null,
+      ratio: allocated > 0 ? 1 : 0,
+    };
+  }
+
+  const ratio = allocated > 0
+    ? spent / allocated
+    : spent > 0
+      ? 1
+      : 0;
+
+  if (ratio >= 1) {
+    return {
+      state: "danger",
+      label: spent > allocated ? "Over budget" : "Limit reached",
+      progressRgb: "248 113 113",
+      ratio,
+    };
+  }
+
+  if (ratio >= 0.8) {
+    return {
+      state: "warning",
+      label: "Near limit",
+      progressRgb: "251 191 36",
+      ratio,
+    };
+  }
+
+  return {
+    state: "healthy",
+    label: "Safe",
+    progressRgb: null,
+    ratio,
+  };
+}
 
 export default function BudgetCategoryItem({
   item,
@@ -16,82 +133,201 @@ export default function BudgetCategoryItem({
   onEditBudgetCategory,
   onDeleteBudgetCategory,
 }) {
+  const [menuOpen, setMenuOpen] = useState(false);
   const isProtected =
     item?.isProtectedCommitment === true ||
     item?.is_protected_commitment === true;
-  const categoryAllocated = safeNumber(item.allocated ?? item.allocated_amount);
-  const categorySpent = safeNumber(item.spent ?? item.spent_amount);
-  const categoryRemaining = Math.max(categoryAllocated - categorySpent, 0);
-  const categoryProgress =
-    categoryAllocated > 0 ? Math.min(100, (categorySpent / categoryAllocated) * 100) : 0;
-  const displayProgress = isProtected && categoryAllocated > 0 ? 100 : categoryProgress;
-  const progressLabel = isProtected
-    ? "100% protected"
-    : `${Math.round(categoryProgress)}% used`;
-  const amountLabel = isProtected
-    ? `${fmt(categoryAllocated)} reserved`
-    : `${fmt(categoryAllocated)} allocated`;
+  const categoryAllocated = safeNumber(item?.allocated ?? item?.allocated_amount);
+  const categorySpent = safeNumber(item?.spent ?? item?.spent_amount ?? item?.used);
+  const rawRemaining = categoryAllocated - categorySpent;
+  const categoryRemaining = Math.max(rawRemaining, 0);
+  const overAmount = Math.max(categorySpent - categoryAllocated, 0);
+  const reserveTone = getReserveTone(item, categoryAllocated);
+  const health = getHealthState({
+    allocated: categoryAllocated,
+    spent: categorySpent,
+    isProtected,
+  });
+  const Icon = getCategoryIcon(item?.title, isProtected);
+  const progressRgb = health.progressRgb || reserveTone.rgb;
+  const displayProgress = Math.min(Math.max(health.ratio * 100, 0), 100);
+  const usagePercent = categoryAllocated > 0
+    ? Math.round((categorySpent / categoryAllocated) * 100)
+    : 0;
+  const heroAmount = isProtected
+    ? categoryAllocated
+    : overAmount > 0
+      ? overAmount
+      : categoryRemaining;
+  const heroLabel = isProtected
+    ? "Protected reserve"
+    : overAmount > 0
+      ? "Over budget"
+      : "Remaining";
+  const heroTone = health.state === "danger"
+    ? "text-rose-100"
+    : "text-white/96";
+
+  const closeAndEdit = () => {
+    setMenuOpen(false);
+    onEditBudgetCategory?.(item);
+  };
+
+  const closeAndDelete = () => {
+    setMenuOpen(false);
+    onDeleteBudgetCategory?.(item);
+  };
 
   return (
-    <div className={`rounded-[20px] p-3.5 ${glassPanel}`}>
-      <div className="pointer-events-none absolute inset-x-4 top-0 h-px bg-gradient-to-r from-transparent via-white/16 to-transparent" />
-      <div className="pointer-events-none absolute -right-8 -top-10 h-24 w-24 rounded-full bg-violet-400/[0.08] blur-2xl" />
-      <div className="pointer-events-none absolute -left-10 bottom-[-42px] h-24 w-24 rounded-full bg-cyan-300/[0.07] blur-2xl" />
-
-      <div className="relative mb-2.5 flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <p className="truncate text-[15px] font-black leading-tight tracking-[-0.02em] text-white/94">
-            {item.title}
-          </p>
-          <p className="mt-1 text-[12px] font-semibold leading-relaxed text-white/66">
-            {isProtected
-              ? `${fmt(categoryAllocated)} reserved • protected first`
-              : `${fmt(categorySpent)} spent • ${fmt(categoryRemaining)} left`}
-          </p>
-        </div>
-
-        <div className="flex shrink-0 items-center gap-1.5">
-          {isProtected ? (
-            <span className="rounded-xl border border-emerald-300/20 bg-emerald-400/10 px-2.5 py-1 text-[10px] font-black text-emerald-100">
-              Protected
-            </span>
-          ) : (
-            <>
-              <button
-                type="button"
-                onClick={() => onEditBudgetCategory?.(item)}
-                disabled={financeActionLoading}
-                className={`${softButton} flex h-8 w-8 items-center justify-center`}
-                aria-label={`Edit ${item.title}`}
-              >
-                <Edit3 className="h-3.5 w-3.5" />
-              </button>
-
-              <button
-                type="button"
-                onClick={() => onDeleteBudgetCategory?.(item)}
-                disabled={financeActionLoading}
-                className="flex h-8 w-8 items-center justify-center rounded-xl border border-rose-200/[0.14] bg-rose-400/[0.075] text-rose-100/78 transition hover:border-rose-200/24 hover:bg-rose-400/[0.13] hover:text-rose-50 disabled:opacity-50"
-                aria-label={`Delete ${item.title}`}
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-              </button>
-            </>
-          )}
-        </div>
-      </div>
-
-      <div className="relative h-1.5 overflow-hidden rounded-full border border-white/[0.055] bg-black/[0.22]">
+    <article
+      className="relative rounded-[20px] border p-4 pl-[18px] transition-[border-color,box-shadow,transform] duration-300 hover:-translate-y-px"
+      style={{
+        borderColor: `rgb(${reserveTone.rgb} / 0.22)`,
+        background: `radial-gradient(circle at 12% 0%, rgb(${reserveTone.rgb} / 0.115), transparent 38%), linear-gradient(145deg, rgba(8,20,38,0.97), rgba(8,13,31,0.985))`,
+        boxShadow: `inset 0 1px 0 rgba(255,255,255,0.065), 0 12px 26px rgba(0,0,0,0.22), 0 0 22px rgb(${reserveTone.rgb} / 0.045)`,
+      }}
+    >
+      <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]">
         <div
-          className="h-full rounded-full bg-gradient-to-r from-emerald-300 via-cyan-300 to-sky-300 shadow-[0_0_12px_rgba(94,234,212,0.24)] transition-all duration-500"
-          style={{ width: `${displayProgress}%` }}
+          className="absolute inset-x-5 top-0 h-px"
+          style={{
+            background: `linear-gradient(90deg, transparent, rgb(${reserveTone.rgb} / 0.42), transparent)`,
+          }}
+        />
+        <div
+          className="absolute -right-10 -top-12 h-28 w-28 rounded-full blur-3xl"
+          style={{ backgroundColor: `rgb(${reserveTone.rgb} / 0.09)` }}
         />
       </div>
 
-      <div className="relative mt-2.5 flex items-center justify-between text-[10px] font-black text-white/58">
-        <span>{progressLabel}</span>
-        <span>{amountLabel}</span>
+      <div
+        className="pointer-events-none absolute bottom-3 left-0 top-3 w-[3px] rounded-r-full"
+        style={{
+          backgroundColor: `rgb(${reserveTone.rgb})`,
+          boxShadow: `0 0 14px rgb(${reserveTone.rgb} / 0.30)`,
+        }}
+      />
+
+      <div className="relative flex items-start justify-between gap-3">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <div
+            className="grid h-10 w-10 shrink-0 place-items-center rounded-[14px] border"
+            style={{
+              color: `rgb(${reserveTone.rgb})`,
+              borderColor: `rgb(${reserveTone.rgb} / 0.25)`,
+              backgroundColor: `rgb(${reserveTone.rgb} / 0.11)`,
+              boxShadow: `inset 0 1px 0 rgb(255 255 255 / 0.055)`,
+            }}
+          >
+            <Icon className="h-[18px] w-[18px]" strokeWidth={2.1} />
+          </div>
+
+          <div className="min-w-0">
+            <h3 className="truncate text-[15px] font-black leading-tight tracking-[-0.025em] text-white/95">
+              {item?.title || "Budget category"}
+            </h3>
+            <p className="mt-1 text-[9px] font-black uppercase tracking-[0.14em] text-white/34">
+              {reserveTone.name}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-1.5">
+          <span className={`rounded-full border px-2.5 py-1 text-[9px] font-black ${STATUS_STYLES[health.state]}`}>
+            {health.label}
+          </span>
+
+          {!isProtected ? (
+            <div
+              className="relative"
+              onBlur={(event) => {
+                if (!event.currentTarget.contains(event.relatedTarget)) setMenuOpen(false);
+              }}
+            >
+              <button
+                type="button"
+                onClick={() => setMenuOpen((current) => !current)}
+                disabled={financeActionLoading}
+                className="grid h-8 w-8 place-items-center rounded-xl border border-transparent bg-white/[0.025] text-white/48 transition hover:border-white/[0.09] hover:bg-white/[0.065] hover:text-white/82 disabled:opacity-40"
+                aria-label={`Open actions for ${item?.title || "budget category"}`}
+                aria-haspopup="menu"
+                aria-expanded={menuOpen}
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </button>
+
+              {menuOpen ? (
+                <div
+                  role="menu"
+                  className="absolute right-0 top-9 z-30 w-36 overflow-hidden rounded-2xl border border-white/[0.10] bg-[#081426]/96 p-1.5 shadow-[0_18px_42px_rgba(0,0,0,0.46),inset_0_1px_0_rgba(255,255,255,0.055)] backdrop-blur-xl"
+                >
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={closeAndEdit}
+                    className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-[11px] font-bold text-white/72 transition hover:bg-white/[0.07] hover:text-white"
+                  >
+                    <Edit3 className="h-3.5 w-3.5" />
+                    Edit category
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={closeAndDelete}
+                    className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-[11px] font-bold text-rose-100/72 transition hover:bg-rose-400/[0.10] hover:text-rose-50"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                    Delete category
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
       </div>
-    </div>
+
+      <div className="relative mt-4 flex items-end justify-between gap-3">
+        <div className="min-w-0">
+          <p className={`truncate text-[22px] font-black leading-none tracking-[-0.045em] ${heroTone}`}>
+            {fmt(heroAmount)}
+          </p>
+          <p className="mt-1.5 text-[9px] font-black uppercase tracking-[0.15em] text-white/36">
+            {heroLabel}
+          </p>
+        </div>
+
+        <div className="shrink-0 text-right">
+          <p
+            className="text-[13px] font-black leading-none"
+            style={{ color: `rgb(${reserveTone.rgb})` }}
+          >
+            {fmt(categoryAllocated)}
+          </p>
+          <p className="mt-1.5 text-[9px] font-black uppercase tracking-[0.13em] text-white/32">
+            Reserved
+          </p>
+        </div>
+      </div>
+
+      <div className="relative mt-3.5 h-2 overflow-hidden rounded-full border border-white/[0.055] bg-black/[0.30] shadow-[inset_0_1px_2px_rgba(0,0,0,0.32)]">
+        <div
+          className="h-full rounded-full transition-[width] duration-500 ease-out"
+          style={{
+            width: `${displayProgress}%`,
+            background: `linear-gradient(90deg, rgb(${progressRgb} / 0.78), rgb(${progressRgb}))`,
+            boxShadow: `0 0 12px rgb(${progressRgb} / 0.30)`,
+          }}
+        />
+      </div>
+
+      <div className="relative mt-2.5 flex items-center justify-between gap-3 text-[10px] font-bold text-white/50">
+        <span>
+          {isProtected ? `${fmt(categoryAllocated)} protected` : `${fmt(categorySpent)} spent`}
+        </span>
+        <span className={health.state === "danger" ? "text-rose-100/90" : "text-white/58"}>
+          {isProtected ? "100% protected" : `${usagePercent}% used`}
+        </span>
+      </div>
+    </article>
   );
 }


### PR DESCRIPTION
## Summary

Surgically reconstructs the expanded Budget category cards without redesigning the surrounding CLARA finance experience.

### UI changes
- Introduces amount-based reserve accents using each category's share of the declared cycle budget
- Keeps every card on a deep premium dark surface with restrained accent rails, icon chips, border highlights, and corner glow
- Adds category-aware icons for food, groceries, bills, utilities, rent, transport, fuel, health, education, entertainment, shopping, debt, savings, and fallback categories
- Makes remaining or over-budget amount the hero metric
- Separates reserve identity colors from health colors
- Uses reserve accent below 80% usage, amber near the limit, and rose at/over the limit
- Replaces permanent edit/delete buttons with a quieter overflow menu
- Makes progress tracks and fills more readable
- Preserves protected commitments as a dedicated protected state

### Logic changes
- Adds `reserveShare`, `declaredBudget`, and `totalAllocated` metadata to displayed categories
- Calculates reserve color weight against declared cycle capacity, falling back to total allocation
- Stops reordering ordinary categories based on live spending percentage
- Preserves protected commitments first, then explicit display order, then original order
- Shows the actual amount over budget rather than reducing remaining to an ambiguous zero

## Scope

Only the expanded budget category card component and its supporting display logic are changed. No global finance-card redesign or budget storage behavior is included.