### PR TITLE
Order budget categories by reserved amount

### DIFF
--- a/src/components/financial-carousel/cards/budget/logic/useBudgetCardLogic.js
+++ b/src/components/financial-carousel/cards/budget/logic/useBudgetCardLogic.js
@@ -194,6 +194,11 @@ export default function useBudgetCardLogic({
 
         if (aProtected !== bProtected) return aProtected ? -1 : 1;
 
+        const aAllocated = safeNumber(a?.allocated ?? a?.allocated_amount);
+        const bAllocated = safeNumber(b?.allocated ?? b?.allocated_amount);
+
+        if (aAllocated !== bAllocated) return bAllocated - aAllocated;
+
         const aOrderValue =
           a?.sortOrder ??
           a?.sort_order ??


### PR DESCRIPTION
## Summary

Fixes the expanded budget category hierarchy so the visual order now matches the pricing hierarchy.

### Ordering rules
1. Protected commitments remain grouped first.
2. Within each group, categories are ordered by reserved/allocated amount from highest to lowest.
3. Explicit display position is used only when two categories have the same reserved amount.
4. Original source order remains the final stable fallback.

This keeps the largest financial commitments visually dominant while avoiding movement based on current spending progress.