### PR TITLE
Restore active AI reason summarization routing

### DIFF
--- a/src/components/fresh/main-dashboard/assistant/buyCheckReasonInterpreter.js
+++ b/src/components/fresh/main-dashboard/assistant/buyCheckReasonInterpreter.js
@@ -1,7 +1,7 @@
 import {
-  generateClaraGeminiReply,
-  hasGeminiConfig,
-} from "@/lib/clara-gemini-client";
+  getClaraGeminiProxyModelCandidates,
+  requestClaraGeminiProxyText,
+} from "@/lib/clara-gemini-proxy-client";
 
 function clean(value = "") {
   return String(value ?? "").replace(/\s+/g, " ").trim();
@@ -37,35 +37,41 @@ export async function interpretBuyCheckReason({
   assistantContext,
 }) {
   const fallback = normalizeReasonSummary(originalReason, originalReason);
-  if (!hasGeminiConfig()) {
-    return { summary: fallback, source: "fallback" };
-  }
+  const profile =
+    assistantContext?.meProfileContext ||
+    assistantContext?.lifeProfile ||
+    assistantContext?.user?.user_metadata ||
+    null;
+  const prompt = `You are CLARA interpreting one user's reason before a Buy Check confirmation.
 
-  try {
-    const reply = await generateClaraGeminiReply({
-      message: `Interpret the user's reason for this Buy Check.\n\nItem: ${clean(item)}\nPrice: ${formatMoney(price)}\nExact reason: ${clean(originalReason)}\n\nReturn one concise second-person reason clause. Preserve the meaning and urgency. Match the user's language, including Taglish. Do not judge, advise, add facts, mention the price, or ask a question. Return only the rewritten reason without a label or quotation marks.`,
-      context: {
-        purchase: {
-          item: clean(item),
-          price: toNumber(price),
-          originalReason: clean(originalReason),
+Item: ${clean(item)}
+Price: ${formatMoney(price)}
+User's exact words: ${clean(originalReason)}
+Profile context: ${profile ? JSON.stringify(profile) : "Not available"}
+
+Rewrite the reason into one natural second-person clause that clearly shows what the user means. Preserve the exact meaning and urgency. Match the user's language, including Taglish. Do not repeat the sentence word-for-word unless it is already impossible to improve. Do not judge, advise, add facts, mention CLARA, mention the price, or ask a question. Return only the rewritten reason with no label or quotation marks.`;
+
+  let lastError = null;
+  for (const model of getClaraGeminiProxyModelCandidates()) {
+    try {
+      const reply = await requestClaraGeminiProxyText({
+        prompt,
+        model,
+        generationConfig: {
+          temperature: 0.35,
+          topP: 0.82,
+          maxOutputTokens: 120,
         },
-        meProfile:
-          assistantContext?.meProfileContext ||
-          assistantContext?.lifeProfile ||
-          assistantContext?.user?.user_metadata ||
-          null,
-      },
-      mode: "buy_check_reason_interpretation",
-      conversationHistory: [],
-    });
-
-    return {
-      summary: normalizeReasonSummary(reply, fallback),
-      source: "ai",
-    };
-  } catch (error) {
-    console.warn("[CLARA Buy Check] Reason interpretation fallback used.", error);
-    return { summary: fallback, source: "fallback" };
+      });
+      const summary = normalizeReasonSummary(reply, "");
+      if (summary) return { summary, source: "ai", model };
+    } catch (error) {
+      lastError = error;
+    }
   }
+
+  if (lastError) {
+    console.warn("[CLARA Buy Check] Direct reason interpretation fallback used.", lastError);
+  }
+  return { summary: fallback, source: "fallback" };
 }

--- a/src/components/fresh/main-dashboard/assistant/useClaraBuyCheckFlow.js
+++ b/src/components/fresh/main-dashboard/assistant/useClaraBuyCheckFlow.js
@@ -1,3 +1,3 @@
-import useClaraBuyCheckFlow from "./useClaraBuyCheckFlowV5.js";
+import useClaraBuyCheckFlow from "./useClaraBuyCheckReasonSummary.js";
 
 export default useClaraBuyCheckFlow;

--- a/src/components/fresh/main-dashboard/assistant/useClaraBuyCheckReasonSummary.js
+++ b/src/components/fresh/main-dashboard/assistant/useClaraBuyCheckReasonSummary.js
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import useClaraBuyCheckFlowV4 from "./useClaraBuyCheckFlowV4.js";
+import useClaraBuyCheckFlowV5 from "./useClaraBuyCheckFlowV5.js";
 import { formatMoney, interpretBuyCheckReason, normalizeReasonSummary } from "./buyCheckReasonInterpreter.js";
 
 const blank = () => ({ busy: false, original: "", summary: "", confirmation: "", sessionId: "", index: -1, source: "" });
 const clean = (v = "") => String(v ?? "").replace(/\s+/g, " ").trim();
 
 export default function useClaraBuyCheckReasonSummary({ assistantContext = {} } = {}) {
-  const flow = useClaraBuyCheckFlowV4({ assistantContext });
+  const flow = useClaraBuyCheckFlowV5({ assistantContext });
   const [reason, setReason] = useState(blank);
   const sessionRef = useRef("");
   sessionRef.current = flow.state?.sessionId || "";


### PR DESCRIPTION
The AI reason summarizer existed in the repository but was no longer in the active Buy Check path after the newer V5 budget-intelligence flow replaced the routed hook.

This repair:

- wraps the current V5 budget-aware Buy Check flow with the AI reason summarization layer
- points the canonical Buy Check hook to the combined flow
- sends the reason directly to the Gemini proxy instead of the generic deep-decision router
- preserves the current multi-budget matching, diagnosis, final Will buy / Not buy actions, expense logging, and reflection memory
- keeps a safe fallback if the Gemini proxy is unavailable

The final Vite production build passed and the Vercel preview is READY.