### PR TITLE
Add AI summarization to Buy Check reason confirmation

### DIFF
--- a/src/components/fresh/main-dashboard/assistant/buyCheckReasonInterpreter.js
+++ b/src/components/fresh/main-dashboard/assistant/buyCheckReasonInterpreter.js
@@ -1,0 +1,71 @@
+import {
+  generateClaraGeminiReply,
+  hasGeminiConfig,
+} from "@/lib/clara-gemini-client";
+
+function clean(value = "") {
+  return String(value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function toNumber(value) {
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
+  const parsed = Number(String(value ?? "").replace(/[₱,\s]/g, ""));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function formatMoney(value = 0) {
+  return `₱${toNumber(value).toLocaleString("en-PH", { maximumFractionDigits: 0 })}`;
+}
+
+export function normalizeReasonSummary(value = "", fallback = "") {
+  const summary = clean(value)
+    .replace(/^```(?:text)?/i, "")
+    .replace(/```$/i, "")
+    .replace(/^(?:summary|interpretation|reason)\s*:\s*/i, "")
+    .replace(/^['“”"]+|['“”"]+$/g, "")
+    .replace(/\s*(?:did i understand that correctly\??|is that correct\??)$/i, "")
+    .replace(/[?.!]+$/, "")
+    .trim();
+
+  return summary || clean(fallback).replace(/[?.!]+$/, "");
+}
+
+export async function interpretBuyCheckReason({
+  item,
+  price,
+  originalReason,
+  assistantContext,
+}) {
+  const fallback = normalizeReasonSummary(originalReason, originalReason);
+  if (!hasGeminiConfig()) {
+    return { summary: fallback, source: "fallback" };
+  }
+
+  try {
+    const reply = await generateClaraGeminiReply({
+      message: `Interpret the user's reason for this Buy Check.\n\nItem: ${clean(item)}\nPrice: ${formatMoney(price)}\nExact reason: ${clean(originalReason)}\n\nReturn one concise second-person reason clause. Preserve the meaning and urgency. Match the user's language, including Taglish. Do not judge, advise, add facts, mention the price, or ask a question. Return only the rewritten reason without a label or quotation marks.`,
+      context: {
+        purchase: {
+          item: clean(item),
+          price: toNumber(price),
+          originalReason: clean(originalReason),
+        },
+        meProfile:
+          assistantContext?.meProfileContext ||
+          assistantContext?.lifeProfile ||
+          assistantContext?.user?.user_metadata ||
+          null,
+      },
+      mode: "buy_check_reason_interpretation",
+      conversationHistory: [],
+    });
+
+    return {
+      summary: normalizeReasonSummary(reply, fallback),
+      source: "ai",
+    };
+  } catch (error) {
+    console.warn("[CLARA Buy Check] Reason interpretation fallback used.", error);
+    return { summary: fallback, source: "fallback" };
+  }
+}

--- a/src/components/fresh/main-dashboard/assistant/useClaraBuyCheckFlow.js
+++ b/src/components/fresh/main-dashboard/assistant/useClaraBuyCheckFlow.js
@@ -1,2 +1,3 @@
-// Canonical export kept at the original import path.
-export { default } from "./useClaraBuyCheckFlowV4.js";
+import useClaraBuyCheckFlow from "./useClaraBuyCheckFlowV5.js";
+
+export default useClaraBuyCheckFlow;

--- a/src/components/fresh/main-dashboard/assistant/useClaraBuyCheckFlowV5.js
+++ b/src/components/fresh/main-dashboard/assistant/useClaraBuyCheckFlowV5.js
@@ -1,1 +1,1 @@
-export { default } from "./useClaraBuyCheckFlowV4.js";
+export { default } from "./useClaraBuyCheckReasonSummary.js";

--- a/src/components/fresh/main-dashboard/assistant/useClaraBuyCheckFlowV5.js
+++ b/src/components/fresh/main-dashboard/assistant/useClaraBuyCheckFlowV5.js
@@ -1,0 +1,1 @@
+export { default } from "./useClaraBuyCheckFlowV4.js";

--- a/src/components/fresh/main-dashboard/assistant/useClaraBuyCheckReasonSummary.js
+++ b/src/components/fresh/main-dashboard/assistant/useClaraBuyCheckReasonSummary.js
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import useClaraBuyCheckFlowV4 from "./useClaraBuyCheckFlowV4.js";
 import { formatMoney, interpretBuyCheckReason, normalizeReasonSummary } from "./buyCheckReasonInterpreter.js";
 
@@ -10,6 +10,8 @@ export default function useClaraBuyCheckReasonSummary({ assistantContext = {} } 
   const [reason, setReason] = useState(blank);
   const sessionRef = useRef("");
   sessionRef.current = flow.state?.sessionId || "";
+
+  useEffect(() => setReason(blank()), [flow.state?.sessionId]);
 
   const submitAnswer = useCallback(async (raw = "") => {
     const answer = clean(raw);
@@ -35,7 +37,7 @@ export default function useClaraBuyCheckReasonSummary({ assistantContext = {} } 
 
   const messages = useMemo(() => {
     const list = flow.messages || [];
-    if (reason.busy) return [...list, { id: `reason-${reason.sessionId}`, role: "clara", text: "Let me make sure I understood your reason correctly..." }];
+    if (reason.busy && reason.sessionId === flow.state?.sessionId) return [...list, { id: `reason-${reason.sessionId}`, role: "clara", text: "Let me make sure I understood your reason correctly..." }];
     if (!reason.confirmation || reason.sessionId !== flow.state?.sessionId) return list;
     return list.map((message, index) => index === reason.index ? { ...message, role: "user", text: reason.original } : index === reason.index + 1 ? { ...message, role: "clara", text: reason.confirmation } : message);
   }, [flow.messages, flow.state?.sessionId, reason]);

--- a/src/components/fresh/main-dashboard/assistant/useClaraBuyCheckReasonSummary.js
+++ b/src/components/fresh/main-dashboard/assistant/useClaraBuyCheckReasonSummary.js
@@ -1,0 +1,44 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import useClaraBuyCheckFlowV4 from "./useClaraBuyCheckFlowV4.js";
+import { formatMoney, interpretBuyCheckReason, normalizeReasonSummary } from "./buyCheckReasonInterpreter.js";
+
+const blank = () => ({ busy: false, original: "", summary: "", confirmation: "", sessionId: "", index: -1, source: "" });
+const clean = (v = "") => String(v ?? "").replace(/\s+/g, " ").trim();
+
+export default function useClaraBuyCheckReasonSummary({ assistantContext = {} } = {}) {
+  const flow = useClaraBuyCheckFlowV4({ assistantContext });
+  const [reason, setReason] = useState(blank);
+  const sessionRef = useRef("");
+  sessionRef.current = flow.state?.sessionId || "";
+
+  const submitAnswer = useCallback(async (raw = "") => {
+    const answer = clean(raw);
+    if (!answer) return false;
+    if (flow.state?.step !== "reason") return flow.submitAnswer(answer);
+    if (reason.busy || flow.state?.busy) return false;
+
+    const sessionId = flow.state?.sessionId || "";
+    const item = clean(flow.state?.item || "this purchase");
+    const price = Number(flow.state?.price || 0);
+    const index = flow.messages?.length || 0;
+    setReason({ busy: true, original: answer, summary: "", confirmation: "", sessionId, index, source: "" });
+
+    const result = await interpretBuyCheckReason({ item, price, originalReason: answer, assistantContext });
+    if (sessionRef.current !== sessionId) return false;
+
+    const summary = normalizeReasonSummary(result.summary, answer);
+    const confirmation = `You’re considering ${item} for ${formatMoney(price)} because ${summary}. Did I understand that correctly before I run the full Buy Check?`;
+    if (!flow.submitAnswer(summary)) return false;
+    setReason({ busy: false, original: answer, summary, confirmation, sessionId, index, source: result.source });
+    return true;
+  }, [assistantContext, flow, reason.busy]);
+
+  const messages = useMemo(() => {
+    const list = flow.messages || [];
+    if (reason.busy) return [...list, { id: `reason-${reason.sessionId}`, role: "clara", text: "Let me make sure I understood your reason correctly..." }];
+    if (!reason.confirmation || reason.sessionId !== flow.state?.sessionId) return list;
+    return list.map((message, index) => index === reason.index ? { ...message, role: "user", text: reason.original } : index === reason.index + 1 ? { ...message, role: "clara", text: reason.confirmation } : message);
+  }, [flow.messages, flow.state?.sessionId, reason]);
+
+  return { ...flow, submitAnswer, messages, state: { ...flow.state, busy: Boolean(flow.state?.busy || reason.busy), originalReason: reason.original || flow.state?.reason || "", summarizedReason: reason.summary || flow.state?.reason || "", reasonSummarySource: reason.source } };
+}


### PR DESCRIPTION
Replaces the static reason echo with an AI interpretation step before confirmation.

The user's exact reason remains visible in the conversation, while Gemini rewrites it into a concise natural summary that matches the user's language, including Taglish. CLARA shows a short understanding message while processing, then asks the user to confirm the interpreted reason before running the full diagnosis.

The flow includes a deterministic fallback when Gemini is unavailable and resets safely between Buy Check sessions so a cancelled AI request cannot lock the next session.

The existing diagnosis, final Will buy / Not buy accountability stage, wallet logging, and reflection behavior remain unchanged.

Vite production build passed and the Vercel preview is READY.