### PR TITLE
Add money visibility sound to ME heart guidance

### DIFF
--- a/src/runtime/installMoneyVisibilitySound.js
+++ b/src/runtime/installMoneyVisibilitySound.js
@@ -1,7 +1,7 @@
 import { playMoneyVisibilitySound } from "@/lib/moneyVisibilitySound";
 
 const SELECTOR =
-  "[data-clara-summary-privacy-toggle='true'], button[data-clara-trend-card='true']";
+  "[data-clara-summary-privacy-toggle='true'], button[data-clara-trend-card='true'], [data-clara-heart-cta='true']";
 let installed = false;
 
 function findButton(target) {


### PR DESCRIPTION
Use the existing money-visibility sound for the ME heart guidance control when toggling between ready and advice. Guidance content, state changes, layout, and styling remain unchanged.