### PR TITLE
Move Buy Check report header closer to carousel

### DIFF
--- a/src/components/fresh/main-dashboard/assistant/buy-check/BuyCheckDetailCarouselCompact.jsx
+++ b/src/components/fresh/main-dashboard/assistant/buy-check/BuyCheckDetailCarouselCompact.jsx
@@ -76,7 +76,7 @@ export default function BuyCheckDetailCarouselCompact({ cards = [], onIndexChang
 
   return (
     <div
-      className="flex min-h-full w-full flex-col justify-center py-4"
+      className="w-full"
       role="region"
       aria-roledescription="carousel"
       aria-label="Buy Check financial report"

--- a/src/components/fresh/main-dashboard/assistant/buy-check/BuyCheckEvidencePanel.jsx
+++ b/src/components/fresh/main-dashboard/assistant/buy-check/BuyCheckEvidencePanel.jsx
@@ -23,23 +23,25 @@ export default function BuyCheckEvidencePanel({ open = false, diagnosis, onClose
     <section data-clara-buy-check-details-sheet="true" className="fixed inset-0 z-[400] mx-auto flex w-full max-w-[430px] flex-col overflow-hidden bg-[#020617] px-3 pb-[max(env(safe-area-inset-bottom),14px)] pt-[max(env(safe-area-inset-top),14px)] text-white">
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_12%_0%,rgba(34,211,238,.10),transparent_32%),radial-gradient(circle_at_92%_4%,rgba(124,58,237,.14),transparent_36%),linear-gradient(180deg,#020617_0%,#020617_100%)]" />
 
-      <header className="relative z-10 shrink-0 px-1 pb-3">
-        <div className="flex items-center justify-between gap-3">
-          <div className="min-w-0">
-            <p className="text-[9px] font-bold uppercase tracking-[0.20em] text-cyan-100/54">BUY CHECK REPORT</p>
-            <h2 className="mt-1 text-[22px] font-extrabold leading-tight tracking-[-0.03em] text-white/95">Why this result?</h2>
-          </div>
-          <button type="button" onClick={onClose} aria-label="Back to Buy Check result" className="grid h-10 w-10 shrink-0 place-items-center rounded-full border border-white/[0.08] bg-white/[0.035] text-white/84">
-            <ArrowLeft className="h-[17px] w-[17px]" />
-          </button>
-        </div>
-        <div className="mt-3 h-1 overflow-hidden rounded-full bg-white/[0.06]" aria-hidden="true">
-          <div className="h-full rounded-full bg-[linear-gradient(90deg,rgba(45,212,191,.88),rgba(103,232,249,.88),rgba(139,92,246,.82))] transition-[width] duration-300 motion-reduce:transition-none" style={{ width: `${progress}%` }} />
-        </div>
-      </header>
+      <div className="relative z-10 flex min-h-0 flex-1 flex-col justify-center overflow-y-auto px-0.5 py-4">
+        <div className="w-full">
+          <header className="px-1 pb-4">
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <p className="text-[9px] font-bold uppercase tracking-[0.20em] text-cyan-100/54">BUY CHECK REPORT</p>
+                <h2 className="mt-1 text-[22px] font-extrabold leading-tight tracking-[-0.03em] text-white/95">Why this result?</h2>
+              </div>
+              <button type="button" onClick={onClose} aria-label="Back to Buy Check result" className="grid h-10 w-10 shrink-0 place-items-center rounded-full border border-white/[0.08] bg-white/[0.035] text-white/84">
+                <ArrowLeft className="h-[17px] w-[17px]" />
+              </button>
+            </div>
+            <div className="mt-3 h-1 overflow-hidden rounded-full bg-white/[0.06]" aria-hidden="true">
+              <div className="h-full rounded-full bg-[linear-gradient(90deg,rgba(45,212,191,.88),rgba(103,232,249,.88),rgba(139,92,246,.82))] transition-[width] duration-300 motion-reduce:transition-none" style={{ width: `${progress}%` }} />
+            </div>
+          </header>
 
-      <div className="relative z-10 min-h-0 flex-1 overflow-y-auto px-0.5 pb-1">
-        <BuyCheckDetailCarousel cards={cards} onIndexChange={setCurrentIndex} onFinish={onClose} />
+          <BuyCheckDetailCarousel cards={cards} onIndexChange={setCurrentIndex} onFinish={onClose} />
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
Group the Buy Check report title, progress bar, and carousel into one vertically centered stack so the header sits naturally just above the active card.

Changes are limited to report layout:
- header and carousel now center together as one block
- excessive gap between title and active card is removed
- Back button and top progress remain unchanged
- swipe and keyboard navigation remain unchanged
- no financial logic or report data changes