### PR TITLE
Align Buy Check buttons with CLARA recommendation

### DIFF
--- a/src/components/fresh/main-dashboard/assistant/buy-check/BuyCheckDecisionCard.jsx
+++ b/src/components/fresh/main-dashboard/assistant/buy-check/BuyCheckDecisionCard.jsx
@@ -4,13 +4,68 @@ const clean = (value = "") => String(value || "").replace(/\s+/g, " ").trim();
 
 function actionConfig(decision = "", reasonCode = "") {
   const normalized = clean(decision).toUpperCase();
-  if (["NO_PAYABLE_WALLET", "SCAN_FAILED"].includes(clean(reasonCode).toUpperCase())) return { primary: "Review setup", primaryAction: "open_details", secondary: "Not now", secondaryAction: "not_buy" };
-  if (normalized === "BUY") return { primary: "Buy and log expense", primaryAction: "buy", secondary: "Not now", secondaryAction: "not_buy" };
-  if (normalized === "BUY WITH CAP") return { primary: "Buy within limit", primaryAction: "buy", secondary: "Wait for now", secondaryAction: "not_buy" };
-  if (normalized === "REDUCE") return { primary: "Adjust amount", primaryAction: "edit_amount", secondary: "Continue anyway", secondaryAction: "buy" };
-  if (normalized === "WAIT") return { primary: "Wait for now", primaryAction: "not_buy", secondary: "Continue anyway", secondaryAction: "buy" };
-  if (normalized === "DO NOT BUY") return { primary: "Protect my money", primaryAction: "not_buy", secondary: "Continue anyway", secondaryAction: "buy" };
-  return { primary: "Review setup", primaryAction: "open_details", secondary: "Continue carefully", secondaryAction: "buy" };
+  const normalizedReason = clean(reasonCode).toUpperCase();
+
+  if (["NO_PAYABLE_WALLET", "SCAN_FAILED"].includes(normalizedReason)) {
+    return {
+      primary: "Will not buy yet",
+      primaryAction: "not_buy",
+      secondary: "Buy anyway",
+      secondaryAction: "buy",
+    };
+  }
+
+  if (normalized === "BUY") {
+    return {
+      primary: "Will buy",
+      primaryAction: "buy",
+      secondary: "Will not buy",
+      secondaryAction: "not_buy",
+    };
+  }
+
+  if (normalized === "BUY WITH CAP") {
+    return {
+      primary: "Will buy within limit",
+      primaryAction: "buy",
+      secondary: "Will not buy",
+      secondaryAction: "not_buy",
+    };
+  }
+
+  if (normalized === "REDUCE") {
+    return {
+      primary: "Will reduce amount",
+      primaryAction: "edit_amount",
+      secondary: "Buy anyway",
+      secondaryAction: "buy",
+    };
+  }
+
+  if (normalized === "WAIT") {
+    return {
+      primary: "Will wait for now",
+      primaryAction: "not_buy",
+      secondary: "Buy anyway",
+      secondaryAction: "buy",
+    };
+  }
+
+  if (normalized === "DO NOT BUY") {
+    return {
+      primary: "Will not buy",
+      primaryAction: "not_buy",
+      secondary: "Buy anyway",
+      secondaryAction: "buy",
+    };
+  }
+
+  return {
+    primary: "Will wait for now",
+    primaryAction: "not_buy",
+    secondary: "Buy anyway",
+    secondaryAction: "buy",
+  };
 }
 
 function themeFor(decision = "") {


### PR DESCRIPTION
Update only the action labels and mappings on the one-card Buy Check result.

Behavior:
- BUY → blue `Will buy`, dark `Will not buy`
- BUY WITH CAP → blue `Will buy within limit`, dark `Will not buy`
- REDUCE → blue `Will reduce amount`, dark `Buy anyway`
- WAIT → blue `Will wait for now`, dark `Buy anyway`
- DO NOT BUY → blue `Will not buy`, dark `Buy anyway`
- Missing wallet / scan failure / PAUSE → blue waiting or not-buying action, dark `Buy anyway`

The blue primary action now always follows CLARA’s recommendation. No card styling, layout, financial logic, or report UI is changed.