### PR TITLE
Add Learning Hub sound to ME pressure signals

### DIFF
--- a/src/runtime/installLearningHubOpenSound.js
+++ b/src/runtime/installLearningHubOpenSound.js
@@ -4,7 +4,7 @@ import { triggerClaraHaptic } from "@/lib/claraHaptics";
 const CLARA_SOUND_STORAGE_KEY = "clara:sound-enabled";
 const CLARA_SOUND_VOLUME_KEY = "clara:sound-volume";
 const LEARNING_HUB_TOGGLE_SELECTOR =
-  'button[aria-label="Open Learning Hub."], button[aria-label="Collapse Learning Hub."]';
+  'button[aria-label="Open Learning Hub."], button[aria-label="Collapse Learning Hub."], button[data-clara-pressure-signal]';
 const LEADING_SILENCE_SECONDS = 0.04;
 
 let installed = false;


### PR DESCRIPTION
Use the existing Learning Hub sound and light haptic for every ME pressure-signal button. The change relies on the existing delegated listener, so dynamically rendered signals are covered without changing advice behavior or layout.