### PR TITLE
Restore Learning Hub side bubbles after collapse

### DIFF
--- a/src/components/fresh/main-dashboard/learning-hub/LearningHub.jsx
+++ b/src/components/fresh/main-dashboard/learning-hub/LearningHub.jsx
@@ -161,6 +161,10 @@ export default function LearningHub({
     [],
   );
 
+  const handleCloseHub = useCallback(() => {
+    setShouldLoadHub(false);
+  }, []);
+
   useEffect(() => {
     if (!isGuideMode && !shouldLoadHub) return;
     setIsGuidedOnboardingIntroOpen(false);
@@ -358,7 +362,11 @@ export default function LearningHub({
           </div>
         ) : (
           <Suspense fallback={null}>
-            <LearningHubLoaded initialExpanded flushSpacing={true} />
+            <LearningHubLoaded
+              initialExpanded
+              flushSpacing={true}
+              onCollapse={handleCloseHub}
+            />
           </Suspense>
         )}
 

--- a/src/components/fresh/main-dashboard/learning-hub/LearningHubLoaded.jsx
+++ b/src/components/fresh/main-dashboard/learning-hub/LearningHubLoaded.jsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import { PlayCircle, Sparkles, X } from "lucide-react";
 import useLearningHub from "./logic/useLearningHub";
 import LearningHubCarousel from "./ui/LearningHubCarousel";
+import { LearningHubCollapseProvider } from "./ui/LearningHubToggleButton";
 import {
   openCommittedVersionModal,
   useCommittedFeatureAccess,
@@ -62,18 +63,19 @@ export default function LearningHubLoaded({
 
   return (
     <>
-      <LearningHubCarousel
-        items={carouselItems}
-        activeCategory={activeCategory}
-        activeCategoryLabel={activeCategoryMeta?.title || ""}
-        hasCommittedAccess={hasCommittedAccess}
-        initialExpanded={initialExpanded}
-        flushSpacing={flushSpacing}
-        onBackToCategories={backToHome}
-        onOpenCommitmentBooklet={openCommittedVersionModal}
-        onOpenItem={handleOpenItem}
-        onCollapse={onCollapse}
-      />
+      <LearningHubCollapseProvider onCollapse={onCollapse}>
+        <LearningHubCarousel
+          items={carouselItems}
+          activeCategory={activeCategory}
+          activeCategoryLabel={activeCategoryMeta?.title || ""}
+          hasCommittedAccess={hasCommittedAccess}
+          initialExpanded={initialExpanded}
+          flushSpacing={flushSpacing}
+          onBackToCategories={backToHome}
+          onOpenCommitmentBooklet={openCommittedVersionModal}
+          onOpenItem={handleOpenItem}
+        />
+      </LearningHubCollapseProvider>
 
       {hasCommittedAccess && isOpen && selectedMaterial ? (
         <Suspense fallback={null}>

--- a/src/components/fresh/main-dashboard/learning-hub/LearningHubLoaded.jsx
+++ b/src/components/fresh/main-dashboard/learning-hub/LearningHubLoaded.jsx
@@ -14,7 +14,11 @@ const FourPicsOneMoneyWordModal = lazy(() => import("./modal/FourPicsOneMoneyWor
 const MoneyRushModal = lazy(() => import("./modal/MoneyRushModal"));
 const MoneyPulseModal = lazy(() => import("./modal/MoneyPulseModal"));
 
-export default function LearningHubLoaded({ initialExpanded = false, flushSpacing = false }) {
+export default function LearningHubLoaded({
+  initialExpanded = false,
+  flushSpacing = false,
+  onCollapse,
+}) {
   const {
     activeCategory,
     activeCategoryMeta,
@@ -68,6 +72,7 @@ export default function LearningHubLoaded({ initialExpanded = false, flushSpacin
         onBackToCategories={backToHome}
         onOpenCommitmentBooklet={openCommittedVersionModal}
         onOpenItem={handleOpenItem}
+        onCollapse={onCollapse}
       />
 
       {hasCommittedAccess && isOpen && selectedMaterial ? (

--- a/src/components/fresh/main-dashboard/learning-hub/ui/LearningHubToggleButton.jsx
+++ b/src/components/fresh/main-dashboard/learning-hub/ui/LearningHubToggleButton.jsx
@@ -1,4 +1,8 @@
+import { createContext, useContext, useRef } from "react";
 import { BookOpen, ChevronDown, ChevronLeft, Lock } from "lucide-react";
+
+const LearningHubCollapseContext = createContext(null);
+const SWIPE_THRESHOLD = 34;
 
 const learningHubToggleSurface = {
   background:
@@ -7,6 +11,14 @@ const learningHubToggleSurface = {
   boxShadow:
     "0 10px 26px rgba(0,0,0,0.18), inset 0 1px 0 rgba(255,255,255,0.08)",
 };
+
+export function LearningHubCollapseProvider({ onCollapse, children }) {
+  return (
+    <LearningHubCollapseContext.Provider value={onCollapse}>
+      {children}
+    </LearningHubCollapseContext.Provider>
+  );
+}
 
 export default function LearningHubToggleButton({
   isExpanded = false,
@@ -20,7 +32,43 @@ export default function LearningHubToggleButton({
   flushSpacing = false,
   guideTarget = false,
 }) {
+  const collapseMainHub = useContext(LearningHubCollapseContext);
+  const touchStartYRef = useRef(null);
   const spacingClass = flushSpacing || isExpanded ? "mt-0 mb-0" : "mt-3 mb-0";
+  const usesParentCollapse =
+    isExpanded && !isInsideCategory && typeof collapseMainHub === "function";
+
+  const handleClick = (event) => {
+    if (usesParentCollapse) {
+      collapseMainHub();
+      return;
+    }
+
+    onClick?.(event);
+  };
+
+  const handleTouchStart = (event) => {
+    touchStartYRef.current = event.touches?.[0]?.clientY ?? null;
+    onTouchStart?.(event);
+  };
+
+  const handleTouchEnd = (event) => {
+    const startY = touchStartYRef.current;
+    const endY = event.changedTouches?.[0]?.clientY;
+    touchStartYRef.current = null;
+
+    if (
+      usesParentCollapse &&
+      startY !== null &&
+      Number.isFinite(endY) &&
+      endY - startY < -SWIPE_THRESHOLD
+    ) {
+      collapseMainHub();
+      return;
+    }
+
+    onTouchEnd?.(event);
+  };
 
   return (
     <button
@@ -36,9 +84,9 @@ export default function LearningHubToggleButton({
               ? "Collapse Learning Hub."
               : "Open Learning Hub."
       }
-      onClick={onClick}
-      onTouchStart={isLocked ? undefined : onTouchStart}
-      onTouchEnd={isLocked ? undefined : onTouchEnd}
+      onClick={handleClick}
+      onTouchStart={isLocked ? undefined : handleTouchStart}
+      onTouchEnd={isLocked ? undefined : handleTouchEnd}
       className={`clara-learning-motion relative isolate mx-auto ${spacingClass} flex w-fit items-center justify-center gap-2 overflow-hidden rounded-full border px-4 py-2 text-[11px] font-bold uppercase tracking-[0.24em] text-white/64 transition-[transform,background-color,border-color] duration-300 active:scale-[0.98] ${className}`}
       style={learningHubToggleSurface}
     >


### PR DESCRIPTION
Reset the parent Learning Hub state when the main Learning Hub closes so the Schedule Appointment and Guide bubbles return immediately. Existing category navigation, modals, access logic, and visual styling remain unchanged.