### PR TITLE
Fix local Daily Check-In consecutive streak tracking

### DIFF
--- a/src/components/fresh/main-dashboard/daily-tip/logic/useDailyCheckIn.js
+++ b/src/components/fresh/main-dashboard/daily-tip/logic/useDailyCheckIn.js
@@ -1,168 +1,529 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  addLocalDays,
+  compareDateKeys,
+  getChallengeTimeZone,
+  getLocalDateKey,
+} from "@/lib/challenge-schedule";
 
-const CHECK_IN_STORAGE_KEY = "clara_daily_check_in_v1";
+const LEGACY_KEY = "clara_daily_check_in_v1";
+const STORAGE_PREFIX = "clara_daily_check_in_v2:";
+const MIGRATION_OWNER_KEY = "clara_daily_check_in_v1_migrated_to";
+const UPDATE_EVENT = "clara:daily-check-in-updated";
 const MAX_VISIBLE_DAYS = 30;
+const memoryStateByUser = new Map();
+const BUBBLE_PRIORITY = {
+  streak_30_completed: 5,
+  streak_reset: 4,
+  streak_14_day: 3,
+  streak_7_day: 2,
+  new_longest_streak: 1,
+};
 
-export default function useDailyCheckIn({ simulationMode = false } = {}) {
-  const todayKey = useMemo(() => getTodayKey(), []);
+export default function useDailyCheckIn({ userId = "guest", simulationMode = false } = {}) {
+  const resolvedUserId = normalizeUserId(userId);
+  const [todayKey, setTodayKey] = useState(() => getLocalDateKey());
   const [checkInState, setCheckInState] = useState(() =>
-    simulationMode ? createSimulationCheckInState(todayKey) : readCheckInState(todayKey)
+    simulationMode
+      ? createSimulationState(resolvedUserId, getLocalDateKey())
+      : loadState(resolvedUserId, getLocalDateKey()),
   );
+  const checkInLockRef = useRef(false);
+
+  const validateStreak = useCallback(() => {
+    const freshTodayKey = getLocalDateKey();
+    setTodayKey(freshTodayKey);
+
+    if (simulationMode) {
+      const nextSimulationState = createSimulationState(resolvedUserId, freshTodayKey);
+      setCheckInState(nextSimulationState);
+      return nextSimulationState;
+    }
+
+    const latestState = loadState(resolvedUserId, freshTodayKey);
+    const validation = validateState(latestState, resolvedUserId, freshTodayKey);
+    const nextState = validation.changed
+      ? writeState(resolvedUserId, validation.state, validation.reason)
+      : validation.state;
+
+    setCheckInState(nextState);
+    return nextState;
+  }, [resolvedUserId, simulationMode]);
 
   useEffect(() => {
     if (simulationMode) {
-      setCheckInState(createSimulationCheckInState(todayKey));
+      setTodayKey(getLocalDateKey());
+      setCheckInState(createSimulationState(resolvedUserId, getLocalDateKey()));
       return undefined;
     }
 
-    const syncCheckInState = () => setCheckInState(readCheckInState(todayKey));
-
-    syncCheckInState();
-
+    validateStreak();
     if (typeof window === "undefined") return undefined;
 
-    window.addEventListener("storage", syncCheckInState);
-    return () => window.removeEventListener("storage", syncCheckInState);
-  }, [simulationMode, todayKey]);
+    let midnightTimer = null;
+    const scheduleMidnightValidation = () => {
+      if (midnightTimer) window.clearTimeout(midnightTimer);
+      midnightTimer = window.setTimeout(() => {
+        validateStreak();
+        scheduleMidnightValidation();
+      }, millisecondsUntilNextManilaMidnight());
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") validateStreak();
+    };
+    const handleStorage = (event) => {
+      if (event.key && event.key !== storageKey(resolvedUserId) && event.key !== LEGACY_KEY) return;
+      validateStreak();
+    };
+    const handleLocalUpdate = (event) => {
+      if (normalizeUserId(event?.detail?.userId) !== resolvedUserId) return;
+      const freshTodayKey = getLocalDateKey();
+      setTodayKey(freshTodayKey);
+      setCheckInState(normalizeState(event.detail.state, resolvedUserId, freshTodayKey));
+    };
 
-  const completedDates = useMemo(
-    () => normalizeCompletedDates(checkInState.completedDates),
-    [checkInState.completedDates]
-  );
-  const checkedInToday = completedDates.includes(todayKey);
-  const totalCompleted = Math.min(completedDates.length, MAX_VISIBLE_DAYS);
-  const challengeDay = checkedInToday
-    ? Math.min(Math.max(totalCompleted, 1), MAX_VISIBLE_DAYS)
-    : Math.min(totalCompleted + 1, MAX_VISIBLE_DAYS);
-  const currentStreak = useMemo(
-    () => calculateCurrentStreak(completedDates, todayKey),
-    [completedDates, todayKey]
-  );
+    scheduleMidnightValidation();
+    window.addEventListener("focus", validateStreak);
+    window.addEventListener("storage", handleStorage);
+    window.addEventListener(UPDATE_EVENT, handleLocalUpdate);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      if (midnightTimer) window.clearTimeout(midnightTimer);
+      window.removeEventListener("focus", validateStreak);
+      window.removeEventListener("storage", handleStorage);
+      window.removeEventListener(UPDATE_EVENT, handleLocalUpdate);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [resolvedUserId, simulationMode, validateStreak]);
 
   const checkInToday = useCallback(() => {
+    const freshTodayKey = getLocalDateKey();
+    setTodayKey(freshTodayKey);
+
     if (simulationMode) {
-      const nextState = createSimulationCheckInState(todayKey, true);
+      const nextState = createSimulationState(resolvedUserId, freshTodayKey, true);
       setCheckInState(nextState);
-      return nextState;
+      return {
+        status: "completed",
+        currentStreak: 1,
+        longestStreak: 1,
+        milestoneType: null,
+        bubbleEvent: null,
+        state: nextState,
+      };
     }
 
-    let nextState = null;
+    if (checkInLockRef.current) {
+      const current = normalizeState(checkInState, resolvedUserId, freshTodayKey);
+      return {
+        status: current.lastCheckInDate === freshTodayKey ? "already_checked_in" : "busy",
+        currentStreak: current.currentStreak,
+        longestStreak: current.longestStreak,
+        milestoneType: null,
+        bubbleEvent: null,
+        state: current,
+      };
+    }
 
-    setCheckInState((currentState) => {
-      const latestStoredState = readCheckInState(todayKey);
-      const baseState = latestStoredState || normalizeCheckInState(currentState, todayKey);
-      const baseCompletedDates = normalizeCompletedDates(baseState.completedDates);
+    checkInLockRef.current = true;
+    try {
+      const latestState = loadState(resolvedUserId, freshTodayKey);
+      const validation = validateState(latestState, resolvedUserId, freshTodayKey);
+      const baseState = validation.state;
 
-      if (baseCompletedDates.includes(todayKey)) {
-        nextState = {
-          ...baseState,
-          completedDates: baseCompletedDates,
-          lastCheckInDate: todayKey,
+      if (baseState.lastCheckInDate === freshTodayKey || baseState.completedDates.includes(freshTodayKey)) {
+        const existingState = validation.changed
+          ? writeState(resolvedUserId, baseState, validation.reason)
+          : baseState;
+        setCheckInState(existingState);
+        return {
+          status: "already_checked_in",
+          currentStreak: existingState.currentStreak,
+          longestStreak: existingState.longestStreak,
+          milestoneType: null,
+          bubbleEvent: null,
+          state: existingState,
         };
-        return nextState;
       }
 
-      const completedDatesWithToday = normalizeCompletedDates([...baseCompletedDates, todayKey]);
-      nextState = {
-        startedAt: baseState.startedAt || completedDatesWithToday[0] || todayKey,
-        completedDates: completedDatesWithToday,
-        lastCheckInDate: todayKey,
+      const yesterdayKey = addLocalDays(freshTodayKey, -1);
+      const continuesStreak = baseState.lastCheckInDate === yesterdayKey;
+      const nextStreak = continuesStreak ? baseState.currentStreak + 1 : 1;
+      const previousLongest = baseState.longestStreak;
+      const milestoneType = selectMilestone({
+        nextStreak,
+        previousLongest,
+        completedThirtyDays: baseState.completedThirtyDays,
+        hasResetHistory: Boolean(baseState.lastResetAt),
+      });
+      const milestoneBubble = milestoneType
+        ? createBubble(milestoneType, nextStreak, freshTodayKey)
+        : null;
+      const completedDates = normalizeDates([...baseState.completedDates, freshTodayKey]);
+      const nowIso = new Date().toISOString();
+      const nextState = normalizeState(
+        {
+          ...baseState,
+          currentStreak: nextStreak,
+          longestStreak: Math.max(previousLongest, nextStreak),
+          lifetimeCheckIns: completedDates.length,
+          cycleStartedAt:
+            continuesStreak && baseState.cycleStartedAt ? baseState.cycleStartedAt : freshTodayKey,
+          lastCheckInDate: freshTodayKey,
+          completedDates,
+          completedThirtyDays: baseState.completedThirtyDays || nextStreak >= 30,
+          completedThirtyDaysAt:
+            nextStreak >= 30 && !baseState.completedThirtyDaysAt
+              ? nowIso
+              : baseState.completedThirtyDaysAt,
+          pendingBubble: higherPriorityBubble(baseState.pendingBubble, milestoneBubble),
+          updatedAt: nowIso,
+        },
+        resolvedUserId,
+        freshTodayKey,
+      );
+      const writtenState = writeState(resolvedUserId, nextState, "check_in");
+      setCheckInState(writtenState);
+
+      return {
+        status: "completed",
+        currentStreak: writtenState.currentStreak,
+        longestStreak: writtenState.longestStreak,
+        milestoneType,
+        bubbleEvent: milestoneBubble,
+        state: writtenState,
       };
+    } finally {
+      checkInLockRef.current = false;
+    }
+  }, [checkInState, resolvedUserId, simulationMode]);
 
-      writeCheckInState(nextState);
-      return nextState;
-    });
+  const dismissPendingBubble = useCallback(
+    (eventId = null) => {
+      if (simulationMode) return;
+      const latestState = loadState(resolvedUserId, getLocalDateKey());
+      if (!latestState.pendingBubble) return;
+      if (eventId && latestState.pendingBubble.id !== eventId) return;
 
-    return nextState;
-  }, [simulationMode, todayKey]);
+      const nextState = writeState(
+        resolvedUserId,
+        {
+          ...latestState,
+          pendingBubble: null,
+          updatedAt: new Date().toISOString(),
+        },
+        "bubble_dismissed",
+      );
+      setCheckInState(nextState);
+    },
+    [resolvedUserId, simulationMode],
+  );
+
+  const displayState = useMemo(
+    () =>
+      checkInState.userId === resolvedUserId
+        ? normalizeState(checkInState, resolvedUserId, todayKey)
+        : createEmptyState(resolvedUserId),
+    [checkInState, resolvedUserId, todayKey],
+  );
+  const checkedInToday = displayState.lastCheckInDate === todayKey;
+  const challengeProgress = Math.min(displayState.currentStreak, MAX_VISIBLE_DAYS);
+  const challengeDay =
+    displayState.currentStreak >= MAX_VISIBLE_DAYS
+      ? MAX_VISIBLE_DAYS
+      : checkedInToday
+        ? Math.max(1, displayState.currentStreak)
+        : Math.min(MAX_VISIBLE_DAYS, displayState.currentStreak + 1);
 
   return {
     todayKey,
     checkedInToday,
-    completedDates,
-    totalCompleted,
+    completedDates: displayState.completedDates,
+    totalCompleted: challengeProgress,
+    challengeProgress,
     challengeDay,
-    currentStreak,
+    currentStreak: displayState.currentStreak,
+    longestStreak: displayState.longestStreak,
+    lifetimeCheckIns: displayState.lifetimeCheckIns,
+    completedThirtyDays: displayState.completedThirtyDays,
+    pendingBubble: simulationMode ? null : displayState.pendingBubble,
     checkInToday,
+    dismissPendingBubble,
+    validateStreak,
   };
 }
 
-function createSimulationCheckInState(todayKey, completedToday = false) {
-  return {
-    startedAt: todayKey,
-    completedDates: completedToday ? [todayKey] : [],
-    lastCheckInDate: completedToday ? todayKey : null,
-  };
-}
+function validateState(value, userId, todayKey) {
+  const state = normalizeState(value, userId, todayKey);
+  if (!state.lastCheckInDate) return { state, changed: false, reason: "validation" };
 
-function readCheckInState(todayKey) {
-  const stored = safeGet(CHECK_IN_STORAGE_KEY);
-  return normalizeCheckInState(safeParse(stored), todayKey);
-}
-
-function writeCheckInState(state) {
-  safeSet(CHECK_IN_STORAGE_KEY, JSON.stringify(state));
-}
-
-function normalizeCheckInState(value, todayKey) {
-  const completedDates = normalizeCompletedDates(value?.completedDates);
-  const startedAt = isDateKey(value?.startedAt)
-    ? value.startedAt
-    : completedDates[0] || todayKey;
-  const lastCheckInDate = isDateKey(value?.lastCheckInDate)
-    ? value.lastCheckInDate
-    : completedDates[completedDates.length - 1] || null;
-
-  return {
-    startedAt,
-    completedDates,
-    lastCheckInDate,
-  };
-}
-
-function normalizeCompletedDates(value) {
-  if (!Array.isArray(value)) return [];
-
-  return [...new Set(value.filter(isDateKey))].sort();
-}
-
-function calculateCurrentStreak(completedDates, todayKey) {
-  const completedDateSet = new Set(completedDates);
-  const streakEndDate = completedDateSet.has(todayKey) ? todayKey : shiftDateKey(todayKey, -1);
-  let cursor = streakEndDate;
-  let streak = 0;
-
-  while (completedDateSet.has(cursor)) {
-    streak += 1;
-    cursor = shiftDateKey(cursor, -1);
+  const yesterdayKey = addLocalDays(todayKey, -1);
+  if (
+    state.lastCheckInDate === todayKey ||
+    state.lastCheckInDate === yesterdayKey ||
+    compareDateKeys(state.lastCheckInDate, todayKey) > 0
+  ) {
+    return { state, changed: false, reason: "validation" };
   }
 
+  const previousStreak = Math.max(0, state.currentStreak);
+  const resetBubble = previousStreak > 0
+    ? createBubble("streak_reset", previousStreak, todayKey)
+    : null;
+  const nowIso = new Date().toISOString();
+
+  return {
+    changed: true,
+    reason: "reset",
+    state: normalizeState(
+      {
+        ...state,
+        currentStreak: 0,
+        longestStreak: Math.max(state.longestStreak, previousStreak),
+        cycleStartedAt: null,
+        lastCheckInDate: null,
+        lastResetAt: nowIso,
+        pendingBubble: higherPriorityBubble(state.pendingBubble, resetBubble),
+        updatedAt: nowIso,
+      },
+      userId,
+      todayKey,
+    ),
+  };
+}
+
+function loadState(userId, todayKey) {
+  const resolvedUserId = normalizeUserId(userId);
+  const stored = safeParse(safeGet(storageKey(resolvedUserId)));
+  if (stored) {
+    const normalized = normalizeState(stored, resolvedUserId, todayKey);
+    memoryStateByUser.set(resolvedUserId, normalized);
+    return normalized;
+  }
+
+  const memoryState = memoryStateByUser.get(resolvedUserId);
+  if (memoryState) return normalizeState(memoryState, resolvedUserId, todayKey);
+
+  const migrated = migrateLegacyState(resolvedUserId, todayKey);
+  if (migrated) return migrated;
+
+  const emptyState = createEmptyState(resolvedUserId);
+  memoryStateByUser.set(resolvedUserId, emptyState);
+  return emptyState;
+}
+
+function writeState(userId, value, reason) {
+  const resolvedUserId = normalizeUserId(userId);
+  const state = normalizeState(value, resolvedUserId, getLocalDateKey());
+  memoryStateByUser.set(resolvedUserId, state);
+  safeSet(storageKey(resolvedUserId), JSON.stringify(state));
+
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent(UPDATE_EVENT, {
+        detail: { userId: resolvedUserId, state, reason },
+      }),
+    );
+  }
+  return state;
+}
+
+function migrateLegacyState(userId, todayKey) {
+  if (userId === "guest") return null;
+  const migrationOwner = safeGet(MIGRATION_OWNER_KEY);
+  if (migrationOwner && migrationOwner !== userId) return null;
+
+  const legacyState = safeParse(safeGet(LEGACY_KEY));
+  if (!legacyState) return null;
+
+  const completedDates = normalizeDates(legacyState.completedDates);
+  const currentStreak = calculateActiveStreak(completedDates, todayKey);
+  const longestStreak = calculateLongestStreak(completedDates);
+  const lastHistoricalDate = isDateKey(legacyState.lastCheckInDate)
+    ? legacyState.lastCheckInDate
+    : completedDates[completedDates.length - 1] || null;
+  const lastCheckInDate = currentStreak > 0 ? lastHistoricalDate : null;
+  const migratedState = normalizeState(
+    {
+      ...createEmptyState(userId),
+      currentStreak,
+      longestStreak,
+      lifetimeCheckIns: completedDates.length,
+      cycleStartedAt:
+        currentStreak > 0 && lastCheckInDate
+          ? addLocalDays(lastCheckInDate, -(currentStreak - 1))
+          : null,
+      lastCheckInDate,
+      completedDates,
+      completedThirtyDays: longestStreak >= 30,
+      updatedAt: new Date().toISOString(),
+    },
+    userId,
+    todayKey,
+  );
+
+  memoryStateByUser.set(userId, migratedState);
+  if (safeSet(storageKey(userId), JSON.stringify(migratedState))) {
+    safeSet(MIGRATION_OWNER_KEY, userId);
+  }
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent(UPDATE_EVENT, {
+        detail: { userId, state: migratedState, reason: "migration" },
+      }),
+    );
+  }
+  return migratedState;
+}
+
+function createEmptyState(userId) {
+  return {
+    version: 2,
+    userId: normalizeUserId(userId),
+    timezone: getChallengeTimeZone(),
+    currentStreak: 0,
+    longestStreak: 0,
+    lifetimeCheckIns: 0,
+    cycleStartedAt: null,
+    lastCheckInDate: null,
+    completedDates: [],
+    completedThirtyDays: false,
+    completedThirtyDaysAt: null,
+    lastResetAt: null,
+    pendingBubble: null,
+    updatedAt: null,
+  };
+}
+
+function createSimulationState(userId, todayKey, completedToday = false) {
+  return {
+    ...createEmptyState(userId),
+    currentStreak: completedToday ? 1 : 0,
+    longestStreak: completedToday ? 1 : 0,
+    lifetimeCheckIns: completedToday ? 1 : 0,
+    cycleStartedAt: completedToday ? todayKey : null,
+    lastCheckInDate: completedToday ? todayKey : null,
+    completedDates: completedToday ? [todayKey] : [],
+  };
+}
+
+function normalizeState(value, userId, todayKey) {
+  const base = createEmptyState(userId);
+  const completedDates = normalizeDates(value?.completedDates);
+  const lastCheckInDate = isDateKey(value?.lastCheckInDate) ? value.lastCheckInDate : null;
+  const currentStreak = Number.isFinite(Number(value?.currentStreak))
+    ? Math.max(0, Math.floor(Number(value.currentStreak)))
+    : calculateActiveStreak(completedDates, todayKey);
+  const longestStreak = Math.max(
+    currentStreak,
+    calculateLongestStreak(completedDates),
+    Number.isFinite(Number(value?.longestStreak))
+      ? Math.max(0, Math.floor(Number(value.longestStreak)))
+      : 0,
+  );
+
+  return {
+    ...base,
+    currentStreak,
+    longestStreak,
+    lifetimeCheckIns: Math.max(
+      completedDates.length,
+      Number.isFinite(Number(value?.lifetimeCheckIns))
+        ? Math.max(0, Math.floor(Number(value.lifetimeCheckIns)))
+        : 0,
+    ),
+    cycleStartedAt:
+      currentStreak > 0 && isDateKey(value?.cycleStartedAt) ? value.cycleStartedAt : null,
+    lastCheckInDate,
+    completedDates,
+    completedThirtyDays: Boolean(value?.completedThirtyDays) || longestStreak >= 30,
+    completedThirtyDaysAt:
+      typeof value?.completedThirtyDaysAt === "string" ? value.completedThirtyDaysAt : null,
+    lastResetAt: typeof value?.lastResetAt === "string" ? value.lastResetAt : null,
+    pendingBubble: normalizeBubble(value?.pendingBubble),
+    updatedAt: typeof value?.updatedAt === "string" ? value.updatedAt : null,
+  };
+}
+
+function normalizeDates(value) {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.filter(isDateKey))].sort(compareDateKeys);
+}
+
+function calculateActiveStreak(completedDates, todayKey) {
+  const dateSet = new Set(normalizeDates(completedDates));
+  let cursor = dateSet.has(todayKey) ? todayKey : addLocalDays(todayKey, -1);
+  let streak = 0;
+  while (dateSet.has(cursor)) {
+    streak += 1;
+    cursor = addLocalDays(cursor, -1);
+  }
   return streak;
 }
 
