### PR TITLE
Center the Buy Check opening board

### DIFF
--- a/src/components/fresh/main-dashboard/assistant/ClaraAiEnvironmentOverlay.jsx
+++ b/src/components/fresh/main-dashboard/assistant/ClaraAiEnvironmentOverlay.jsx
@@ -241,7 +241,7 @@ export default function ClaraAiEnvironmentOverlay({
             <div ref={messagesEndRef} className="h-1 shrink-0" />
           </div>
         ) : (
-          <div className="flex min-h-full flex-col justify-end pb-24 pt-20">
+          <div className="flex min-h-full flex-col justify-center px-1 pb-24 pt-8">
             <PauseEntryBoard
               onClose={onClose}
               acknowledgmentMessage={acknowledgmentMessage}


### PR DESCRIPTION
Moves the Buy Check opening card from bottom-anchored placement to a vertically centered floating position above the input bar. This is a one-line layout change in `ClaraAiEnvironmentOverlay.jsx`; the Buy Check flow and logic remain unchanged.