### PR TITLE
Prevent cut-off Buy Check AI explanations

### DIFF
--- a/src/components/fresh/main-dashboard/assistant/buyCheckReasonInterpreter.js
+++ b/src/components/fresh/main-dashboard/assistant/buyCheckReasonInterpreter.js
@@ -30,6 +30,51 @@ export function normalizeReasonSummary(value = "", fallback = "") {
   return summary || clean(fallback).replace(/[?.!]+$/, "");
 }
 
+function isCompleteReasonSummary(value = "") {
+  const summary = normalizeReasonSummary(value, "");
+  if (!summary || summary.length < 16 || summary.split(/\s+/).length < 4) return false;
+  if (/CLARA AI is unavailable/i.test(summary)) return false;
+  if (/[,:;\-–—]$/.test(clean(value))) return false;
+  if (/\b(and|but|because|so|while|with|for|to|if|unless|before|after|about|around|from|of|the|a|an|your|my|their|this|that)$/i.test(summary)) return false;
+  const openParentheses = (summary.match(/\(/g) || []).length;
+  const closeParentheses = (summary.match(/\)/g) || []).length;
+  return openParentheses === closeParentheses;
+}
+
+function completionRetryPrompt(originalPrompt, incompleteReply) {
+  return `${originalPrompt}
+
+Your previous response was incomplete and must not be used:
+"${clean(incompleteReply)}"
+
+Rewrite it again as one COMPLETE natural reason clause that can follow the word "because." Finish the thought with a concrete need, purpose, situation, or motivation. Do not end with a conjunction, article, or preposition. Return only the complete rewritten reason.`;
+}
+
+async function requestCompleteSummary({ prompt, model }) {
+  const generationConfig = {
+    temperature: 0.3,
+    topP: 0.82,
+    maxOutputTokens: 180,
+  };
+  const firstReply = await requestClaraGeminiProxyText({
+    prompt,
+    model,
+    generationConfig,
+  });
+  if (isCompleteReasonSummary(firstReply)) return firstReply;
+
+  const retryReply = await requestClaraGeminiProxyText({
+    prompt: completionRetryPrompt(prompt, firstReply),
+    model,
+    generationConfig: {
+      ...generationConfig,
+      temperature: 0.2,
+      maxOutputTokens: 220,
+    },
+  });
+  return isCompleteReasonSummary(retryReply) ? retryReply : "";
+}
+
 export async function interpretBuyCheckReason({
   item,
   price,
@@ -49,20 +94,12 @@ Price: ${formatMoney(price)}
 User's exact words: ${clean(originalReason)}
 Profile context: ${profile ? JSON.stringify(profile) : "Not available"}
 
-Rewrite the reason into one natural second-person clause that clearly shows what the user means. Preserve the exact meaning and urgency. Match the user's language, including Taglish. Do not repeat the sentence word-for-word unless it is already impossible to improve. Do not judge, advise, add facts, mention CLARA, mention the price, or ask a question. Return only the rewritten reason with no label or quotation marks.`;
+Rewrite the reason into one complete, natural second-person clause that clearly shows what the user means and can grammatically follow the word "because." Preserve the exact meaning and urgency. Match the user's language, including Taglish. Do not repeat the sentence word-for-word unless it is already impossible to improve. Do not judge, advise, add facts, mention CLARA, mention the price, or ask a question. Finish the thought completely. Return only the rewritten reason with no label or quotation marks.`;
 
   let lastError = null;
   for (const model of getClaraGeminiProxyModelCandidates()) {
     try {
-      const reply = await requestClaraGeminiProxyText({
-        prompt,
-        model,
-        generationConfig: {
-          temperature: 0.35,
-          topP: 0.82,
-          maxOutputTokens: 120,
-        },
-      });
+      const reply = await requestCompleteSummary({ prompt, model });
       const summary = normalizeReasonSummary(reply, "");
       if (summary) return { summary, source: "ai", model };
     } catch (error) {
@@ -71,7 +108,7 @@ Rewrite the reason into one natural second-person clause that clearly shows what
   }
 
   if (lastError) {
-    console.warn("[CLARA Buy Check] Direct reason interpretation fallback used.", lastError);
+    console.warn("[CLARA Buy Check] Complete reason interpretation fallback used.", lastError);
   }
   return { summary: fallback, source: "fallback" };
 }


### PR DESCRIPTION
The direct Gemini reason-summary path accepted any non-empty response, so an incomplete fragment could be shown to the user without a retry.

This fix:

- validates that the AI summary is long enough and grammatically complete
- rejects replies ending in conjunctions, articles, or prepositions
- rejects unfinished punctuation and unbalanced parentheses
- retries once on the same model with a stricter completion prompt
- increases the output allowance for the retry
- safely falls back to the user's original reason if all model attempts remain incomplete

The existing budget intelligence, diagnosis, final Will buy / Not buy flow, expense logging, and decision memory remain unchanged.

The Vite production build passed and the Vercel preview is READY.