### PR TITLE
Refine Buy Check report carousel into premium briefing

### DIFF
--- a/src/components/fresh/main-dashboard/assistant/buy-check/BuyCheckDetailCarousel.jsx
+++ b/src/components/fresh/main-dashboard/assistant/buy-check/BuyCheckDetailCarousel.jsx
@@ -1,29 +1,250 @@
-function cardTheme(card = {}) {
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Check, ChevronLeft, ChevronRight } from "lucide-react";
+
+const clamp = (value, minimum, maximum) => Math.min(Math.max(value, minimum), maximum);
+
+function cardVisual(card = {}) {
+  const eyebrow = String(card.eyebrow || "").toUpperCase();
   const decision = String(card.decision || "").toUpperCase();
-  if (!card.final) return "border-white/10 bg-slate-950/30";
-  if (decision === "BUY") return "border-emerald-200/22 bg-emerald-300/10";
-  if (decision === "WAIT") return "border-orange-200/22 bg-orange-300/10";
-  if (decision === "REDUCE") return "border-amber-200/22 bg-amber-300/10";
-  if (decision === "DO NOT BUY") return "border-rose-200/22 bg-rose-300/10";
-  return "border-violet-200/22 bg-violet-300/10";
+
+  if (card.final) {
+    if (decision === "BUY") {
+      return {
+        surface: "bg-[linear-gradient(145deg,rgba(6,78,59,0.30),rgba(2,6,23,0.94)_58%,rgba(8,47,73,0.36))]",
+        glow: "bg-emerald-300/12",
+        metric: "text-emerald-100",
+      };
+    }
+    if (decision === "WAIT" || decision === "DO NOT BUY") {
+      return {
+        surface: "bg-[linear-gradient(145deg,rgba(127,29,29,0.20),rgba(2,6,23,0.95)_58%,rgba(67,20,7,0.28))]",
+        glow: "bg-rose-300/10",
+        metric: "text-rose-100",
+      };
+    }
+    if (decision === "REDUCE") {
+      return {
+        surface: "bg-[linear-gradient(145deg,rgba(120,53,15,0.22),rgba(2,6,23,0.95)_58%,rgba(69,26,3,0.30))]",
+        glow: "bg-amber-300/10",
+        metric: "text-amber-100",
+      };
+    }
+    return {
+      surface: "bg-[linear-gradient(145deg,rgba(76,29,149,0.24),rgba(2,6,23,0.95)_58%,rgba(30,58,138,0.26))]",
+      glow: "bg-violet-300/12",
+      metric: "text-violet-100",
+    };
+  }
+
+  if (/INCOME|CALENDAR/.test(eyebrow)) {
+    return {
+      surface: "bg-[linear-gradient(145deg,rgba(8,145,178,0.18),rgba(2,6,23,0.95)_58%,rgba(49,46,129,0.20))]",
+      glow: "bg-cyan-300/10",
+      metric: "text-cyan-100",
+    };
+  }
+
+  if (/WALLET|SAFE TO SPEND|FINAL CALCULATION/.test(eyebrow)) {
+    return {
+      surface: "bg-[linear-gradient(145deg,rgba(13,148,136,0.18),rgba(2,6,23,0.95)_58%,rgba(30,64,175,0.20))]",
+      glow: "bg-teal-300/10",
+      metric: "text-teal-100",
+    };
+  }
+
+  if (/BUDGET|OBLIGATION|EMERGENCY|SAVINGS/.test(eyebrow)) {
+    return {
+      surface: "bg-[linear-gradient(145deg,rgba(67,56,202,0.18),rgba(2,6,23,0.95)_58%,rgba(88,28,135,0.20))]",
+      glow: "bg-violet-300/10",
+      metric: "text-violet-100",
+    };
+  }
+
+  return {
+    surface: "bg-[linear-gradient(145deg,rgba(14,116,144,0.14),rgba(2,6,23,0.95)_58%,rgba(76,29,149,0.18))]",
+    glow: "bg-cyan-300/10",
+    metric: "text-slate-100",
+  };
 }
 
