### PR TITLE
Add money visibility sound to Life Stage Trend

### DIFF
--- a/src/runtime/installMoneyVisibilitySound.js
+++ b/src/runtime/installMoneyVisibilitySound.js
@@ -1,6 +1,7 @@
 import { playMoneyVisibilitySound } from "@/lib/moneyVisibilitySound";
 
-const SELECTOR = "[data-clara-summary-privacy-toggle='true']";
+const SELECTOR =
+  "[data-clara-summary-privacy-toggle='true'], button[data-clara-trend-card='true']";
 let installed = false;
 
 function findButton(target) {


### PR DESCRIPTION
Use the existing eye-open/hide-money visibility sound for every clickable Life Stage Trend card. The existing trend behavior, modal flow, styling, and data remain unchanged.