-function shiftDateKey(dateKey, dayOffset) {
-  const date = parseDateKey(dateKey);
-  if (!date) return dateKey;
-
-  date.setDate(date.getDate() + dayOffset);
-  return formatDateKey(date);
+function calculateLongestStreak(completedDates) {
+  let longest = 0;
+  let running = 0;
+  let previousDate = null;
+  normalizeDates(completedDates).forEach((dateKey) => {
+    running = previousDate && addLocalDays(previousDate, 1) === dateKey ? running + 1 : 1;
+    longest = Math.max(longest, running);
+    previousDate = dateKey;
+  });
+  return longest;
 }
 
-function getTodayKey() {
-  return formatDateKey(new Date());
+function selectMilestone({ nextStreak, previousLongest, completedThirtyDays, hasResetHistory }) {
+  if (nextStreak === 30 && !completedThirtyDays) return "streak_30_completed";
+  if (nextStreak === 14) return "streak_14_day";
+  if (nextStreak === 7) return "streak_7_day";
+  if (hasResetHistory && previousLongest > 0 && nextStreak > previousLongest) {
+    return "new_longest_streak";
+  }
+  return null;
 }
 
-function formatDateKey(date) {
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(
-    date.getDate()
-  ).padStart(2, "0")}`;
+function createBubble(type, streakCount, dateKey) {
+  return {
+    id: `${type}:${dateKey}:${streakCount}:${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    type,
+    previousStreak: streakCount,
+    streakCount,
+    createdAt: new Date().toISOString(),
+  };
 }
 
-function parseDateKey(value) {
-  if (!isDateKey(value)) return null;
+function normalizeBubble(value) {
+  if (!value || !BUBBLE_PRIORITY[value.type] || typeof value.id !== "string") return null;
+  return {
+    id: value.id,
+    type: value.type,
+    previousStreak: Math.max(0, Number(value.previousStreak) || 0),
+    streakCount: Math.max(0, Number(value.streakCount) || 0),
+    createdAt: typeof value.createdAt === "string" ? value.createdAt : new Date().toISOString(),
+  };
+}
 
-  const [year, month, day] = value.split("-").map(Number);
-  return new Date(year, month - 1, day);
+function higherPriorityBubble(currentValue, candidateValue) {
+  const current = normalizeBubble(currentValue);
+  const candidate = normalizeBubble(candidateValue);
+  if (!current) return candidate;
+  if (!candidate) return current;
+  return BUBBLE_PRIORITY[candidate.type] > BUBBLE_PRIORITY[current.type] ? candidate : current;
+}
+
+function millisecondsUntilNextManilaMidnight(now = new Date()) {
+  const tomorrowKey = addLocalDays(getLocalDateKey(now), 1);
+  return Math.max(1000, Date.parse(`${tomorrowKey}T00:00:00+08:00`) - now.getTime() + 1000);
+}
+
+function storageKey(userId) {
+  return `${STORAGE_PREFIX}${normalizeUserId(userId)}`;
+}
+
+function normalizeUserId(userId) {
+  return String(userId || "").trim() || "guest";
 }
 
 function isDateKey(value) {
@@ -171,7 +532,6 @@ function isDateKey(value) {
 
 function safeGet(key) {
   if (typeof window === "undefined") return null;
-
   try {
     return window.localStorage.getItem(key);
   } catch {
@@ -180,12 +540,12 @@ function safeGet(key) {
 }
 
 function safeSet(key, value) {
-  if (typeof window === "undefined") return;
-
+  if (typeof window === "undefined") return false;
   try {
     window.localStorage.setItem(key, value);
+    return true;
   } catch {
-    // Keep the card working even if storage is blocked.
+    return false;
   }
 }
 

--- a/src/components/fresh/main-dashboard/daily-tip/ui/DailyTipCard.jsx
+++ b/src/components/fresh/main-dashboard/daily-tip/ui/DailyTipCard.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Lock } from "lucide-react";
+import { useAuth } from "@/context/AuthContext";
 import useDailyTip from "../logic/useDailyTip";
 import useDailyCheckIn from "../logic/useDailyCheckIn";
 import { exitYoungProfessionalCurrentState } from "@/lib/clara-young-professional-current-state";
@@ -23,6 +24,7 @@ function readActiveCurrentState() {
 }
 
 export default function DailyTipCard({
+  userId: providedUserId,
   hasCommittedAccess = true,
   onOpenCommitmentBooklet,
   flushSpacing = false,
@@ -31,26 +33,34 @@ export default function DailyTipCard({
   isDailyTipGuideActive = false,
   onGuideDailyTipTap,
 }) {
-  const { tip, hasSeenToday, markSeenToday } = useDailyTip({ simulationMode: isGuideMode });
+  const { user } = useAuth();
+  const [activeCurrentState, setActiveCurrentState] = useState(() => readActiveCurrentState());
+  const simulationMode = isGuideMode || Boolean(activeCurrentState);
+  const userId = providedUserId || user?.id || "guest";
+  const { tip, hasSeenToday, markSeenToday } = useDailyTip({ simulationMode });
   const {
     checkedInToday,
-    totalCompleted,
+    challengeProgress,
     challengeDay,
     currentStreak,
     checkInToday,
-  } = useDailyCheckIn({ simulationMode: isGuideMode });
+  } = useDailyCheckIn({ userId, simulationMode });
   const [flipped, setFlipped] = useState(false);
   const [isFlipping, setIsFlipping] = useState(false);
   const [showCelebration, setShowCelebration] = useState(false);
+  const [celebrationLevel, setCelebrationLevel] = useState("normal");
   const isFlippingRef = useRef(false);
   const flipUnlockTimerRef = useRef(null);
   const celebrationTimerRef = useRef(null);
-  const [activeCurrentState, setActiveCurrentState] = useState(() => readActiveCurrentState());
   const [exiting, setExiting] = useState(false);
   const spacingClass = flushSpacing ? "px-3" : "px-3 mt-1.5";
   const isGuideStepActive = isGuideMode && isDailyTipGuideActive && guideStep === 0;
   const cardEyebrow = isGuideMode ? "Daily Money Tip" : "Daily Check-In";
-  const cardHeadline = isGuideMode ? "Today's money reminder" : `Day ${challengeDay} of ${CHECK_IN_DAYS}`;
+  const cardHeadline = isGuideMode
+    ? "Today's money reminder"
+    : currentStreak >= CHECK_IN_DAYS
+      ? "30-Day Goal Complete"
+      : `Day ${challengeDay} of ${CHECK_IN_DAYS}`;
   const cardSubtitle = isGuideMode
     ? "Tap this card to learn what CLARA gives you each day."
     : "Tap today to protect your money discipline.";
@@ -103,10 +113,22 @@ export default function DailyTipCard({
     };
   }, []);
 
-  const triggerCheckInCelebration = () => {
+  const triggerCheckInCelebration = (milestoneType = null) => {
     if (typeof window === "undefined") return;
 
+    const level =
+      milestoneType === "streak_30_completed"
+        ? "thirty"
+        : milestoneType === "streak_14_day"
+          ? "fourteen"
+          : milestoneType === "streak_7_day"
+            ? "seven"
+            : "normal";
+    const duration =
+      level === "thirty" ? 1900 : level === "fourteen" ? 1450 : level === "seven" ? 1200 : 950;
+
     setShowCelebration(false);
+    setCelebrationLevel(level);
 
     if (celebrationTimerRef.current) {
       window.clearTimeout(celebrationTimerRef.current);
@@ -119,7 +141,7 @@ export default function DailyTipCard({
       celebrationTimerRef.current = window.setTimeout(() => {
         setShowCelebration(false);
         celebrationTimerRef.current = null;
-      }, 950);
+      }, duration);
     };
 
     if (typeof window.requestAnimationFrame === "function") {
@@ -151,8 +173,10 @@ export default function DailyTipCard({
     setIsFlipping(true);
 
     if (willRevealTip && !checkedInToday) {
-      checkInToday();
-      triggerCheckInCelebration();
+      const checkInResult = checkInToday();
+      if (checkInResult?.status === "completed") {
+        triggerCheckInCelebration(checkInResult.milestoneType);
+      }
     }
 
     setFlipped((current) => !current);
@@ -220,6 +244,15 @@ export default function DailyTipCard({
       </div>
     );
   }
+
+  const sparkCount =
+    celebrationLevel === "thirty"
+      ? 30
+      : celebrationLevel === "fourteen"
+        ? 24
+        : celebrationLevel === "seven"
+          ? 20
+          : 18;
 
   return (
     <div
@@ -300,8 +333,11 @@ export default function DailyTipCard({
                 <div className="pt-1">
                   <div className="clara-checkin-grid" aria-hidden="true">
                     {Array.from({ length: CHECK_IN_DAYS }).map((_, dotIndex) => {
-                      const isDone = dotIndex < totalCompleted;
-                      const isToday = !checkedInToday && dotIndex === Math.min(totalCompleted, CHECK_IN_DAYS - 1);
+                      const isDone = dotIndex < challengeProgress;
+                      const isToday =
+                        !checkedInToday &&
+                        challengeProgress < CHECK_IN_DAYS &&
+                        dotIndex === challengeProgress;
 
                       return (
                         <span
@@ -340,11 +376,22 @@ export default function DailyTipCard({
         </div>
 
         {showCelebration ? (
-          <div className="clara-checkin-celebration" aria-hidden="true">
-            {Array.from({ length: 18 }).map((_, index) => (
+          <div
+            className="clara-checkin-celebration"
+            aria-hidden="true"
+            style={{
+              transform:
+                celebrationLevel === "thirty"
+                  ? "scale(1.08)"
+                  : celebrationLevel === "fourteen"
+                    ? "scale(1.04)"
+                    : undefined,
+            }}
+          >
+            {Array.from({ length: sparkCount }).map((_, index) => (
               <span
                 key={index}
-                className={`clara-checkin-spark clara-checkin-spark--${index + 1}`}
+                className={`clara-checkin-spark clara-checkin-spark--${(index % 18) + 1}`}
               />
             ))}
           </div>

--- a/src/components/fresh/main-dashboard/daily-tip/ui/StreakAchievementBubble.jsx
+++ b/src/components/fresh/main-dashboard/daily-tip/ui/StreakAchievementBubble.jsx
@@ -1,0 +1,199 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Flame, Sparkles, Trophy, X } from "lucide-react";
+import { useAuth } from "@/context/AuthContext";
+import useDailyCheckIn from "../logic/useDailyCheckIn";
+
+const ACTIVE_CURRENT_STATE_KEY = "CLARA_ACTIVE_CURRENT_STATE_V1";
+const GUIDE_MODE_CHANGE_EVENT = "clara:guide-mode-change";
+
+function hasActiveSampleMode() {
+  if (typeof window === "undefined") return false;
+  try {
+    const value = JSON.parse(window.localStorage.getItem(ACTIVE_CURRENT_STATE_KEY) || "null");
+    return value?.mode === "current_state";
+  } catch {
+    return false;
+  }
+}
+
+function getBubbleCopy(event) {
+  const streakCount = Math.max(0, Number(event?.streakCount) || 0);
+  const previousStreak = Math.max(0, Number(event?.previousStreak) || streakCount);
+  const dayLabel = previousStreak === 1 ? "day" : "days";
+
+  switch (event?.type) {
+    case "streak_reset":
+      return {
+        eyebrow: "Your progress remains",
+        title: `You showed up for ${previousStreak} ${dayLabel} straight! 🔥`,
+        body: `That consistency was real progress. A full daily check-in was missed, so your active streak has restarted—but your ${previousStreak}-${dayLabel.slice(0, -1) || "day"} achievement remains part of your journey.`,
+        action: "Start again today",
+        icon: Flame,
+      };
+    case "streak_7_day":
+      return {
+        eyebrow: "Consistency milestone",
+        title: "7 days of consistency! 🔥",
+        body: "You showed up for your money discipline seven days in a row. Keep protecting the habit you are building.",
+        action: "Keep going",
+        icon: Flame,
+      };
+    case "streak_14_day":
+      return {
+        eyebrow: "Consistency milestone",
+        title: "Two weeks strong! ✨",
+        body: "You have checked in for 14 consecutive days. Your consistency is becoming part of how you manage money.",
+        action: "Continue the streak",
+        icon: Sparkles,
+      };
+    case "streak_30_completed":
+      return {
+        eyebrow: "30-day achievement unlocked",
+        title: "30 DAYS COMPLETED! 🏆",
+        body: "You checked in for 30 consecutive days. You proved that you can repeatedly show up and stay committed to your financial growth.",
+        footer: "Your streak continues. Let’s see how far you can take it.",
+        action: "Keep building",
+        icon: Trophy,
+      };
+    case "new_longest_streak":
+      return {
+        eyebrow: "New personal best",
+        title: `${streakCount}-day streak achieved! ✨`,
+        body: "You have moved beyond your previous best. Keep building this habit one thoughtful day at a time.",
+        action: "Keep going",
+        icon: Sparkles,
+      };
+    default:
+      return null;
+  }
+}
+
+export default function StreakAchievementBubble() {
+  const { user } = useAuth();
+  const [guideMode, setGuideMode] = useState(false);
+  const [sampleMode, setSampleMode] = useState(() => hasActiveSampleMode());
+  const actionRef = useRef(null);
+  const simulationMode = guideMode || sampleMode;
+  const { pendingBubble, dismissPendingBubble } = useDailyCheckIn({
+    userId: user?.id || "guest",
+    simulationMode,
+  });
+  const copy = useMemo(() => getBubbleCopy(pendingBubble), [pendingBubble]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+
+    const handleGuideModeChange = (event) => setGuideMode(Boolean(event?.detail?.active));
+    const syncSampleMode = () => setSampleMode(hasActiveSampleMode());
+
+    window.addEventListener(GUIDE_MODE_CHANGE_EVENT, handleGuideModeChange);
+    window.addEventListener("clara-young-professional-current-state-loaded", syncSampleMode);
+    window.addEventListener("storage", syncSampleMode);
+
+    return () => {
+      window.removeEventListener(GUIDE_MODE_CHANGE_EVENT, handleGuideModeChange);
+      window.removeEventListener("clara-young-professional-current-state-loaded", syncSampleMode);
+      window.removeEventListener("storage", syncSampleMode);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!copy || typeof window === "undefined") return undefined;
+
+    const focusTimer = window.setTimeout(() => actionRef.current?.focus?.(), 80);
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") dismissPendingBubble(pendingBubble?.id);
+    };
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.clearTimeout(focusTimer);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [copy, dismissPendingBubble, pendingBubble?.id]);
+
+  if (simulationMode || !pendingBubble || !copy) return null;
+
+  const Icon = copy.icon;
+  const isThirtyDayAchievement = pendingBubble.type === "streak_30_completed";
+
+  return (
+    <div
+      className="pointer-events-none fixed inset-x-0 bottom-0 z-[220] flex justify-center px-3 pb-[max(18px,env(safe-area-inset-bottom))]"
+      role="dialog"
+      aria-modal="false"
+      aria-live="polite"
+      aria-labelledby="clara-streak-bubble-title"
+      aria-describedby="clara-streak-bubble-body"
+    >
+      <div
+        className={`pointer-events-auto relative w-full max-w-[404px] overflow-hidden rounded-[28px] border p-5 text-white shadow-[0_26px_90px_rgba(0,0,0,0.62),0_0_55px_rgba(34,211,238,0.14)] backdrop-blur-2xl ${
+          isThirtyDayAchievement
+            ? "border-amber-200/24 bg-[linear-gradient(145deg,rgba(9,25,48,0.98),rgba(31,27,68,0.97)_52%,rgba(49,34,10,0.96))]"
+            : "border-cyan-100/16 bg-[linear-gradient(145deg,rgba(5,19,41,0.97),rgba(8,24,55,0.96)_52%,rgba(18,13,52,0.96))]"
+        }`}
+      >
+        <div className="pointer-events-none absolute -left-16 -top-16 h-40 w-40 rounded-full bg-cyan-300/14 blur-3xl" />
+        <div className="pointer-events-none absolute -bottom-20 -right-10 h-48 w-48 rounded-full bg-indigo-400/16 blur-3xl" />
+        {isThirtyDayAchievement ? (
+          <div className="pointer-events-none absolute right-4 top-3 h-24 w-24 rounded-full bg-amber-300/14 blur-2xl" />
+        ) : null}
+
+        <button
+          type="button"
+          onClick={() => dismissPendingBubble(pendingBubble.id)}
+          className="absolute right-4 top-4 z-10 flex h-8 w-8 items-center justify-center rounded-full border border-white/10 bg-white/[0.06] text-white/58 transition hover:bg-white/[0.10] hover:text-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100/70"
+          aria-label="Close streak message"
+        >
+          <X className="h-4 w-4" />
+        </button>
+
+        <div className="relative z-10 pr-8">
+          <div
+            className={`flex h-12 w-12 items-center justify-center rounded-2xl border shadow-[inset_0_1px_0_rgba(255,255,255,0.10)] ${
+              isThirtyDayAchievement
+                ? "border-amber-100/20 bg-amber-300/12 text-amber-100"
+                : "border-cyan-100/15 bg-cyan-300/10 text-cyan-100"
+            }`}
+          >
+            <Icon className="h-5 w-5" />
+          </div>
+
+          <p className="mt-4 text-[9px] font-black uppercase tracking-[0.24em] text-cyan-100/58">
+            {copy.eyebrow}
+          </p>
+          <h2
+            id="clara-streak-bubble-title"
+            className="mt-2 text-[21px] font-black leading-tight tracking-[-0.035em] text-white"
+          >
+            {copy.title}
+          </h2>
+          <p
+            id="clara-streak-bubble-body"
+            className="mt-3 text-[12.5px] font-semibold leading-relaxed text-cyan-50/76"
+          >
+            {copy.body}
+          </p>
+          {copy.footer ? (
+            <p className="mt-2 text-[11.5px] font-black leading-relaxed text-amber-100/82">
+              {copy.footer}
+            </p>
+          ) : null}
+
+          <button
+            ref={actionRef}
+            type="button"
+            onClick={() => dismissPendingBubble(pendingBubble.id)}
+            className={`mt-5 w-full rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-[0.15em] shadow-[0_14px_34px_rgba(0,0,0,0.24)] transition active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${
+              isThirtyDayAchievement
+                ? "bg-amber-200 text-slate-950 focus-visible:ring-amber-100"
+                : "bg-cyan-200 text-slate-950 focus-visible:ring-cyan-100"
+            }`}
+          >
+            {copy.action}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/fresh/main-dashboard/daily-tip/ui/StreakAchievementBubble.jsx
+++ b/src/components/fresh/main-dashboard/daily-tip/ui/StreakAchievementBubble.jsx
@@ -26,7 +26,7 @@ function getBubbleCopy(event) {
       return {
         eyebrow: "Your progress remains",
         title: `You showed up for ${previousStreak} ${dayLabel} straight! 🔥`,
-        body: `That consistency was real progress. A full daily check-in was missed, so your active streak has restarted—but your ${previousStreak}-${dayLabel.slice(0, -1) || "day"} achievement remains part of your journey.`,
+        body: `That consistency was real progress. A full daily check-in was missed, so your active streak has restarted—but your ${previousStreak}-day achievement remains part of your journey.`,
         action: "Start again today",
         icon: Flame,
       };

--- a/src/components/fresh/main-dashboard/shell/DashboardModalStack.jsx
+++ b/src/components/fresh/main-dashboard/shell/DashboardModalStack.jsx
@@ -3,6 +3,7 @@ import DashboardFinanceModalRenderer from "@/components/fresh/main-dashboard/she
 import DashboardFinanceExpandedSheetLayer from "@/components/fresh/main-dashboard/shell/DashboardFinanceExpandedSheetLayer";
 import DashboardProgramOnboardingModal from "@/components/fresh/main-dashboard/onboarding/DashboardProgramOnboardingModal";
 import EmergencyReserveExpenseGuard from "@/components/fresh/main-dashboard/finance-content/EmergencyReserveExpenseGuard";
+import StreakAchievementBubble from "@/components/fresh/main-dashboard/daily-tip/ui/StreakAchievementBubble";
 
 export default function DashboardModalStack({
   expandedSheetLayerProps,
@@ -23,6 +24,7 @@ export default function DashboardModalStack({
       />
 
       <DashboardFinanceModalRenderer {...financeModalRendererProps} />
+      <StreakAchievementBubble />
     </DashboardModalLayer>
   );
 }


### PR DESCRIPTION
## Summary
- rebuild the active Daily Check-In hook as a Manila-calendar consecutive streak engine
- migrate legacy `clara_daily_check_in_v1` data once into user-scoped `clara_daily_check_in_v2:<userId>` storage
- reset only after a complete missed Manila calendar day while preserving longest streak and history
- make the 30 dots follow the active consecutive streak instead of lifetime check-ins
- add one-time reset, 7-day, 14-day, 30-day, and new-longest CLARA bubbles
- keep streaks running beyond 30 days while preserving the permanent 30-day achievement
- validate on mount, focus, visibility resume, storage changes, local update events, and Manila midnight
- isolate Guide Mode and Sample Mode from real streak storage

## Scope
Frontend/localStorage only. No Supabase, SQL, Edge Functions, backend APIs, cron jobs, authentication changes, finance changes, or legacy `src/components/DailyTipCard.jsx` changes.

## Files changed
- `src/components/fresh/main-dashboard/daily-tip/logic/useDailyCheckIn.js`
- `src/components/fresh/main-dashboard/daily-tip/ui/DailyTipCard.jsx`
- `src/components/fresh/main-dashboard/daily-tip/ui/StreakAchievementBubble.jsx`
- `src/components/fresh/main-dashboard/shell/DashboardModalStack.jsx`

## Verification
- PR is mergeable with `main`
- Vercel preview build for head commit `3540f66` completed successfully
- build completed in 27 seconds
- only reported build notice is the existing Rollup chunk-size warning
- duplicate same-day check-ins are blocked
- yesterday remains an active streak until the current day ends
- two-day-old or older last check-in resets once and creates a praise-first bubble
- 30-day achievement is permanent and day 31 continues the streak
- localStorage failure falls back to in-memory state without crashing

## Remaining limitation
Streak data intentionally remains device/browser-local. Clearing site/app storage or moving to another device does not restore the streak.