-export default function BuyCheckDetailCarousel({ cards = [] }) {
-  const visibleCards = Array.isArray(cards) ? cards.filter(Boolean) : [];
+function isPrimaryMetric(value = "") {
+  return /₱|^-?\d|\bday\b|\bdays\b|%/i.test(String(value).trim());
+}
+
+export default function BuyCheckDetailCarousel({ cards = [], onIndexChange, onFinish }) {
+  const visibleCards = useMemo(() => (Array.isArray(cards) ? cards.filter(Boolean) : []), [cards]);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const trackRef = useRef(null);
+  const cardRefs = useRef([]);
+  const frameRef = useRef(0);
+
+  const publishIndex = useCallback((index) => {
+    const nextIndex = clamp(index, 0, Math.max(visibleCards.length - 1, 0));
+    setActiveIndex((current) => {
+      if (current === nextIndex) return current;
+      return nextIndex;
+    });
+    onIndexChange?.(nextIndex);
+  }, [onIndexChange, visibleCards.length]);
+
+  const goToCard = useCallback((index) => {
+    if (!visibleCards.length) return;
+    const nextIndex = clamp(index, 0, visibleCards.length - 1);
+    const track = trackRef.current;
+    const target = cardRefs.current[nextIndex];
+    if (!track || !target) return;
+
+    const left = target.offsetLeft - (track.clientWidth - target.clientWidth) / 2;
+    track.scrollTo({ left, behavior: "smooth" });
+    publishIndex(nextIndex);
+  }, [publishIndex, visibleCards.length]);
+
+  const updateIndexFromScroll = useCallback(() => {
+    window.cancelAnimationFrame(frameRef.current);
+    frameRef.current = window.requestAnimationFrame(() => {
+      const track = trackRef.current;
+      if (!track || !visibleCards.length) return;
+
+      const viewportCenter = track.scrollLeft + track.clientWidth / 2;
+      let nearestIndex = 0;
+      let nearestDistance = Number.POSITIVE_INFINITY;
+
+      cardRefs.current.forEach((card, index) => {
+        if (!card) return;
+        const cardCenter = card.offsetLeft + card.clientWidth / 2;
+        const distance = Math.abs(cardCenter - viewportCenter);
+        if (distance < nearestDistance) {
+          nearestDistance = distance;
+          nearestIndex = index;
+        }
+      });
+
+      if (nearestIndex !== activeIndex) publishIndex(nearestIndex);
+    });
+  }, [activeIndex, publishIndex, visibleCards.length]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+    onIndexChange?.(0);
+    const frame = window.requestAnimationFrame(() => {
+      trackRef.current?.scrollTo({ left: 0, behavior: "auto" });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [onIndexChange, visibleCards]);
+
+  useEffect(() => () => window.cancelAnimationFrame(frameRef.current), []);
+
+  const handleKeyDown = (event) => {
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      goToCard(activeIndex - 1);
+    }
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      if (activeIndex === visibleCards.length - 1) onFinish?.();
+      else goToCard(activeIndex + 1);
+    }
+  };
+
   if (!visibleCards.length) {
-    return <p className="text-sm font-semibold text-slate-300/75">No detailed evidence is available for this result.</p>;
+    return (
+      <div className="grid h-full min-h-[280px] place-items-center rounded-[26px] border border-white/10 bg-white/[0.035] px-6 text-center">
+        <p className="text-sm font-medium leading-6 text-slate-300/75">No detailed evidence is available for this result.</p>
+      </div>
+    );
   }
+
+  const isLastCard = activeIndex === visibleCards.length - 1;
+
   return (
-    <div data-clara-buy-check-detail-carousel="true" className="flex snap-x snap-mandatory gap-3 overflow-x-auto pb-4">
-      {visibleCards.map((card, index) => (
-        <article key={`${card.eyebrow || "detail"}-${index}`} className={`min-w-full snap-center rounded-[24px] border px-5 py-5 text-left ${cardTheme(card)}`}>
-          <p className="text-[9px] font-black uppercase tracking-[0.18em] text-cyan-100/48">{card.eyebrow}</p>
-          <h3 className="mt-2 text-[20px] font-black leading-tight text-white">{card.title}</h3>
-          {card.stat ? <div className="mt-3 inline-flex rounded-full border border-white/10 bg-white/10 px-3 py-1 text-[11px] font-black text-slate-100/90">{card.stat}</div> : null}
-          <p className="mt-4 text-[13px] font-bold leading-6 text-slate-100/90">{card.body}</p>
-          {card.note ? <p className="mt-4 text-[11px] font-black leading-5 text-slate-300/62">{card.note}</p> : null}
-        </article>
-      ))}
+    <div
+      data-clara-buy-check-detail-carousel="true"
+      className="flex h-full min-h-0 flex-col"
+      role="region"
+      aria-roledescription="carousel"
+      aria-label="Buy Check financial report"
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+    >
+      <div
+        ref={trackRef}
+        onScroll={updateIndexFromScroll}
+        className="flex min-h-0 flex-1 snap-x snap-mandatory gap-3.5 overflow-x-auto overscroll-x-contain px-1.5 pb-2 scroll-smooth [scrollbar-width:none] focus:outline-none motion-reduce:scroll-auto [&::-webkit-scrollbar]:hidden"
+      >
+        {visibleCards.map((card, index) => {
+          const visual = cardVisual(card);
+          const metric = isPrimaryMetric(card.stat);
+          const active = index === activeIndex;
+
+          return (
+            <article
+              ref={(element) => { cardRefs.current[index] = element; }}
+              key={`${card.eyebrow || "detail"}-${index}`}
+              role="group"
+              aria-roledescription="slide"
+              aria-label={`${index + 1} of ${visibleCards.length}: ${card.title || "Buy Check finding"}`}
+              style={{ minWidth: "calc(100% - 44px)", flexBasis: "calc(100% - 44px)" }}
+              className={`relative h-full min-h-[360px] snap-center overflow-y-auto rounded-[28px] border border-white/10 px-5 py-5 text-left shadow-[0_24px_60px_rgba(0,0,0,0.30),inset_0_1px_0_rgba(255,255,255,0.06)] transition-[opacity,transform,border-color] duration-300 motion-reduce:transition-none ${visual.surface} ${active ? "scale-100 border-white/14 opacity-100" : "scale-[0.985] opacity-70"}`}
+            >
+              <div className={`pointer-events-none absolute -right-12 -top-12 h-36 w-36 rounded-full blur-3xl ${visual.glow}`} />
+              <div className="relative z-10 flex min-h-full flex-col">
+                <p className="text-[9px] font-bold uppercase tracking-[0.20em] text-cyan-100/58">{card.eyebrow}</p>
+                <h3 className="mt-3 max-w-[95%] text-[23px] font-extrabold leading-[1.12] tracking-[-0.025em] text-white/95">{card.title}</h3>
+
+                {card.stat ? (
+                  metric ? (
+                    <p className={`mt-5 text-[28px] font-black leading-none tracking-[-0.035em] ${visual.metric}`}>{card.stat}</p>
+                  ) : (
+                    <div className="mt-4 inline-flex w-fit rounded-full border border-white/10 bg-white/[0.07] px-3 py-1.5 text-[11px] font-semibold text-slate-100/86">
+                      {card.stat}
+                    </div>
+                  )
+                ) : null}
+
+                <p className="mt-5 max-w-[95%] text-[13.5px] font-medium leading-[1.65] text-slate-100/84">{card.body}</p>
+
+                {card.note ? (
+                  <div className="mt-auto pt-7">
+                    <div className="border-t border-white/10 pt-4">
+                      <p className="text-[9px] font-bold uppercase tracking-[0.18em] text-cyan-100/46">
+                        {card.final ? "CLARA’S SAFER MOVE" : "WHAT THIS MEANS"}
+                      </p>
+                      <p className="mt-2 text-[12px] font-semibold leading-5 text-slate-200/72">{card.note}</p>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+
+      <div className="mt-3 flex shrink-0 items-center justify-between gap-3 rounded-[20px] border border-white/[0.08] bg-white/[0.04] p-1.5 backdrop-blur-xl">
+        <button
+          type="button"
+          onClick={() => goToCard(activeIndex - 1)}
+          disabled={activeIndex === 0}
+          aria-label="Previous report card"
+          className="inline-flex min-h-11 items-center gap-1 rounded-[15px] px-3 text-[11px] font-semibold text-slate-100/82 transition hover:bg-white/[0.06] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-30 motion-reduce:transition-none"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          Previous
+        </button>
+
+        <span aria-live="polite" className="text-[11px] font-medium tabular-nums text-slate-300/68">
+          {activeIndex + 1} of {visibleCards.length}
+        </span>
+
+        <button
+          type="button"
+          onClick={() => isLastCard ? onFinish?.() : goToCard(activeIndex + 1)}
+          aria-label={isLastCard ? "Back to Buy Check result" : "Next report card"}
+          className="inline-flex min-h-11 items-center gap-1 rounded-[15px] px-3 text-[11px] font-semibold text-cyan-100/88 transition hover:bg-white/[0.06] active:scale-[0.98] motion-reduce:transition-none"
+        >
+          {isLastCard ? "Back to result" : "Next"}
+          {isLastCard ? <Check className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/fresh/main-dashboard/assistant/buy-check/BuyCheckEvidencePanel.jsx
+++ b/src/components/fresh/main-dashboard/assistant/buy-check/BuyCheckEvidencePanel.jsx
@@ -1,25 +1,68 @@
+import { useEffect, useMemo, useState } from "react";
 import { ArrowLeft } from "lucide-react";
 import BuyCheckDetailCarousel from "./BuyCheckDetailCarousel.jsx";
 
 export default function BuyCheckEvidencePanel({ open = false, diagnosis, onClose }) {
+  const cards = useMemo(() => {
+    const source = diagnosis?.detailCards || diagnosis?.cards || [];
+    return Array.isArray(source) ? source.filter(Boolean) : [];
+  }, [diagnosis]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  useEffect(() => {
+    if (open) setCurrentIndex(0);
+  }, [diagnosis, open]);
+
   if (!open) return null;
-  const cards = diagnosis?.detailCards || diagnosis?.cards || [];
+
+  const pageCount = cards.length;
+  const safeIndex = pageCount ? Math.min(currentIndex, pageCount - 1) : 0;
+  const progress = pageCount ? ((safeIndex + 1) / pageCount) * 100 : 0;
+
   return (
-    <section data-clara-buy-check-details-sheet="true" className="fixed inset-0 z-[400] mx-auto flex w-full max-w-[430px] flex-col overflow-hidden bg-slate-950 px-3 pb-[max(env(safe-area-inset-bottom),16px)] pt-[max(env(safe-area-inset-top),18px)] text-white">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_18%_0%,rgba(45,212,191,0.18),transparent_34%),radial-gradient(circle_at_88%_10%,rgba(124,58,237,0.24),transparent_40%),linear-gradient(180deg,#020617_0%,#020617_100%)]" />
-      <header className="relative z-10 flex shrink-0 items-start justify-between gap-3 px-2 pb-5 pt-2">
-        <div>
-          <p className="text-[10px] font-black uppercase tracking-[0.22em] text-cyan-100/55">FULL BUY CHECK</p>
-          <h2 className="mt-1 text-[22px] font-black text-white">Why this result?</h2>
-          <p className="mt-1 text-[11px] font-semibold text-slate-300/70">Swipe through the verified financial evidence.</p>
+    <section
+      data-clara-buy-check-details-sheet="true"
+      className="fixed inset-0 z-[400] mx-auto flex w-full max-w-[430px] flex-col overflow-hidden bg-[#020617] px-3 pb-[max(env(safe-area-inset-bottom),14px)] pt-[max(env(safe-area-inset-top),16px)] text-white"
+    >
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_12%_0%,rgba(34,211,238,0.14),transparent_34%),radial-gradient(circle_at_92%_5%,rgba(124,58,237,0.20),transparent_38%),linear-gradient(180deg,#020617_0%,#020617_100%)]" />
+
+      <header className="relative z-10 shrink-0 px-2 pb-4 pt-1">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <p className="text-[9px] font-bold uppercase tracking-[0.22em] text-cyan-100/58">BUY CHECK REPORT</p>
+            <h2 className="mt-1.5 max-w-[285px] text-[24px] font-extrabold leading-[1.12] tracking-[-0.03em] text-white/96">
+              Why CLARA gave this result
+            </h2>
+            <p className="mt-2 text-[11px] font-medium leading-5 text-slate-300/66">
+              Verified financial evidence, one finding at a time.
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={onClose}
+            className="grid h-11 w-11 shrink-0 place-items-center rounded-full border border-white/10 bg-white/[0.05] text-white/88 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] transition hover:bg-white/[0.08] active:scale-[0.97] motion-reduce:transition-none"
+            aria-label="Back to Buy Check result"
+          >
+            <ArrowLeft className="h-[18px] w-[18px]" />
+          </button>
         </div>
-        <button type="button" onClick={onClose} className="inline-flex min-h-10 shrink-0 items-center gap-2 rounded-full border border-white/14 bg-white/[0.06] px-3 text-[11px] font-black text-white" aria-label="Back to Buy Check result">
-          <ArrowLeft className="h-4 w-4" />
-          Back
-        </button>
+
+        <div className="mt-4 flex items-center gap-3">
+          <span aria-live="polite" className="shrink-0 text-[11px] font-medium tabular-nums text-slate-300/68">
+            {pageCount ? `${safeIndex + 1} of ${pageCount}` : "No report pages"}
+          </span>
+          <div className="h-1 flex-1 overflow-hidden rounded-full bg-white/[0.07]" aria-hidden="true">
+            <div
+              className="h-full rounded-full bg-[linear-gradient(90deg,rgba(45,212,191,0.92),rgba(103,232,249,0.92),rgba(139,92,246,0.88))] transition-[width] duration-300 motion-reduce:transition-none"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
       </header>
-      <div className="relative z-10 min-h-0 flex-1 overflow-y-auto px-1 pb-4">
-        <BuyCheckDetailCarousel cards={cards} />
+
+      <div className="relative z-10 min-h-0 flex-1 px-0.5 pb-1">
+        <BuyCheckDetailCarousel cards={cards} onIndexChange={setCurrentIndex} onFinish={onClose} />
       </div>
     </section>
   );


### PR DESCRIPTION
## Scope
Refine only the dedicated Buy Check report presentation and carousel interaction.

## Changes
- Add a compact premium report header with page count and animated progress
- Keep the report fully opaque and dedicated
- Add clear horizontal swipe affordance with partial next-card preview
- Synchronize swipe position, page count, Previous/Next controls, and keyboard navigation
- Change the final Next action to `Back to result`
- Use full-height briefing cards with restrained gradients, softer borders, intentional spacing, lighter body typography, and anchored meaning/safer-move sections
- Preserve the existing `cards` / `detailCards` payload and Back contract

## Strict non-changes
- No Buy Check calculation changes
- No diagnosis or verdict changes
- No action mapping changes
- No expense-flow changes
- No main result-card changes
- No conversation or input-bar changes

## Verification
GitHub Actions will run:
- `npm test`
- `npm run lint:buy-check`
- `npm run build`

Implementation follows the uploaded surgical UI scope lock.