### PR TITLE
Fix Buy Check carousel sizing and slide bleed

### DIFF
--- a/src/components/fresh/main-dashboard/assistant/buy-check/BuyCheckDetailCarouselCompact.jsx
+++ b/src/components/fresh/main-dashboard/assistant/buy-check/BuyCheckDetailCarouselCompact.jsx
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+function surfaceFor(card = {}) {
+  const key = String(card.eyebrow || "").toUpperCase();
+  const decision = String(card.decision || "").toUpperCase();
+  if (card.final && decision === "BUY") return "bg-[linear-gradient(145deg,rgba(6,78,59,.16),rgba(8,15,34,.98)_60%,rgba(8,47,73,.14))]";
+  if (card.final && /WAIT|DO NOT BUY/.test(decision)) return "bg-[linear-gradient(145deg,rgba(127,29,29,.10),rgba(8,15,34,.98)_60%,rgba(67,20,7,.12))]";
+  if (/INCOME|CALENDAR/.test(key)) return "bg-[linear-gradient(145deg,rgba(8,145,178,.09),rgba(8,15,34,.98)_60%,rgba(49,46,129,.09))]";
+  if (/WALLET|SAFE TO SPEND|FINAL CALCULATION/.test(key)) return "bg-[linear-gradient(145deg,rgba(13,148,136,.09),rgba(8,15,34,.98)_60%,rgba(30,64,175,.09))]";
+  return "bg-[linear-gradient(145deg,rgba(67,56,202,.09),rgba(8,15,34,.98)_60%,rgba(88,28,135,.09))]";
+}
+
+function metricLike(value = "") {
+  return /₱|^-?\d|\bday\b|\bdays\b|%/i.test(String(value).trim());
+}
+
+export default function BuyCheckDetailCarouselCompact({ cards = [], onIndexChange, onFinish }) {
+  const items = useMemo(() => (Array.isArray(cards) ? cards.filter(Boolean) : []), [cards]);
+  const [index, setIndex] = useState(0);
+  const trackRef = useRef(null);
+  const slideRefs = useRef([]);
+  const frameRef = useRef(0);
+
+  const publish = useCallback((next) => {
+    const safe = clamp(next, 0, Math.max(items.length - 1, 0));
+    setIndex(safe);
+    onIndexChange?.(safe);
+  }, [items.length, onIndexChange]);
+
+  const goTo = useCallback((next) => {
+    if (!items.length) return;
+    const safe = clamp(next, 0, items.length - 1);
+    const track = trackRef.current;
+    const slide = slideRefs.current[safe];
+    if (!track || !slide) return;
+    track.scrollTo({ left: slide.offsetLeft, behavior: "smooth" });
+    publish(safe);
+  }, [items.length, publish]);
+
+  const readPosition = useCallback(() => {
+    window.cancelAnimationFrame(frameRef.current);
+    frameRef.current = window.requestAnimationFrame(() => {
+      const track = trackRef.current;
+      if (!track) return;
+      let nearest = 0;
+      let distance = Number.POSITIVE_INFINITY;
+      slideRefs.current.forEach((slide, slideIndex) => {
+        if (!slide) return;
+        const current = Math.abs(slide.offsetLeft - track.scrollLeft);
+        if (current < distance) {
+          distance = current;
+          nearest = slideIndex;
+        }
+      });
+      if (nearest !== index) publish(nearest);
+    });
+  }, [index, publish]);
+
+  useEffect(() => {
+    slideRefs.current = slideRefs.current.slice(0, items.length);
+    setIndex(0);
+    onIndexChange?.(0);
+    const frame = window.requestAnimationFrame(() => trackRef.current?.scrollTo({ left: 0, behavior: "auto" }));
+    return () => window.cancelAnimationFrame(frame);
+  }, [items, onIndexChange]);
+
+  useEffect(() => () => window.cancelAnimationFrame(frameRef.current), []);
+
+  if (!items.length) {
+    return <div className="grid min-h-[260px] place-items-center rounded-[22px] border border-white/[0.08] bg-white/[0.025] px-6 text-center text-sm font-medium text-slate-300/75">No detailed evidence is available for this result.</div>;
+  }
+
+  const last = index === items.length - 1;
+
+  return (
+    <div role="region" aria-roledescription="carousel" aria-label="Buy Check financial report" tabIndex={0} onKeyDown={(event) => {
+      if (event.key === "ArrowLeft") { event.preventDefault(); goTo(index - 1); }
+      if (event.key === "ArrowRight") { event.preventDefault(); last ? onFinish?.() : goTo(index + 1); }
+    }}>
+      <div ref={trackRef} onScroll={readPosition} className="flex snap-x snap-mandatory gap-3 overflow-x-auto overflow-y-hidden scroll-smooth [scrollbar-width:none] [&::-webkit-scrollbar]:hidden" style={{ scrollPaddingInline: 0 }}>
+        {items.map((card, slideIndex) => (
+          <article
+            key={`${card.eyebrow || "detail"}-${slideIndex}`}
+            ref={(node) => { slideRefs.current[slideIndex] = node; }}
+            role="group"
+            aria-roledescription="slide"
+            aria-label={`${slideIndex + 1} of ${items.length}: ${card.title || "Buy Check finding"}`}
+            className={`w-full shrink-0 snap-start rounded-[24px] border border-white/[0.08] px-5 py-5 text-left shadow-[0_18px_42px_rgba(0,0,0,.24),inset_0_1px_0_rgba(255,255,255,.04)] ${surfaceFor(card)}`}
+          >
+            <p className="text-[9px] font-bold uppercase tracking-[0.18em] text-cyan-100/56">{card.eyebrow}</p>
+            <h3 className="mt-3 max-w-[96%] text-[21px] font-extrabold leading-[1.16] tracking-[-0.025em] text-white/95">{card.title}</h3>
+            {card.stat ? metricLike(card.stat)
+              ? <p className="mt-4 text-[26px] font-black leading-none tracking-[-0.03em] text-white/94">{card.stat}</p>
+              : <div className="mt-4 inline-flex w-fit rounded-full border border-white/[0.08] bg-white/[0.055] px-3 py-1.5 text-[11px] font-semibold text-slate-100/84">{card.stat}</div>
+              : null}
+            <p className="mt-4 max-w-[96%] text-[13px] font-medium leading-[1.62] text-slate-100/82">{card.body}</p>
+            {card.note ? <div className="mt-6 border-t border-white/[0.08] pt-4">
+              <p className="text-[9px] font-bold uppercase tracking-[0.16em] text-cyan-100/44">{card.final ? "CLARA’S SAFER MOVE" : "WHAT THIS MEANS"}</p>
+              <p className="mt-2 text-[12px] font-semibold leading-5 text-slate-200/70">{card.note}</p>
+            </div> : null}
+          </article>
+        ))}
+      </div>
+
+      <div className="mt-4 flex items-center justify-between border-t border-white/[0.07] pt-3">
+        <button type="button" onClick={() => goTo(index - 1)} disabled={index === 0} aria-label="Previous report card" className="inline-flex min-h-11 items-center gap-1 px-1 text-[11px] font-semibold text-slate-100/76 disabled:opacity-25">
+          <ChevronLeft className="h-4 w-4" /> Previous
+        </button>
+        <span aria-live="polite" className="text-[11px] font-medium tabular-nums text-slate-300/64">{index + 1} of {items.length}</span>
+        <button type="button" onClick={() => last ? onFinish?.() : goTo(index + 1)} aria-label={last ? "Back to Buy Check result" : "Next report card"} className="inline-flex min-h-11 items-center gap-1 px-1 text-[11px] font-semibold text-cyan-100/82">
+          {last ? "Back to result" : "Next"} <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/fresh/main-dashboard/assistant/buy-check/BuyCheckEvidencePanel.jsx
+++ b/src/components/fresh/main-dashboard/assistant/buy-check/BuyCheckEvidencePanel.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { ArrowLeft } from "lucide-react";
-import BuyCheckDetailCarousel from "./BuyCheckDetailCarousel.jsx";
+import BuyCheckDetailCarousel from "./BuyCheckDetailCarouselCompact.jsx";
 
 export default function BuyCheckEvidencePanel({ open = false, diagnosis, onClose }) {
   const cards = useMemo(() => {
@@ -15,53 +15,30 @@ export default function BuyCheckEvidencePanel({ open = false, diagnosis, onClose
 
   if (!open) return null;
 
-  const pageCount = cards.length;
-  const safeIndex = pageCount ? Math.min(currentIndex, pageCount - 1) : 0;
-  const progress = pageCount ? ((safeIndex + 1) / pageCount) * 100 : 0;
+  const total = cards.length;
+  const safeIndex = total ? Math.min(currentIndex, total - 1) : 0;
+  const progress = total ? ((safeIndex + 1) / total) * 100 : 0;
 
   return (
-    <section
-      data-clara-buy-check-details-sheet="true"
-      className="fixed inset-0 z-[400] mx-auto flex w-full max-w-[430px] flex-col overflow-hidden bg-[#020617] px-3 pb-[max(env(safe-area-inset-bottom),14px)] pt-[max(env(safe-area-inset-top),16px)] text-white"
-    >
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_12%_0%,rgba(34,211,238,0.14),transparent_34%),radial-gradient(circle_at_92%_5%,rgba(124,58,237,0.20),transparent_38%),linear-gradient(180deg,#020617_0%,#020617_100%)]" />
+    <section data-clara-buy-check-details-sheet="true" className="fixed inset-0 z-[400] mx-auto flex w-full max-w-[430px] flex-col overflow-hidden bg-[#020617] px-3 pb-[max(env(safe-area-inset-bottom),14px)] pt-[max(env(safe-area-inset-top),14px)] text-white">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_12%_0%,rgba(34,211,238,.10),transparent_32%),radial-gradient(circle_at_92%_4%,rgba(124,58,237,.14),transparent_36%),linear-gradient(180deg,#020617_0%,#020617_100%)]" />
 
-      <header className="relative z-10 shrink-0 px-2 pb-4 pt-1">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0 flex-1">
-            <p className="text-[9px] font-bold uppercase tracking-[0.22em] text-cyan-100/58">BUY CHECK REPORT</p>
-            <h2 className="mt-1.5 max-w-[285px] text-[24px] font-extrabold leading-[1.12] tracking-[-0.03em] text-white/96">
-              Why CLARA gave this result
-            </h2>
-            <p className="mt-2 text-[11px] font-medium leading-5 text-slate-300/66">
-              Verified financial evidence, one finding at a time.
-            </p>
+      <header className="relative z-10 shrink-0 px-1 pb-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-[9px] font-bold uppercase tracking-[0.20em] text-cyan-100/54">BUY CHECK REPORT</p>
+            <h2 className="mt-1 text-[22px] font-extrabold leading-tight tracking-[-0.03em] text-white/95">Why this result?</h2>
           </div>
-
-          <button
-            type="button"
-            onClick={onClose}
-            className="grid h-11 w-11 shrink-0 place-items-center rounded-full border border-white/10 bg-white/[0.05] text-white/88 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] transition hover:bg-white/[0.08] active:scale-[0.97] motion-reduce:transition-none"
-            aria-label="Back to Buy Check result"
-          >
-            <ArrowLeft className="h-[18px] w-[18px]" />
+          <button type="button" onClick={onClose} aria-label="Back to Buy Check result" className="grid h-10 w-10 shrink-0 place-items-center rounded-full border border-white/[0.08] bg-white/[0.035] text-white/84">
+            <ArrowLeft className="h-[17px] w-[17px]" />
           </button>
         </div>
-
-        <div className="mt-4 flex items-center gap-3">
-          <span aria-live="polite" className="shrink-0 text-[11px] font-medium tabular-nums text-slate-300/68">
-            {pageCount ? `${safeIndex + 1} of ${pageCount}` : "No report pages"}
-          </span>
-          <div className="h-1 flex-1 overflow-hidden rounded-full bg-white/[0.07]" aria-hidden="true">
-            <div
-              className="h-full rounded-full bg-[linear-gradient(90deg,rgba(45,212,191,0.92),rgba(103,232,249,0.92),rgba(139,92,246,0.88))] transition-[width] duration-300 motion-reduce:transition-none"
-              style={{ width: `${progress}%` }}
-            />
-          </div>
+        <div className="mt-3 h-1 overflow-hidden rounded-full bg-white/[0.06]" aria-hidden="true">
+          <div className="h-full rounded-full bg-[linear-gradient(90deg,rgba(45,212,191,.88),rgba(103,232,249,.88),rgba(139,92,246,.82))] transition-[width] duration-300 motion-reduce:transition-none" style={{ width: `${progress}%` }} />
         </div>
       </header>
 
-      <div className="relative z-10 min-h-0 flex-1 px-0.5 pb-1">
+      <div className="relative z-10 min-h-0 flex-1 overflow-y-auto px-0.5 pb-1">
         <BuyCheckDetailCarousel cards={cards} onIndexChange={setCurrentIndex} onFinish={onClose} />
       </div>
     </section>


### PR DESCRIPTION
Surgical UI correction for the dedicated Buy Check report only.

Changes:
- Replace partial-width centered slides with full-width `snap-start` slides
- Remove manual centering that caused the neighboring slide to bleed into view
- Make report cards content-driven instead of full-height
- Remove the large empty middle area and bottom-pinned note layout
- Reduce header size and remove the duplicate header page count
- Keep one flat Previous / page count / Next navigation row
- Reduce gradients, borders, shadows, and typography weight

No financial logic, report data, verdict, action mapping, or main Buy Check screen was changed.