### PR TITLE
WIP: Stable local vault and safe account linking

### DIFF
--- a/.github/scripts/patch_vault_core.py
+++ b/.github/scripts/patch_vault_core.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def replace(path, old, new, all_matches=False):
+    file = ROOT / path
+    text = file.read_text(encoding="utf-8")
+    if old not in text:
+        raise RuntimeError(f"Missing target in {path}: {old[:90]}")
+    text = text.replace(old, new) if all_matches else text.replace(old, new, 1)
+    file.write_text(text, encoding="utf-8")
+
+
+replace(
+    "src/components/fresh/main-dashboard/dashboard-cache/useDashboardPageCacheController.js",
+    'import { createEmptyDashboardCache } from "@/components/fresh/main-dashboard/dashboard-cache/dashboardCacheFactory";',
+    'import { createEmptyDashboardCache } from "@/components/fresh/main-dashboard/dashboard-cache/dashboardCacheFactory";\nimport { ensureActiveLocalVaultId } from "@/lib/localVaultIdentity";',
+)
+replace(
+    "src/components/fresh/main-dashboard/dashboard-cache/useDashboardPageCacheController.js",
+    "export default function useDashboardPageCacheController({ cacheKey = null } = {}) {\n  const hasLoadedDashboardRef = useRef(false);",
+    "export default function useDashboardPageCacheController() {\n  const cacheKey = ensureActiveLocalVaultId();\n  const hasLoadedDashboardRef = useRef(false);",
+)
+
+replace(
+    "src/components/fresh/main-dashboard/dashboard-cache/useDashboardDataLoader.js",
+    '} from "@/lib/supabaseQuotaGuard";',
+    '} from "@/lib/supabaseQuotaGuard";\nimport { ensureActiveLocalVaultId } from "@/lib/localVaultIdentity";',
+)
+replace(
+    "src/components/fresh/main-dashboard/dashboard-cache/useDashboardDataLoader.js",
+    'const ownerKey = cacheKey || currentUser.id || currentUser.email || "guest";',
+    'const ownerKey = ensureActiveLocalVaultId();',
+)
+replace(
+    "src/components/fresh/main-dashboard/dashboard-cache/useDashboardDataLoader.js",
+    "readDashboardPrefs(currentUser.id)",
+    "readDashboardPrefs(ownerKey)",
+    True,
+)
+replace(
+    "src/components/fresh/main-dashboard/dashboard-cache/useDashboardDataLoader.js",
+    "readStoredSurvivalExpense(currentUser.id)",
+    "readStoredSurvivalExpense(ownerKey)",
+    True,
+)
+
+replace(
+    "src/components/fresh/main-dashboard/finance-content/useDashboardFinanceStateSync.js",
+    'import { getWalletDisplayBalance } from "@/utils/dashboard/dashboardHelpers";',
+    'import { getWalletDisplayBalance } from "@/utils/dashboard/dashboardHelpers";\nimport { ensureActiveLocalVaultId } from "@/lib/localVaultIdentity";',
+)
+replace(
+    "src/components/fresh/main-dashboard/finance-content/useDashboardFinanceStateSync.js",
+    "export default function useDashboardFinanceStateSync({\n  cacheKey,",
+    "export default function useDashboardFinanceStateSync({",
+)
+replace(
+    "src/components/fresh/main-dashboard/finance-content/useDashboardFinanceStateSync.js",
+    "}) {\n  useEffect(() => {",
+    "}) {\n  const cacheKey = ensureActiveLocalVaultId();\n\n  useEffect(() => {",
+)
+
+replace(
+    "src/components/fresh/main-dashboard/dashboard-cache/useDashboardCacheOwnerSync.js",
+    'import { hasDashboardFinanceContent } from "@/components/fresh/main-dashboard/finance-content/dashboardFinanceContent";',
+    'import { hasDashboardFinanceContent } from "@/components/fresh/main-dashboard/finance-content/dashboardFinanceContent";\nimport { ensureActiveLocalVaultId } from "@/lib/localVaultIdentity";',
+)
+replace(
+    "src/components/fresh/main-dashboard/dashboard-cache/useDashboardCacheOwnerSync.js",
+    "export default function useDashboardCacheOwnerSync({\n  cacheKey,",
+    "export default function useDashboardCacheOwnerSync({",
+)
+replace(
+    "src/components/fresh/main-dashboard/dashboard-cache/useDashboardCacheOwnerSync.js",
+    "} = {}) {\n  useEffect(() => {",
+    "} = {}) {\n  const cacheKey = ensureActiveLocalVaultId();\n\n  useEffect(() => {",
+)
+
+replace(
+    "src/components/fresh/main-dashboard/dashboard-settings/useDashboardNotificationSettings.js",
+    'import { readStoredNotificationSettings } from "@/components/fresh/main-dashboard/dashboard-settings/dashboardRuntimeSettings";',
+    'import { readStoredNotificationSettings } from "@/components/fresh/main-dashboard/dashboard-settings/dashboardRuntimeSettings";\nimport { ensureActiveLocalVaultId } from "@/lib/localVaultIdentity";',
+)
+replace(
+    "src/components/fresh/main-dashboard/dashboard-settings/useDashboardNotificationSettings.js",
+    "export default function useDashboardNotificationSettings(userId) {",
+    "export default function useDashboardNotificationSettings() {\n  const userId = ensureActiveLocalVaultId();",
+)
+
+replace(
+    "src/hooks/useNotificationPreferences.js",
+    '} from "@/lib/notifications/notificationPreferences";',
+    '} from "@/lib/notifications/notificationPreferences";\nimport { ensureActiveLocalVaultId } from "@/lib/localVaultIdentity";',
+)
+replace(
+    "src/hooks/useNotificationPreferences.js",
+    "export default function useNotificationPreferences(userId) {",
+    "export default function useNotificationPreferences() {\n  const userId = ensureActiveLocalVaultId();",
+)
+
+replace(
+    "src/components/fresh/main-dashboard/dashboard-theme/useDashboardThemePersistence.js",
+    'import { normalizeString } from "@/utils/dashboard/dashboardHelpers";',
+    'import { normalizeString } from "@/utils/dashboard/dashboardHelpers";\nimport { ensureActiveLocalVaultId } from "@/lib/localVaultIdentity";',
+)
+replace(
+    "src/components/fresh/main-dashboard/dashboard-theme/useDashboardThemePersistence.js",
+    "export default function useDashboardThemePersistence({\n  selectedDashboardTheme,\n  userId,\n}) {",
+    "export default function useDashboardThemePersistence({ selectedDashboardTheme }) {\n  const userId = ensureActiveLocalVaultId();",
+)
+
+print("Core vault ownership patch applied.")

--- a/.github/scripts/patch_vault_security_card.py
+++ b/.github/scripts/patch_vault_security_card.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[2]
+PATH = ROOT / "src/components/fresh/main-dashboard/dashboard-panels/settings/DashboardSettingsPanel.jsx"
+text = PATH.read_text(encoding="utf-8")
+
+marker = "  const openSupportMessages = useCallback(() => {"
+handler = '''  const handleProtectAndLink = useCallback(() => {
+    if (!CLARA_AUTH_ENABLED || !CLARA_ACCOUNT_LINKING_ENABLED) {
+      setSettingsNotice({
+        type: "error",
+        message: "Account linking is temporarily unavailable while account services are being restored. Your current data remains safe on this device.",
+      });
+      return;
+    }
+    navigate("/login?intent=link-local-vault");
+  }, [navigate]);
+
+  const openSupportMessages = useCallback(() => {'''
+if marker not in text:
+    raise RuntimeError("Missing support handler marker")
+text = text.replace(marker, handler, 1)
+
+status_pattern = re.compile(
+    r'''              <h3 className="text-base font-black text-white">Your CLARA data is private</h3>\n\n              \{user\?\.email \? \(.*?              \)\}''',
+    re.S,
+)
+status_replacement = '''              <h3 className="text-base font-black text-white">
+                {vaultMetadata?.linkStatus === "linked"
+                  ? hasGenuineAccount
+                    ? "Your CLARA account is linked"
+                    : "Account linked — signed out"
+                  : vaultMetadata?.linkStatus === "link_failed"
+                    ? "We could not link your account"
+                    : "Your CLARA data is private"}
+              </h3>
+
+              <div className="mt-3">
+                <p className="text-[10px] font-bold uppercase tracking-[0.14em] text-white/35">
+                  {vaultMetadata?.linkStatus === "linked" && hasGenuineAccount ? "Signed in as" : "Status"}
+                </p>
+                <p className="mt-1 break-all text-sm font-semibold leading-5 text-white/78">
+                  {vaultMetadata?.linkStatus === "linked" && hasGenuineAccount
+                    ? user?.email || vaultMetadata?.accountEmail
+                    : vaultMetadata?.linkStatus === "linked"
+                      ? "Stored on this device — signed out"
+                      : vaultMetadata?.linkStatus === "linking"
+                        ? "Connecting your CLARA data…"
+                        : "Stored on this device"}
+                </p>
+                <p className="mt-2 text-xs leading-5 text-white/48">
+                  {vaultMetadata?.linkStatus === "link_failed"
+                    ? "Your existing CLARA data is still safe on this device."
+                    : "Your financial records are currently saved on this device."}
+                </p>
+              </div>'''
+text, count = status_pattern.subn(status_replacement, text, count=1)
+if count != 1:
+    raise RuntimeError(f"Expected one security status block, found {count}")
+
+button_marker = '''          <button
+            type="button"
+            onClick={() => setIsDataDetailsOpen((current) => !current)}'''
+button_replacement = '''          <button
+            type="button"
+            onClick={handleProtectAndLink}
+            disabled={vaultMetadataLoading || vaultMetadata?.linkStatus === "linking"}
+            className="mt-4 inline-flex min-h-11 w-full items-center justify-center rounded-2xl bg-emerald-400 px-4 py-3 text-sm font-black text-slate-950 shadow-[0_12px_30px_rgba(16,185,129,0.22)] disabled:cursor-not-allowed disabled:opacity-55"
+          >
+            {vaultMetadata?.linkStatus === "linking"
+              ? "Connecting your CLARA data…"
+              : vaultMetadata?.linkStatus === "linked" && !hasGenuineAccount
+                ? "Sign in again"
+                : vaultMetadata?.linkStatus === "link_failed"
+                  ? "Try again"
+                  : "Protect & link my data"}
+          </button>
+
+          <button
+            type="button"
+            onClick={() => setIsDataDetailsOpen((current) => !current)}'''
+if button_marker not in text:
+    raise RuntimeError("Missing data-details button marker")
+text = text.replace(button_marker, button_replacement, 1)
+
+PATH.write_text(text, encoding="utf-8")
+print("Security card state patch applied.")

--- a/.github/scripts/patch_vault_settings.py
+++ b/.github/scripts/patch_vault_settings.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[2]
+PATH = ROOT / "src/components/fresh/main-dashboard/dashboard-panels/settings/DashboardSettingsPanel.jsx"
+text = PATH.read_text(encoding="utf-8")
+
+
+def swap(old, new):
+    global text
+    if old not in text:
+        raise RuntimeError(f"Missing Settings target: {old[:100]}")
+    text = text.replace(old, new, 1)
+
+
+swap(
+    'import appPackage from "../../../../../../package.json";',
+    'import appPackage from "../../../../../../package.json";\nimport { CLARA_ACCOUNT_LINKING_ENABLED, CLARA_AUTH_ENABLED } from "@/config/claraFeatureFlags";\nimport { ensureActiveLocalVaultId, isTemporaryLocalAuthUser } from "@/lib/localVaultIdentity";\nimport useLocalVaultMetadata from "@/hooks/useLocalVaultMetadata";\nimport { readLocalProfileDisplayName, saveLocalProfileDisplayName } from "@/lib/localProfileDisplayName";',
+)
+swap(
+    "  const navigate = useNavigate();\n\n  const initialDisplayName =",
+    "  const navigate = useNavigate();\n  const localVaultId = ensureActiveLocalVaultId();\n  const isLocalMode = isTemporaryLocalAuthUser(user);\n  const hasGenuineAccount = Boolean(user?.id && !isLocalMode);\n  const { metadata: vaultMetadata, loading: vaultMetadataLoading } = useLocalVaultMetadata();\n  const storedLocalDisplayName = readLocalProfileDisplayName(localVaultId);\n\n  const initialDisplayName =\n    (isLocalMode ? storedLocalDisplayName : \"\") ||",
+)
+swap('useNotificationPreferences(user?.id || "guest")', 'useNotificationPreferences(localVaultId)')
+text = text.replace('readStoredPerformanceMode(user?.id || "guest")', 'readStoredPerformanceMode(localVaultId)')
+text = text.replace('saveVisualPerformanceMode(user?.id || "guest", next)', 'saveVisualPerformanceMode(localVaultId, next)')
+swap(
+    "    if (!user?.id) {\n      setSettingsNotice({ type: \"error\", message: \"User session is not ready. Please log in again.\" });\n      return;\n    }\n\n    setSavingProfile(true);",
+    "    if (isLocalMode) {\n      saveLocalProfileDisplayName(nextName, localVaultId);\n      setProfileName(nextName);\n      setSettingsNotice({ type: \"success\", message: \"Local profile updated.\" });\n      return;\n    }\n\n    if (!user?.id) {\n      setSettingsNotice({ type: \"error\", message: \"User session is not ready. Please log in again.\" });\n      return;\n    }\n\n    setSavingProfile(true);",
+)
+swap(
+    "  }, [profileName, user?.email, user?.id]);",
+    "  }, [isLocalMode, localVaultId, profileName, user?.email, user?.id]);",
+)
+swap(
+    '<p className="truncate text-xs text-white/50">{user?.email || "CLARA user"}</p>',
+    '<p className="truncate text-xs text-white/50">{isLocalMode ? "Stored on this device" : user?.email || "CLARA user"}</p>',
+)
+swap(
+    '<p className="truncate text-base font-black text-white">{displayName}</p>',
+    '<p className="truncate text-base font-black text-white">{isLocalMode ? displayName || "CLARA Local Profile" : displayName}</p>',
+)
+
+email_block = '''        <div className="mt-4 rounded-2xl border border-white/15 bg-black/15 px-4 py-3">
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-white/35">Email</p>
+          <p className="mt-1 truncate text-sm font-semibold text-white">{user?.email || "No email found"}</p>
+          <p className="mt-1 text-[11px] text-white/40">For security, email is read-only inside dashboard settings.</p>
+        </div>'''
+account_block = '''        <div className="mt-4 rounded-2xl border border-white/15 bg-black/15 px-4 py-3">
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-white/35">Account</p>
+          <p className="mt-1 truncate text-sm font-semibold text-white">
+            {isLocalMode ? "No account linked" : user?.email || "No email found"}
+          </p>
+          <p className="mt-1 text-[11px] text-white/40">
+            {isLocalMode ? "Your CLARA records are stored on this device." : "For security, email is read-only inside dashboard settings."}
+          </p>
+          {isLocalMode ? (
+            <button type="button" onClick={() => setActiveSetting("security")} className="mt-3 text-xs font-bold text-emerald-100">
+              Protect & link my data
+            </button>
+          ) : null}
+        </div>'''
+swap(email_block, account_block)
+
+logout_pattern = re.compile(r'      <div className="space-y-2 pt-1">\n        <button\n          type="button"\n          onClick=\{handleSignOut\}.*?      </div>\n    </div>', re.S)
+logout_replacement = '''      {!isLocalMode ? (
+        <div className="space-y-2 pt-1">
+          <button
+            type="button"
+            onClick={handleSignOut}
+            disabled={signingOut}
+            className="flex w-full items-center justify-center gap-2 rounded-[24px] border border-rose-300/20 bg-[radial-gradient(circle_at_top_left,rgba(244,63,94,0.16),transparent_34%),rgba(244,63,94,0.08)] px-4 py-4 text-sm font-black text-rose-100 shadow-[0_14px_40px_rgba(244,63,94,0.08)] transition hover:bg-rose-500/15 disabled:opacity-55"
+          >
+            <X className="h-4 w-4" />
+            {signingOut ? "Signing out..." : "Log out"}
+          </button>
+          <p className="px-3 text-center text-[10px] font-semibold leading-4 text-white/32">
+            Logging out keeps your local CLARA records on this device.
+          </p>
+        </div>
+      ) : null}
+    </div>'''
+text, count = logout_pattern.subn(logout_replacement, text, count=1)
+if count != 1:
+    raise RuntimeError(f"Expected one logout block, found {count}")
+
+PATH.write_text(text, encoding="utf-8")
+print("Settings local-state patch applied.")

--- a/.github/scripts/write_vault_tests.py
+++ b/.github/scripts/write_vault_tests.py
@@ -1,0 +1,127 @@
+from pathlib import Path
+import json
+
+ROOT = Path(__file__).resolve().parents[2]
+
+package_path = ROOT / "package.json"
+package = json.loads(package_path.read_text(encoding="utf-8"))
+command = package["scripts"]["test"]
+for item in ["tests/local-vault-identity.test.mjs", "tests/local-vault-account-linking.test.mjs"]:
+    if item not in command:
+        command += " " + item
+package["scripts"]["test"] = command
+package_path.write_text(json.dumps(package, indent=2) + "\n", encoding="utf-8")
+
+(ROOT / "tests/local-vault-account-linking.test.mjs").write_text('''import test from "node:test";
+import assert from "node:assert/strict";
+import { linkLocalVaultToAccountWithAdapters } from "../src/lib/accountLinking/linkLocalVaultToAccount.js";
+
+const snapshot = {
+  expenses: { active: 1, deleted: 1, activeIds: ["expense_1"], deletedIds: ["expense_deleted"] },
+  wallets: { active: 1, deleted: 0, activeIds: ["wallet_1"], deletedIds: [] },
+};
+
+function adapters(overrides = {}) {
+  let metadata = { linkStatus: "local_only", accountUserId: null };
+  const calls = { linking: 0, linked: 0, failed: 0, dispatched: 0 };
+  return {
+    calls,
+    current: () => metadata,
+    getActiveVaultId: async () => "local-dev-user",
+    getMetadata: async () => metadata,
+    readSnapshot: async () => structuredClone(snapshot),
+    markLinking: async (patch) => {
+      calls.linking += 1;
+      metadata = { ...metadata, ...patch, linkStatus: "linking" };
+      return metadata;
+    },
+    markLinked: async (patch) => {
+      calls.linked += 1;
+      metadata = { ...metadata, ...patch, linkStatus: "linked" };
+      return metadata;
+    },
+    markFailed: async (patch) => {
+      calls.failed += 1;
+      metadata = { ...metadata, linkStatus: "link_failed", linkError: patch };
+      return metadata;
+    },
+    dispatchLinked: () => {
+      calls.dispatched += 1;
+    },
+    ...overrides,
+  };
+}
+
+test("link preserves active and soft-deleted record IDs", async () => {
+  const mock = adapters();
+  const result = await linkLocalVaultToAccountWithAdapters(
+    { expectedVaultId: "local-dev-user", accountUserId: "account-123", accountEmail: "max@example.com" },
+    mock
+  );
+  assert.equal(result.ok, true);
+  assert.equal(result.vaultId, "local-dev-user");
+  assert.deepEqual(result.recordCounts, snapshot);
+  assert.deepEqual(mock.calls, { linking: 1, linked: 1, failed: 0, dispatched: 1 });
+});
+
+test("same account link is idempotent", async () => {
+  const mock = adapters();
+  await linkLocalVaultToAccountWithAdapters({ accountUserId: "account-123" }, mock);
+  const second = await linkLocalVaultToAccountWithAdapters({ accountUserId: "account-123" }, mock);
+  assert.equal(second.idempotent, true);
+  assert.equal(mock.calls.linked, 1);
+});
+
+test("different account returns a controlled conflict", async () => {
+  const mock = adapters({ getMetadata: async () => ({ linkStatus: "linked", accountUserId: "first" }) });
+  await assert.rejects(
+    () => linkLocalVaultToAccountWithAdapters({ accountUserId: "second" }, mock),
+    (error) => error.code === "VAULT_ACCOUNT_CONFLICT"
+  );
+  assert.equal(mock.calls.linking, 0);
+});
+
+test("unexpected active vault change is rejected", async () => {
+  const mock = adapters();
+  await assert.rejects(
+    () => linkLocalVaultToAccountWithAdapters({ expectedVaultId: "vault-before", accountUserId: "account-123" }, mock),
+    (error) => error.code === "VAULT_CHANGED"
+  );
+  assert.equal(mock.calls.linking, 0);
+});
+
+test("failed verification records failure without marking linked", async () => {
+  let reads = 0;
+  const mock = adapters({
+    readSnapshot: async () => {
+      reads += 1;
+      return reads === 1
+        ? structuredClone(snapshot)
+        : { ...structuredClone(snapshot), expenses: { active: 0, deleted: 1, activeIds: [], deletedIds: ["expense_deleted"] } };
+    },
+  });
+  await assert.rejects(
+    () => linkLocalVaultToAccountWithAdapters({ accountUserId: "account-123" }, mock),
+    (error) => error.code === "VAULT_VERIFICATION_FAILED"
+  );
+  assert.equal(mock.calls.linked, 0);
+  assert.equal(mock.calls.failed, 1);
+  assert.equal(mock.current().linkStatus, "link_failed");
+});
+
+test("temporary local identity is rejected as an account", async () => {
+  const mock = adapters();
+  await assert.rejects(
+    () => linkLocalVaultToAccountWithAdapters({ accountUserId: "local-dev-user" }, mock),
+    (error) => error.code === "INVALID_ACCOUNT_ID"
+  );
+});
+''', encoding="utf-8")
+
+identity_path = ROOT / "tests/local-vault-identity.test.mjs"
+identity = identity_path.read_text(encoding="utf-8")
+if "source guards keep local mode truthful" not in identity:
+    identity += '''\nimport fs from "node:fs";\n\ntest("source guards keep local mode truthful", () => {\n  const source = fs.readFileSync(new URL("../src/components/fresh/main-dashboard/dashboard-panels/settings/DashboardSettingsPanel.jsx", import.meta.url), "utf8");\n  assert.match(source, /Stored on this device/);\n  assert.match(source, /No account linked/);\n  assert.match(source, /\{!isLocalMode \? \(/);\n});\n\ntest("feature flags keep account services opt-in", () => {\n  const source = fs.readFileSync(new URL("../src/config/claraFeatureFlags.js", import.meta.url), "utf8");\n  assert.match(source, /VITE_CLARA_AUTH_ENABLED\", false/);\n  assert.match(source, /VITE_CLARA_ACCOUNT_LINKING_ENABLED\",\s*false/);\n  assert.match(source, /VITE_CLARA_LOCAL_MODE_ENABLED\",\s*true/);\n});\n\ntest("demo fallback returns to stable vault ownership", () => {\n  const source = fs.readFileSync(new URL("../src/lib/demo/activeDemoProfile.js", import.meta.url), "utf8");\n  assert.match(source, /getActiveDemoFinanceLocalUserId\(\) \|\| ensureActiveLocalVaultId\(\)/);\n});\n'''
+    identity_path.write_text(identity, encoding="utf-8")
+
+print("Vault tests written and registered.")

--- a/.github/workflows/verify-local-vault-continuation.yml
+++ b/.github/workflows/verify-local-vault-continuation.yml
@@ -1,0 +1,42 @@
+name: Verify local vault continuation
+
+on:
+  push:
+    branches:
+      - feat/local-vault-account-linking
+    paths:
+      - .github/scripts/patch_vault_core.py
+      - .github/scripts/patch_vault_settings.py
+      - .github/scripts/patch_vault_security_card.py
+      - .github/scripts/write_vault_tests.py
+      - .github/workflows/verify-local-vault-continuation.yml
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: feat/local-vault-account-linking
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: python .github/scripts/patch_vault_core.py
+      - run: python .github/scripts/patch_vault_settings.py
+      - run: python .github/scripts/patch_vault_security_card.py
+      - run: python .github/scripts/write_vault_tests.py
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: local-vault-generated-source
+          path: |
+            src
+            tests
+            package.json

--- a/src/components/fresh/main-dashboard/dashboard-cache/useDashboardCacheOwnerSync.js
+++ b/src/components/fresh/main-dashboard/dashboard-cache/useDashboardCacheOwnerSync.js
@@ -1,9 +1,9 @@
 import { useEffect } from "react";
 import { createEmptyDashboardCache } from "@/components/fresh/main-dashboard/dashboard-cache/dashboardCacheFactory";
 import { hasDashboardFinanceContent } from "@/components/fresh/main-dashboard/finance-content/dashboardFinanceContent";
+import { ensureActiveLocalVaultId } from "@/lib/localVaultIdentity";
 
 export default function useDashboardCacheOwnerSync({
-  cacheKey,
   initialCache,
   financeDataLoading = false,
   hasLoadedDashboardRef,
@@ -13,6 +13,8 @@ export default function useDashboardCacheOwnerSync({
   setGuardChecked,
   setLoading,
 } = {}) {
+  const cacheKey = ensureActiveLocalVaultId();
+
   useEffect(() => {
     const currentDashboardCache =
       typeof getDashboardPageCache === "function" ? getDashboardPageCache() : null;

--- a/src/components/fresh/main-dashboard/dashboard-cache/useDashboardDataLoader.js
+++ b/src/components/fresh/main-dashboard/dashboard-cache/useDashboardDataLoader.js
@@ -13,6 +13,7 @@ import {
   getSupabaseQuotaNotice,
   isSupabaseQuotaBlocked,
 } from "@/lib/supabaseQuotaGuard";
+import { ensureActiveLocalVaultId } from "@/lib/localVaultIdentity";
 
 const LOCAL_AUTH_FALLBACK_USER_ID = "local-dev-user";
 
@@ -98,7 +99,7 @@ export default function useDashboardDataLoader({
         return emptyCache;
       }
 
-      const ownerKey = cacheKey || currentUser.id || currentUser.email || "guest";
+      const ownerKey = ensureActiveLocalVaultId();
       const activeInFlight =
         typeof getDashboardPageInFlight === "function"
           ? getDashboardPageInFlight()
@@ -145,7 +146,7 @@ export default function useDashboardDataLoader({
             0
           );
 
-          const storedPrefs = readDashboardPrefs(currentUser.id);
+          const storedPrefs = readDashboardPrefs(ownerKey);
 
           if (localAuthFallbackActive) {
             const localProfile = {
@@ -199,7 +200,7 @@ export default function useDashboardDataLoader({
                 localProfile?.monthly_survival_expense,
                 localProfile?.survival_expense,
                 localProfile?.clara_survival_expense,
-                readStoredSurvivalExpense(currentUser.id),
+                readStoredSurvivalExpense(ownerKey),
                 survivalExpense,
                 dashboardCacheSnapshot?.survivalExpense
               ),
@@ -271,7 +272,7 @@ export default function useDashboardDataLoader({
               safeProfile?.monthly_survival_expense,
               safeProfile?.survival_expense,
               safeProfile?.clara_survival_expense,
-              readStoredSurvivalExpense(currentUser.id),
+              readStoredSurvivalExpense(ownerKey),
               survivalExpense,
               dashboardCacheSnapshot?.survivalExpense
             ),

--- a/src/components/fresh/main-dashboard/dashboard-cache/useDashboardPageCacheController.js
+++ b/src/components/fresh/main-dashboard/dashboard-cache/useDashboardPageCacheController.js
@@ -1,5 +1,6 @@
 import { useCallback, useRef } from "react";
 import { createEmptyDashboardCache } from "@/components/fresh/main-dashboard/dashboard-cache/dashboardCacheFactory";
+import { ensureActiveLocalVaultId } from "@/lib/localVaultIdentity";
 
 let dashboardPageCache = createEmptyDashboardCache();
 let dashboardPageInFlight = null;
@@ -16,7 +17,8 @@ function hasUsableInitialFinanceCache(initialCache) {
   );
 }
 
-export default function useDashboardPageCacheController({ cacheKey = null } = {}) {
+export default function useDashboardPageCacheController() {
+  const cacheKey = ensureActiveLocalVaultId();
   const hasLoadedDashboardRef = useRef(false);
 
   const initialCache =
@@ -30,8 +32,9 @@ export default function useDashboardPageCacheController({ cacheKey = null } = {}
     dashboardPageCache = {
       ...dashboardPageCache,
       ...nextFinanceCache,
+      key: cacheKey,
     };
-  }, []);
+  }, [cacheKey]);
 
   const getDashboardPageCache = useCallback(() => dashboardPageCache, []);
 

--- a/src/components/fresh/main-dashboard/dashboard-settings/dashboardRuntimeSettings.js
+++ b/src/components/fresh/main-dashboard/dashboard-settings/dashboardRuntimeSettings.js
@@ -4,6 +4,7 @@ import {
   readNotificationPreferences,
   updateNotificationPreferences,
 } from "@/lib/notifications/notificationPreferences";
+import { ensureActiveLocalVaultId } from "@/lib/localVaultIdentity";
 
 const dashboardRuntimePrefs = new Map();
 const dashboardRuntimeMoneySummaryVisibility = new Map();
@@ -13,19 +14,23 @@ export const MONEY_SUMMARY_PRIVACY_KEY = "clara_dashboard_money_summary_visible"
 const normalizeRuntimeString = (value) =>
   typeof value === "string" ? value.trim() : value == null ? "" : String(value).trim();
 
-export const getDashboardPrefsStorageKey = (userId) =>
-  `clara_dashboard_prefs_${userId || "guest"}`;
+const resolvePrivateOwner = () => ensureActiveLocalVaultId();
 
-export function readMoneySummaryVisibility(userId = "guest") {
-  return dashboardRuntimeMoneySummaryVisibility.get(userId || "guest") === true;
+export const getDashboardPrefsStorageKey = () =>
+  `clara_dashboard_prefs_${resolvePrivateOwner()}`;
+
+export function readMoneySummaryVisibility() {
+  const ownerId = resolvePrivateOwner();
+  return dashboardRuntimeMoneySummaryVisibility.get(ownerId) === true;
 }
 
-export function persistMoneySummaryVisibility(visible, userId = "guest") {
-  dashboardRuntimeMoneySummaryVisibility.set(userId || "guest", Boolean(visible));
+export function persistMoneySummaryVisibility(visible) {
+  const ownerId = resolvePrivateOwner();
+  dashboardRuntimeMoneySummaryVisibility.set(ownerId, Boolean(visible));
 }
 
-export function readDashboardPrefs(userId) {
-  const key = getDashboardPrefsStorageKey(userId);
+export function readDashboardPrefs() {
+  const key = getDashboardPrefsStorageKey();
   const parsed = dashboardRuntimePrefs.get(key) || {};
 
   return {
@@ -34,23 +39,23 @@ export function readDashboardPrefs(userId) {
   };
 }
 
-export function persistDashboardPrefs(userId, updates) {
-  if (!userId) return;
-
-  const key = getDashboardPrefsStorageKey(userId);
-  const current = readDashboardPrefs(userId);
+export function persistDashboardPrefs(_userId, updates) {
+  const key = getDashboardPrefsStorageKey();
+  const current = readDashboardPrefs();
   dashboardRuntimePrefs.set(key, { ...current, ...(updates || {}) });
 }
 
-export function getSettingsStorageKey(userId) {
-  return getNotificationPreferencesStorageKey(userId);
+export function getSettingsStorageKey() {
+  return getNotificationPreferencesStorageKey(resolvePrivateOwner());
 }
 
-export function readStoredNotificationSettings(userId) {
-  return notificationPreferencesToLegacySettings(readNotificationPreferences(userId));
+export function readStoredNotificationSettings() {
+  return notificationPreferencesToLegacySettings(
+    readNotificationPreferences(resolvePrivateOwner())
+  );
 }
 
-export function persistStoredNotificationSettings(userId, updates = {}) {
-  const saved = updateNotificationPreferences(userId, updates);
+export function persistStoredNotificationSettings(_userId, updates = {}) {
+  const saved = updateNotificationPreferences(resolvePrivateOwner(), updates);
   return notificationPreferencesToLegacySettings(saved);
 }

--- a/src/components/fresh/main-dashboard/dashboard-theme/useDashboardThemePersistence.js
+++ b/src/components/fresh/main-dashboard/dashboard-theme/useDashboardThemePersistence.js
@@ -2,11 +2,11 @@ import { useEffect } from "react";
 import { dispatchClaraEvent } from "@/components/fresh/main-dashboard/dashboard-events/dashboardEvents";
 import { persistDashboardTheme } from "@/components/fresh/main-dashboard/dashboard-theme/dashboardThemeRuntime";
 import { normalizeString } from "@/utils/dashboard/dashboardHelpers";
+import { ensureActiveLocalVaultId } from "@/lib/localVaultIdentity";
 
-export default function useDashboardThemePersistence({
-  selectedDashboardTheme,
-  userId,
-}) {
+export default function useDashboardThemePersistence({ selectedDashboardTheme }) {
+  const userId = ensureActiveLocalVaultId();
+
   useEffect(() => {
     const themeKey = normalizeString(
       selectedDashboardTheme?.key ||
@@ -26,7 +26,7 @@ export default function useDashboardThemePersistence({
       key: themeKey,
       dashboardTheme: themeKey,
       selectedTheme: themeKey,
-      userId: userId || null,
+      userId,
       isLight: selectedDashboardTheme?.isLight === true,
     };
 

--- a/src/components/fresh/main-dashboard/finance-content/useDashboardFinanceStateSync.js
+++ b/src/components/fresh/main-dashboard/finance-content/useDashboardFinanceStateSync.js
@@ -1,10 +1,10 @@
 import { useEffect } from "react";
 import { getWalletDisplayBalance } from "@/utils/dashboard/dashboardHelpers";
+import { ensureActiveLocalVaultId } from "@/lib/localVaultIdentity";
 
 export const CLARA_EMERGENCY_RESERVE_WALLET_ID = "clara-emergency-reserve-wallet";
 
 export default function useDashboardFinanceStateSync({
-  cacheKey,
   financeWallets = [],
   financeWalletTransactions = [],
   financeTransfers = [],
@@ -25,6 +25,8 @@ export default function useDashboardFinanceStateSync({
   setLoading,
   onCacheUpdate,
 }) {
+  const cacheKey = ensureActiveLocalVaultId();
+
   useEffect(() => {
     const safeWallets = Array.isArray(financeWallets)
       ? financeWallets.filter(
@@ -57,11 +59,6 @@ export default function useDashboardFinanceStateSync({
       (sum, wallet) => sum + getWalletDisplayBalance(wallet),
       0
     );
-
-    // IMPORTANT:
-    // Emergency Fund reserve should NOT exist inside global wallet state.
-    // It causes wallet cards and wallet carousels to flicker.
-    // The reserve wallet should only be injected locally into the Manual Log dropdown.
 
     setWallets(safeWallets);
     setWalletTransactions(safeWalletTransactions);

--- a/src/config/claraFeatureFlags.js
+++ b/src/config/claraFeatureFlags.js
@@ -7,20 +7,17 @@ const normalizeBoolean = (value, fallback = false) => {
 };
 
 const readEnvFlag = (key, fallback = false) => {
-  const envValue = import.meta?.env?.[key];
+  const envValue = import.meta.env?.[key];
   const runtimeValue =
     typeof window !== "undefined" ? window.__CLARA_FEATURE_FLAGS__?.[key] : undefined;
   return normalizeBoolean(runtimeValue ?? envValue, fallback);
 };
 
-// Account services remain opt-in while the Supabase organization is restricted.
 export const CLARA_AUTH_ENABLED = readEnvFlag("VITE_CLARA_AUTH_ENABLED", false);
 export const CLARA_ACCOUNT_LINKING_ENABLED = readEnvFlag(
   "VITE_CLARA_ACCOUNT_LINKING_ENABLED",
   false
 );
-
-// Local mode remains available before login, after logout, and when account services fail.
 export const CLARA_LOCAL_MODE_ENABLED = readEnvFlag(
   "VITE_CLARA_LOCAL_MODE_ENABLED",
   true

--- a/src/config/claraFeatureFlags.js
+++ b/src/config/claraFeatureFlags.js
@@ -1,0 +1,35 @@
+const normalizeBoolean = (value, fallback = false) => {
+  if (typeof value === "boolean") return value;
+  const normalized = String(value ?? "").trim().toLowerCase();
+  if (["1", "true", "yes", "on", "enabled"].includes(normalized)) return true;
+  if (["0", "false", "no", "off", "disabled"].includes(normalized)) return false;
+  return fallback;
+};
+
+const readEnvFlag = (key, fallback = false) => {
+  const envValue = import.meta?.env?.[key];
+  const runtimeValue =
+    typeof window !== "undefined" ? window.__CLARA_FEATURE_FLAGS__?.[key] : undefined;
+  return normalizeBoolean(runtimeValue ?? envValue, fallback);
+};
+
+// Account services remain opt-in while the Supabase organization is restricted.
+export const CLARA_AUTH_ENABLED = readEnvFlag("VITE_CLARA_AUTH_ENABLED", false);
+export const CLARA_ACCOUNT_LINKING_ENABLED = readEnvFlag(
+  "VITE_CLARA_ACCOUNT_LINKING_ENABLED",
+  false
+);
+
+// Local mode remains available before login, after logout, and when account services fail.
+export const CLARA_LOCAL_MODE_ENABLED = readEnvFlag(
+  "VITE_CLARA_LOCAL_MODE_ENABLED",
+  true
+);
+
+export function getClaraFeatureFlags() {
+  return {
+    authEnabled: CLARA_AUTH_ENABLED,
+    accountLinkingEnabled: CLARA_ACCOUNT_LINKING_ENABLED,
+    localModeEnabled: CLARA_LOCAL_MODE_ENABLED,
+  };
+}

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -10,6 +10,10 @@ import {
 import { supabase } from '@/lib/supabaseClient';
 import { resolveMembership } from '@/lib/membership';
 import {
+  CLARA_AUTH_ENABLED,
+  CLARA_LOCAL_MODE_ENABLED,
+} from '@/config/claraFeatureFlags';
+import {
   clearAccessSnapshot,
   getAccessSnapshot,
   getOfflineFallbackFlow,
@@ -22,9 +26,7 @@ const AuthContext = createContext(null);
 
 const AUTH_TIMEOUT_MS = 6000;
 const PROFILE_TIMEOUT_MS = 6500;
-
-// TEMP AUTH BYPASS: Used while Supabase project is restricted. Remove or disable when Supabase Auth is restored.
-const TEMP_AUTH_BYPASS_ENABLED = true;
+const TEMP_AUTH_BYPASS_ENABLED = CLARA_LOCAL_MODE_ENABLED;
 
 const LOCAL_DEV_AUTH_USER = {
   id: 'local-dev-user',
@@ -651,6 +653,11 @@ export function AuthProvider({ children }) {
       try {
         setAuthReady(false);
 
+        if (!CLARA_AUTH_ENABLED) {
+          applyLocalAuthBypass();
+          return;
+        }
+
         const cachedSnapshot = getAccessSnapshot();
 
         if (isAccessSnapshotUsable(cachedSnapshot)) {
@@ -739,6 +746,12 @@ export function AuthProvider({ children }) {
 
     init();
 
+    if (!CLARA_AUTH_ENABLED) {
+      return () => {
+        mounted = false;
+      };
+    }
+
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((event, nextSession) => {
@@ -782,7 +795,7 @@ export function AuthProvider({ children }) {
   }, [applyLocalAuthBypass, applySession]);
 
   useEffect(() => {
-    if (!user?.id) return undefined;
+    if (!CLARA_AUTH_ENABLED || !user?.id || isLocalFallbackUser(user)) return undefined;
     if (profile?.offline_access || profile?.offline_limited_access) return undefined;
 
     const channel = supabase
@@ -815,7 +828,7 @@ export function AuthProvider({ children }) {
 
   useEffect(() => {
     if (typeof window === 'undefined') return undefined;
-    if (!user?.id) return undefined;
+    if (!CLARA_AUTH_ENABLED || !user?.id || isLocalFallbackUser(user)) return undefined;
 
     const handleOnline = () => {
       refreshProfileSilently(user).catch((error) => {
@@ -831,6 +844,10 @@ export function AuthProvider({ children }) {
   }, [refreshProfileSilently, user]);
 
   const signUp = async ({ email, password, fullName }) => {
+    if (!CLARA_AUTH_ENABLED) {
+      throw new Error('CLARA account services are temporarily unavailable.');
+    }
+
     const { data, error } = await supabase.auth.signUp({
       email: email.trim(),
       password,
@@ -845,6 +862,10 @@ export function AuthProvider({ children }) {
   };
 
   const signIn = async ({ email, password }) => {
+    if (!CLARA_AUTH_ENABLED) {
+      throw new Error('CLARA account services are temporarily unavailable.');
+    }
+
     const { data, error } = await supabase.auth.signInWithPassword({
       email: email.trim(),
       password,
@@ -889,6 +910,10 @@ export function AuthProvider({ children }) {
   };
 
   const signInWithGoogle = async () => {
+    if (!CLARA_AUTH_ENABLED) {
+      throw new Error('CLARA account services are temporarily unavailable.');
+    }
+
     const redirectTo = `${window.location.origin}${window.location.pathname}`;
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
@@ -905,6 +930,11 @@ export function AuthProvider({ children }) {
   const signOut = async () => {
     const previousUserKey = user?.id || user?.email || null;
     manualSignInSessionRef.current = null;
+
+    if (isLocalFallbackUser(user) || !CLARA_AUTH_ENABLED) {
+      applyLocalAuthBypass();
+      return;
+    }
 
     await supabase.auth.signOut();
 

--- a/src/hooks/useLocalVaultMetadata.js
+++ b/src/hooks/useLocalVaultMetadata.js
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from "react";
+import { ensureActiveLocalVaultId } from "../lib/localVaultIdentity.js";
+import { getActiveVaultMetadata } from "../lib/localVaultMetadata.js";
+
+export default function useLocalVaultMetadata() {
+  const [vaultId] = useState(() => ensureActiveLocalVaultId());
+  const [metadata, setMetadata] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const nextMetadata = await getActiveVaultMetadata(vaultId);
+      setMetadata(nextMetadata);
+      return nextMetadata;
+    } catch (error) {
+      console.warn("[CLARA Vault] Unable to read local vault metadata.", {
+        vaultId,
+        code: error?.name || "VAULT_METADATA_READ_FAILED",
+      });
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, [vaultId]);
+
+  useEffect(() => {
+    refresh();
+    if (typeof window === "undefined") return undefined;
+
+    const handleUpdate = () => refresh();
+    window.addEventListener("clara:local-vault-link-updated", handleUpdate);
+    window.addEventListener("clara:active-local-vault-updated", handleUpdate);
+
+    return () => {
+      window.removeEventListener("clara:local-vault-link-updated", handleUpdate);
+      window.removeEventListener("clara:active-local-vault-updated", handleUpdate);
+    };
+  }, [refresh]);
+
+  return { vaultId, metadata, loading, refresh };
+}

--- a/src/hooks/useNotificationPreferences.js
+++ b/src/hooks/useNotificationPreferences.js
@@ -3,8 +3,10 @@ import {
   persistNotificationPreferences,
   readNotificationPreferences,
 } from "@/lib/notifications/notificationPreferences";
+import { ensureActiveLocalVaultId } from "@/lib/localVaultIdentity";
 
-export default function useNotificationPreferences(userId) {
+export default function useNotificationPreferences() {
+  const userId = ensureActiveLocalVaultId();
   const [preferences, setPreferencesState] = useState(() =>
     readNotificationPreferences(userId)
   );

--- a/src/lib/accountLinking/linkLocalVaultToAccount.js
+++ b/src/lib/accountLinking/linkLocalVaultToAccount.js
@@ -1,6 +1,18 @@
-import { LOCAL_FINANCE_PRIVATE_STORES, getLocalRecordsByUser } from "../localFinanceStore.js";
-import { LEGACY_LOCAL_VAULT_ID, ensureActiveLocalVaultId, getActiveLocalVaultId } from "../localVaultIdentity.js";
-import { getActiveVaultMetadata, markVaultLinked, markVaultLinkFailed, markVaultLinking } from "../localVaultMetadata.js";
+import {
+  LOCAL_FINANCE_PRIVATE_STORES,
+  getLocalRecordsByUser,
+} from "../localFinanceStore.js";
+import {
+  LEGACY_LOCAL_VAULT_ID,
+  ensureActiveLocalVaultId,
+  getActiveLocalVaultId,
+} from "../localVaultIdentity.js";
+import {
+  getActiveVaultMetadata,
+  markVaultLinked,
+  markVaultLinkFailed,
+  markVaultLinking,
+} from "../localVaultMetadata.js";
 
 const clean = (value) => String(value ?? "").trim();
 
@@ -21,9 +33,25 @@ export async function readLocalVaultSnapshot(vaultId) {
         includeDeleted: true,
       });
       const records = Array.isArray(rows) ? rows : [];
-      const activeIds = records.filter((row) => !row?.deletedAt && !row?.deleted_at).map((row) => clean(row?.id)).filter(Boolean).sort();
-      const deletedIds = records.filter((row) => row?.deletedAt || row?.deleted_at).map((row) => clean(row?.id)).filter(Boolean).sort();
-      return [storeName, { active: activeIds.length, deleted: deletedIds.length, activeIds, deletedIds }];
+      const activeIds = records
+        .filter((row) => !row?.deletedAt && !row?.deleted_at)
+        .map((row) => clean(row?.id))
+        .filter(Boolean)
+        .sort();
+      const deletedIds = records
+        .filter((row) => row?.deletedAt || row?.deleted_at)
+        .map((row) => clean(row?.id))
+        .filter(Boolean)
+        .sort();
+      return [
+        storeName,
+        {
+          active: activeIds.length,
+          deleted: deletedIds.length,
+          activeIds,
+          deletedIds,
+        },
+      ];
     })
   );
 
@@ -42,50 +70,122 @@ const defaultAdapters = {
   markFailed: markVaultLinkFailed,
   readSnapshot: readLocalVaultSnapshot,
   dispatchLinked(detail) {
-    if (typeof window === "undefined") return;
-    ["clara:local-vault-link-updated", "clara-finance-updated", "clara:finance-data-updated"].forEach((name) => {
+    if (typeof window === "undefined" || typeof CustomEvent === "undefined") return;
+    [
+      "clara:local-vault-link-updated",
+      "clara-finance-updated",
+      "clara:finance-data-updated",
+    ].forEach((name) => {
       window.dispatchEvent(new CustomEvent(name, { detail }));
     });
   },
 };
 
-export async function linkLocalVaultToAccountWithAdapters(input = {}, adapters = defaultAdapters) {
+export async function linkLocalVaultToAccountWithAdapters(
+  input = {},
+  adapters = defaultAdapters
+) {
   const accountUserId = clean(input.accountUserId);
   const accountEmail = clean(input.accountEmail).toLowerCase();
+  const expectedVaultId = clean(input.expectedVaultId);
+
   if (!accountUserId || accountUserId === LEGACY_LOCAL_VAULT_ID) {
-    throw linkError("A genuine authenticated CLARA account is required.", "INVALID_ACCOUNT_ID");
+    throw linkError(
+      "A genuine authenticated CLARA account is required.",
+      "INVALID_ACCOUNT_ID"
+    );
   }
 
   const vaultId = clean(await adapters.getActiveVaultId());
   if (!vaultId) throw linkError("No active local vault was found.", "VAULT_MISSING");
+  if (expectedVaultId && expectedVaultId !== vaultId) {
+    throw linkError(
+      "The active local vault changed before account linking.",
+      "VAULT_CHANGED"
+    );
+  }
 
   const metadata = await adapters.getMetadata(vaultId);
   const linkedAccountId = clean(metadata?.accountUserId);
-  if (metadata?.linkStatus === "linked" && linkedAccountId && linkedAccountId !== accountUserId) {
-    throw linkError("This local vault is already linked to a different CLARA account.", "VAULT_ACCOUNT_CONFLICT");
+
+  if (
+    metadata?.linkStatus === "linked" &&
+    linkedAccountId &&
+    linkedAccountId !== accountUserId
+  ) {
+    throw linkError(
+      "This local vault is already linked to a different CLARA account.",
+      "VAULT_ACCOUNT_CONFLICT"
+    );
   }
 
   const before = await adapters.readSnapshot(vaultId);
+
   if (metadata?.linkStatus === "linked" && linkedAccountId === accountUserId) {
     const after = await adapters.readSnapshot(vaultId);
-    if (!snapshotsMatch(before, after)) throw linkError("Local record verification failed.", "VAULT_VERIFICATION_FAILED");
-    return { ok: true, idempotent: true, vaultId, accountUserId, accountEmail: accountEmail || metadata?.accountEmail || null, linkedAt: metadata?.linkedAt || null, recordCounts: after };
+    if (!snapshotsMatch(before, after)) {
+      throw linkError("Local record verification failed.", "VAULT_VERIFICATION_FAILED");
+    }
+    return {
+      ok: true,
+      idempotent: true,
+      vaultId,
+      accountUserId,
+      accountEmail: accountEmail || metadata?.accountEmail || null,
+      linkedAt: metadata?.linkedAt || null,
+      recordCounts: after,
+    };
   }
 
   await adapters.markLinking({ accountUserId, accountEmail }, vaultId);
+
   try {
+    const activeVaultAfterAuth = clean(await adapters.getActiveVaultId());
+    if (activeVaultAfterAuth !== vaultId) {
+      throw linkError(
+        "The active local vault changed during account linking.",
+        "VAULT_CHANGED"
+      );
+    }
+
     const after = await adapters.readSnapshot(vaultId);
-    if (!snapshotsMatch(before, after)) throw linkError("Local record verification failed.", "VAULT_VERIFICATION_FAILED");
+    if (!snapshotsMatch(before, after)) {
+      throw linkError("Local record verification failed.", "VAULT_VERIFICATION_FAILED");
+    }
 
     const linkedAt = new Date().toISOString();
     await adapters.markLinked({ accountUserId, accountEmail, linkedAt }, vaultId);
-    const result = { ok: true, idempotent: false, vaultId, accountUserId, accountEmail: accountEmail || null, linkedAt, recordCounts: after };
+
+    const result = {
+      ok: true,
+      idempotent: false,
+      vaultId,
+      accountUserId,
+      accountEmail: accountEmail || null,
+      linkedAt,
+      recordCounts: after,
+    };
+
     adapters.dispatchLinked?.(result);
-    console.info("[CLARA Account Linking] Local vault linked.", { vaultId, storeCount: Object.keys(after).length });
+    console.info("[CLARA Account Linking] Local vault linked.", {
+      vaultId,
+      storeCount: Object.keys(after).length,
+    });
     return result;
   } catch (error) {
-    await adapters.markFailed({ accountUserId, accountEmail, errorCode: error?.code, message: error?.message }, vaultId);
-    console.warn("[CLARA Account Linking] Link failed; local records were preserved.", { vaultId, code: error?.code || "ACCOUNT_LINK_FAILED" });
+    await adapters.markFailed(
+      {
+        accountUserId,
+        accountEmail,
+        errorCode: error?.code,
+        message: error?.message,
+      },
+      vaultId
+    );
+    console.warn(
+      "[CLARA Account Linking] Link failed; local records were preserved.",
+      { vaultId, code: error?.code || "ACCOUNT_LINK_FAILED" }
+    );
     throw error;
   }
 }

--- a/src/lib/accountLinking/linkLocalVaultToAccount.js
+++ b/src/lib/accountLinking/linkLocalVaultToAccount.js
@@ -1,0 +1,95 @@
+import { LOCAL_FINANCE_PRIVATE_STORES, getLocalRecordsByUser } from "../localFinanceStore.js";
+import { LEGACY_LOCAL_VAULT_ID, ensureActiveLocalVaultId, getActiveLocalVaultId } from "../localVaultIdentity.js";
+import { getActiveVaultMetadata, markVaultLinked, markVaultLinkFailed, markVaultLinking } from "../localVaultMetadata.js";
+
+const clean = (value) => String(value ?? "").trim();
+
+function linkError(message, code) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+export async function readLocalVaultSnapshot(vaultId) {
+  const id = clean(vaultId);
+  if (!id) throw linkError("A local vault is required.", "VAULT_MISSING");
+
+  const entries = await Promise.all(
+    LOCAL_FINANCE_PRIVATE_STORES.map(async (storeName) => {
+      const rows = await getLocalRecordsByUser(storeName, {
+        localUserId: id,
+        includeDeleted: true,
+      });
+      const records = Array.isArray(rows) ? rows : [];
+      const activeIds = records.filter((row) => !row?.deletedAt && !row?.deleted_at).map((row) => clean(row?.id)).filter(Boolean).sort();
+      const deletedIds = records.filter((row) => row?.deletedAt || row?.deleted_at).map((row) => clean(row?.id)).filter(Boolean).sort();
+      return [storeName, { active: activeIds.length, deleted: deletedIds.length, activeIds, deletedIds }];
+    })
+  );
+
+  return Object.fromEntries(entries);
+}
+
+export function snapshotsMatch(before = {}, after = {}) {
+  return JSON.stringify(before) === JSON.stringify(after);
+}
+
+const defaultAdapters = {
+  getActiveVaultId: () => getActiveLocalVaultId() || ensureActiveLocalVaultId(),
+  getMetadata: getActiveVaultMetadata,
+  markLinking: markVaultLinking,
+  markLinked: markVaultLinked,
+  markFailed: markVaultLinkFailed,
+  readSnapshot: readLocalVaultSnapshot,
+  dispatchLinked(detail) {
+    if (typeof window === "undefined") return;
+    ["clara:local-vault-link-updated", "clara-finance-updated", "clara:finance-data-updated"].forEach((name) => {
+      window.dispatchEvent(new CustomEvent(name, { detail }));
+    });
+  },
+};
+
+export async function linkLocalVaultToAccountWithAdapters(input = {}, adapters = defaultAdapters) {
+  const accountUserId = clean(input.accountUserId);
+  const accountEmail = clean(input.accountEmail).toLowerCase();
+  if (!accountUserId || accountUserId === LEGACY_LOCAL_VAULT_ID) {
+    throw linkError("A genuine authenticated CLARA account is required.", "INVALID_ACCOUNT_ID");
+  }
+
+  const vaultId = clean(await adapters.getActiveVaultId());
+  if (!vaultId) throw linkError("No active local vault was found.", "VAULT_MISSING");
+
+  const metadata = await adapters.getMetadata(vaultId);
+  const linkedAccountId = clean(metadata?.accountUserId);
+  if (metadata?.linkStatus === "linked" && linkedAccountId && linkedAccountId !== accountUserId) {
+    throw linkError("This local vault is already linked to a different CLARA account.", "VAULT_ACCOUNT_CONFLICT");
+  }
+
+  const before = await adapters.readSnapshot(vaultId);
+  if (metadata?.linkStatus === "linked" && linkedAccountId === accountUserId) {
+    const after = await adapters.readSnapshot(vaultId);
+    if (!snapshotsMatch(before, after)) throw linkError("Local record verification failed.", "VAULT_VERIFICATION_FAILED");
+    return { ok: true, idempotent: true, vaultId, accountUserId, accountEmail: accountEmail || metadata?.accountEmail || null, linkedAt: metadata?.linkedAt || null, recordCounts: after };
+  }
+
+  await adapters.markLinking({ accountUserId, accountEmail }, vaultId);
+  try {
+    const after = await adapters.readSnapshot(vaultId);
+    if (!snapshotsMatch(before, after)) throw linkError("Local record verification failed.", "VAULT_VERIFICATION_FAILED");
+
+    const linkedAt = new Date().toISOString();
+    await adapters.markLinked({ accountUserId, accountEmail, linkedAt }, vaultId);
+    const result = { ok: true, idempotent: false, vaultId, accountUserId, accountEmail: accountEmail || null, linkedAt, recordCounts: after };
+    adapters.dispatchLinked?.(result);
+    console.info("[CLARA Account Linking] Local vault linked.", { vaultId, storeCount: Object.keys(after).length });
+    return result;
+  } catch (error) {
+    await adapters.markFailed({ accountUserId, accountEmail, errorCode: error?.code, message: error?.message }, vaultId);
+    console.warn("[CLARA Account Linking] Link failed; local records were preserved.", { vaultId, code: error?.code || "ACCOUNT_LINK_FAILED" });
+    throw error;
+  }
+}
+
+export function linkLocalVaultToAccount(input = {}) {
+  return linkLocalVaultToAccountWithAdapters(input, defaultAdapters);
+}

--- a/src/lib/demo/activeDemoProfile.js
+++ b/src/lib/demo/activeDemoProfile.js
@@ -2,6 +2,7 @@ import {
   ACTIVE_CURRENT_STATE_KEY,
   SAMPLE_DATA_LOCAL_USER_ID,
 } from "../clara-young-professional-current-state";
+import { ensureActiveLocalVaultId } from "../localVaultIdentity.js";
 
 export const YOUNG_PROFESSIONAL_DEMO_PROFILE_ID = "young-professional-12m";
 export const YOUNG_PROFESSIONAL_DEMO_PROFILE_NAME = "Young Professional";
@@ -39,8 +40,8 @@ export function getActiveDemoFinanceLocalUserId() {
   return clean(state.demoLocalUserId) || clean(state.localUserId) || SAMPLE_DATA_LOCAL_USER_ID;
 }
 
-export function getEffectiveDemoFinanceLocalUserId(localUserId) {
-  return getActiveDemoFinanceLocalUserId() || clean(localUserId) || "local-user";
+export function getEffectiveDemoFinanceLocalUserId() {
+  return getActiveDemoFinanceLocalUserId() || ensureActiveLocalVaultId();
 }
 
 export function isYoungProfessionalDemoActive() {

--- a/src/lib/localProfileDisplayName.js
+++ b/src/lib/localProfileDisplayName.js
@@ -1,0 +1,26 @@
+import { ensureActiveLocalVaultId } from "./localVaultIdentity.js";
+
+const keyForVault = (vaultId) => `clara_local_profile_name_v1:${vaultId}`;
+
+export function readLocalProfileDisplayName(vaultId = ensureActiveLocalVaultId()) {
+  if (typeof window === "undefined") return "";
+  try {
+    return String(window.localStorage?.getItem(keyForVault(vaultId)) || "").trim();
+  } catch {
+    return "";
+  }
+}
+
+export function saveLocalProfileDisplayName(name, vaultId = ensureActiveLocalVaultId()) {
+  const cleanName = String(name || "").trim();
+  if (!cleanName) throw new Error("Please enter a display name.");
+  if (typeof window !== "undefined") {
+    window.localStorage?.setItem(keyForVault(vaultId), cleanName);
+    window.dispatchEvent(
+      new CustomEvent("clara:local-profile-name-updated", {
+        detail: { vaultId, displayName: cleanName },
+      })
+    );
+  }
+  return cleanName;
+}

--- a/src/lib/localVaultIdentity.js
+++ b/src/lib/localVaultIdentity.js
@@ -1,0 +1,149 @@
+import { LOCAL_FINANCE_PRIVATE_STORES, openLocalFinanceDb } from "./localFinanceStore.js";
+
+export const ACTIVE_LOCAL_VAULT_KEY = "clara_active_local_vault_v1";
+export const LEGACY_LOCAL_VAULT_ID = "local-dev-user";
+export const TEMPORARY_LOCAL_EMAIL = "local@clara.app";
+export const LOCAL_VAULT_VERSION = 1;
+
+let memoryVaultId = "";
+const normalize = (value) => String(value ?? "").trim();
+
+function readStoredVaultId() {
+  if (typeof window === "undefined") return memoryVaultId;
+  try {
+    return normalize(window.localStorage?.getItem(ACTIVE_LOCAL_VAULT_KEY)) || memoryVaultId;
+  } catch {
+    return memoryVaultId;
+  }
+}
+
+function writeStoredVaultId(vaultId) {
+  memoryVaultId = normalize(vaultId);
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage?.setItem(ACTIVE_LOCAL_VAULT_KEY, memoryVaultId);
+  } catch {
+    // Keep the in-memory value when browser storage is unavailable.
+  }
+}
+
+function createVaultId() {
+  if (globalThis?.crypto?.randomUUID) return `vault_${globalThis.crypto.randomUUID()}`;
+  return `vault_${Date.now()}_${Math.random().toString(36).slice(2, 14)}`;
+}
+
+function requestToPromise(request) {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error || new Error("IndexedDB request failed."));
+  });
+}
+
+export function isTemporaryLocalAuthUser(user = {}) {
+  return Boolean(
+    normalize(user?.id) === LEGACY_LOCAL_VAULT_ID ||
+      normalize(user?.email).toLowerCase() === TEMPORARY_LOCAL_EMAIL
+  );
+}
+
+export function resolveLocalVaultId({
+  persistedVaultId = "",
+  ownerCounts = {},
+  candidateOwnerIds = [],
+  createId = createVaultId,
+} = {}) {
+  const persisted = normalize(persistedVaultId);
+  if (persisted) return persisted;
+
+  const counts = Object.entries(ownerCounts || {}).reduce((acc, [ownerId, count]) => {
+    const cleanOwnerId = normalize(ownerId);
+    const safeCount = Number(count);
+    if (cleanOwnerId && Number.isFinite(safeCount) && safeCount > 0) acc[cleanOwnerId] = safeCount;
+    return acc;
+  }, {});
+
+  if (counts[LEGACY_LOCAL_VAULT_ID] > 0) return LEGACY_LOCAL_VAULT_ID;
+
+  for (const candidate of candidateOwnerIds || []) {
+    const cleanCandidate = normalize(candidate);
+    if (cleanCandidate && counts[cleanCandidate] > 0) return cleanCandidate;
+  }
+
+  const existingOwners = Object.entries(counts).sort((left, right) => {
+    if (right[1] !== left[1]) return right[1] - left[1];
+    return left[0].localeCompare(right[0]);
+  });
+
+  return existingOwners[0]?.[0] || normalize(createId()) || createVaultId();
+}
+
+export async function getLocalVaultOwnerCounts() {
+  if (typeof globalThis === "undefined" || !globalThis.indexedDB) return {};
+  const db = await openLocalFinanceDb();
+  const stores = [...LOCAL_FINANCE_PRIVATE_STORES];
+  const transaction = db.transaction(stores, "readonly");
+  const rows = await Promise.all(
+    stores.map((storeName) => requestToPromise(transaction.objectStore(storeName).getAll()))
+  );
+
+  return rows.flat().reduce((counts, record) => {
+    const ownerId = normalize(record?.localUserId);
+    if (ownerId) counts[ownerId] = (counts[ownerId] || 0) + 1;
+    return counts;
+  }, {});
+}
+
+export async function detectLegacyLocalVault() {
+  const counts = await getLocalVaultOwnerCounts();
+  return (counts[LEGACY_LOCAL_VAULT_ID] || 0) > 0;
+}
+
+export function getActiveLocalVaultId() {
+  return readStoredVaultId();
+}
+
+export function setActiveLocalVaultId(vaultId) {
+  const cleanVaultId = normalize(vaultId);
+  if (!cleanVaultId) throw new Error("A valid local vault ID is required.");
+  writeStoredVaultId(cleanVaultId);
+  window?.dispatchEvent?.(
+    new CustomEvent("clara:active-local-vault-updated", { detail: { vaultId: cleanVaultId } })
+  );
+  return cleanVaultId;
+}
+
+export function ensureActiveLocalVaultId() {
+  return getActiveLocalVaultId() || setActiveLocalVaultId(createVaultId());
+}
+
+export async function initializeLocalVaultIdentity({ candidateOwnerIds = [] } = {}) {
+  const persistedVaultId = getActiveLocalVaultId();
+  if (persistedVaultId) return persistedVaultId;
+
+  let ownerCounts = {};
+  try {
+    ownerCounts = await getLocalVaultOwnerCounts();
+  } catch (error) {
+    console.warn("[CLARA Vault] Existing owner scan failed.", {
+      code: error?.name || "VAULT_SCAN_FAILED",
+    });
+  }
+
+  const vaultId = resolveLocalVaultId({ ownerCounts, candidateOwnerIds });
+  setActiveLocalVaultId(vaultId);
+  console.info("[CLARA Vault] Active local vault resolved.", {
+    vaultId,
+    preservedLegacyVault: vaultId === LEGACY_LOCAL_VAULT_ID,
+  });
+  return vaultId;
+}
+
+export function getLocalVaultState() {
+  const vaultId = getActiveLocalVaultId();
+  return {
+    vaultId: vaultId || null,
+    vaultVersion: LOCAL_VAULT_VERSION,
+    initialized: Boolean(vaultId),
+    legacy: vaultId === LEGACY_LOCAL_VAULT_ID,
+  };
+}

--- a/src/lib/localVaultIdentity.js
+++ b/src/lib/localVaultIdentity.js
@@ -23,12 +23,14 @@ function writeStoredVaultId(vaultId) {
   try {
     window.localStorage?.setItem(ACTIVE_LOCAL_VAULT_KEY, memoryVaultId);
   } catch {
-    // Keep the in-memory value when browser storage is unavailable.
+    // Keep the session value when browser storage is unavailable.
   }
 }
 
 function createVaultId() {
-  if (globalThis?.crypto?.randomUUID) return `vault_${globalThis.crypto.randomUUID()}`;
+  if (typeof globalThis !== "undefined" && globalThis.crypto?.randomUUID) {
+    return `vault_${globalThis.crypto.randomUUID()}`;
+  }
   return `vault_${Date.now()}_${Math.random().toString(36).slice(2, 14)}`;
 }
 
@@ -58,7 +60,9 @@ export function resolveLocalVaultId({
   const counts = Object.entries(ownerCounts || {}).reduce((acc, [ownerId, count]) => {
     const cleanOwnerId = normalize(ownerId);
     const safeCount = Number(count);
-    if (cleanOwnerId && Number.isFinite(safeCount) && safeCount > 0) acc[cleanOwnerId] = safeCount;
+    if (cleanOwnerId && Number.isFinite(safeCount) && safeCount > 0) {
+      acc[cleanOwnerId] = safeCount;
+    }
     return acc;
   }, {});
 
@@ -79,6 +83,7 @@ export function resolveLocalVaultId({
 
 export async function getLocalVaultOwnerCounts() {
   if (typeof globalThis === "undefined" || !globalThis.indexedDB) return {};
+
   const db = await openLocalFinanceDb();
   const stores = [...LOCAL_FINANCE_PRIVATE_STORES];
   const transaction = db.transaction(stores, "readonly");
@@ -105,10 +110,17 @@ export function getActiveLocalVaultId() {
 export function setActiveLocalVaultId(vaultId) {
   const cleanVaultId = normalize(vaultId);
   if (!cleanVaultId) throw new Error("A valid local vault ID is required.");
+
   writeStoredVaultId(cleanVaultId);
-  window?.dispatchEvent?.(
-    new CustomEvent("clara:active-local-vault-updated", { detail: { vaultId: cleanVaultId } })
-  );
+
+  if (typeof window !== "undefined" && typeof CustomEvent !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent("clara:active-local-vault-updated", {
+        detail: { vaultId: cleanVaultId },
+      })
+    );
+  }
+
   return cleanVaultId;
 }
 

--- a/src/lib/localVaultMetadata.js
+++ b/src/lib/localVaultMetadata.js
@@ -1,0 +1,104 @@
+import { getLocalMetadata, setLocalMetadata } from "./localFinanceStore.js";
+import {
+  LOCAL_VAULT_VERSION,
+  ensureActiveLocalVaultId,
+  getActiveLocalVaultId,
+} from "./localVaultIdentity.js";
+
+const LINK_STATUSES = new Set(["local_only", "linking", "linked", "link_failed"]);
+const normalize = (value) => String(value ?? "").trim();
+const nowIso = () => new Date().toISOString();
+
+function normalizeLinkStatus(value) {
+  const status = normalize(value).toLowerCase();
+  return LINK_STATUSES.has(status) ? status : "local_only";
+}
+
+function makeDefaultMetadata(vaultId) {
+  const now = nowIso();
+  return {
+    vaultId,
+    vaultVersion: LOCAL_VAULT_VERSION,
+    createdAt: now,
+    updatedAt: now,
+    linkStatus: "local_only",
+    accountUserId: null,
+    accountEmail: null,
+    linkedAt: null,
+    lastAuthenticatedAt: null,
+    linkError: null,
+  };
+}
+
+export async function getActiveVaultMetadata(vaultId = "") {
+  const activeVaultId = normalize(vaultId) || getActiveLocalVaultId() || ensureActiveLocalVaultId();
+  const metadataRecord = await getLocalMetadata(activeVaultId);
+  const stored = metadataRecord?.metadata || {};
+  return {
+    ...makeDefaultMetadata(activeVaultId),
+    ...stored,
+    vaultId: activeVaultId,
+    vaultVersion: Number(stored?.vaultVersion || LOCAL_VAULT_VERSION),
+    linkStatus: normalizeLinkStatus(stored?.linkStatus),
+  };
+}
+
+export async function updateActiveVaultMetadata(patch = {}, vaultId = "") {
+  const activeVaultId = normalize(vaultId) || getActiveLocalVaultId() || ensureActiveLocalVaultId();
+  const current = await getActiveVaultMetadata(activeVaultId);
+  const next = {
+    ...current,
+    ...(patch || {}),
+    vaultId: activeVaultId,
+    vaultVersion: LOCAL_VAULT_VERSION,
+    linkStatus: normalizeLinkStatus(patch?.linkStatus ?? current.linkStatus),
+    createdAt: current.createdAt || nowIso(),
+    updatedAt: nowIso(),
+  };
+  await setLocalMetadata(activeVaultId, next);
+  return next;
+}
+
+export function markVaultLinking({ accountUserId, accountEmail } = {}, vaultId = "") {
+  return updateActiveVaultMetadata(
+    {
+      linkStatus: "linking",
+      accountUserId: normalize(accountUserId) || null,
+      accountEmail: normalize(accountEmail).toLowerCase() || null,
+      lastAuthenticatedAt: nowIso(),
+      linkError: null,
+    },
+    vaultId
+  );
+}
+
+export function markVaultLinked({ accountUserId, accountEmail, linkedAt = nowIso() } = {}, vaultId = "") {
+  return updateActiveVaultMetadata(
+    {
+      linkStatus: "linked",
+      accountUserId: normalize(accountUserId) || null,
+      accountEmail: normalize(accountEmail).toLowerCase() || null,
+      linkedAt,
+      lastAuthenticatedAt: nowIso(),
+      linkError: null,
+    },
+    vaultId
+  );
+}
+
+export function markVaultLinkFailed({ accountUserId, accountEmail, errorCode, message } = {}, vaultId = "") {
+  return updateActiveVaultMetadata(
+    {
+      linkStatus: "link_failed",
+      accountUserId: normalize(accountUserId) || null,
+      accountEmail: normalize(accountEmail).toLowerCase() || null,
+      lastAuthenticatedAt: nowIso(),
+      linkError: {
+        code: normalize(errorCode) || "ACCOUNT_LINK_FAILED",
+        message: normalize(message) || "Unable to link this account.",
+        failedAt: nowIso(),
+      },
+    },
+    vaultId
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,6 +7,7 @@ import { queryClientInstance } from "@/lib/query-client";
 import { ThemeProvider } from "@/theme/ThemeProvider";
 import { installClaraGlobalClickSound } from "@/lib/claraSoundSystem";
 import { installNativeNotificationListeners } from "@/lib/notifications/nativePushNotifications";
+import { initializeLocalVaultIdentity } from "@/lib/localVaultIdentity";
 import { installDailyTipFlipSound } from "./runtime/installDailyTipFlipSound";
 import { installLearningHubOpenSound } from "./runtime/installLearningHubOpenSound";
 import { installMoneyVisibilitySound } from "./runtime/installMoneyVisibilitySound";
@@ -118,16 +119,26 @@ try {
   console.warn("CLARA native notification listeners failed to init:", error);
 }
 
-ReactDOM.createRoot(document.getElementById("root")).render(
-  <React.StrictMode>
-    <QueryClientProvider client={queryClientInstance}>
-      <AuthProvider>
-        <ThemeProvider>
-          <HashRouter>
-            <App />
-          </HashRouter>
-        </ThemeProvider>
-      </AuthProvider>
-    </QueryClientProvider>
-  </React.StrictMode>,
-);
+function renderClara() {
+  ReactDOM.createRoot(document.getElementById("root")).render(
+    <React.StrictMode>
+      <QueryClientProvider client={queryClientInstance}>
+        <AuthProvider>
+          <ThemeProvider>
+            <HashRouter>
+              <App />
+            </HashRouter>
+          </ThemeProvider>
+        </AuthProvider>
+      </QueryClientProvider>
+    </React.StrictMode>,
+  );
+}
+
+initializeLocalVaultIdentity()
+  .catch((error) => {
+    console.warn("[CLARA Vault] Startup initialization failed.", {
+      code: error?.name || "VAULT_STARTUP_FAILED",
+    });
+  })
+  .finally(renderClara);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -14,6 +14,7 @@ import { installMoneyVisibilitySound } from "./runtime/installMoneyVisibilitySou
 import { installFinancialCarouselSwipeSound } from "./runtime/installFinancialCarouselSwipeSound";
 import { installMoneyLeftOrbInteractionSound } from "./runtime/installMoneyLeftOrbInteractionSound";
 import { installClaraGuideDemoPatches } from "./runtime/installClaraGuideDemoPatches";
+import { installLocalVaultSettingsExperience } from "./runtime/installLocalVaultSettingsExperience";
 import {
   clearClaraGuideFeatureClasses,
   installClaraGuideCarouselStep,
@@ -117,6 +118,12 @@ try {
   installNativeNotificationListeners();
 } catch (error) {
   console.warn("CLARA native notification listeners failed to init:", error);
+}
+
+try {
+  installLocalVaultSettingsExperience();
+} catch (error) {
+  console.warn("CLARA local vault settings experience failed to init:", error);
 }
 
 function renderClara() {

--- a/src/runtime/installLocalVaultSettingsExperience.js
+++ b/src/runtime/installLocalVaultSettingsExperience.js
@@ -1,0 +1,75 @@
+import {
+  CLARA_ACCOUNT_LINKING_ENABLED,
+  CLARA_AUTH_ENABLED,
+} from "@/config/claraFeatureFlags";
+
+const LOCAL_EMAIL = "local@clara.app";
+
+function findExactText(value) {
+  return [...document.querySelectorAll("*")].filter(
+    (node) => String(node.textContent || "").trim() === value
+  );
+}
+
+function patch() {
+  const localEmailNodes = findExactText(LOCAL_EMAIL);
+  const localMode = localEmailNodes.length > 0;
+
+  localEmailNodes.forEach((node) => {
+    node.textContent = "Stored on this device";
+  });
+
+  if (!localMode) return;
+
+  findExactText("Signed in as").forEach((node) => {
+    node.textContent = "Status";
+  });
+
+  findExactText("Log out").forEach((button) => {
+    if (button.parentElement) button.parentElement.style.display = "none";
+  });
+
+  const heading = findExactText("Your CLARA data is private")[0];
+  const section = heading?.closest("section");
+  if (!section || section.querySelector("#clara-link-local-data")) return;
+
+  const button = document.createElement("button");
+  button.id = "clara-link-local-data";
+  button.type = "button";
+  button.textContent = "Protect & link my data";
+  button.className =
+    "mt-4 inline-flex min-h-11 w-full items-center justify-center rounded-2xl bg-emerald-400 px-4 py-3 text-sm font-black text-slate-950";
+  button.onclick = () => {
+    if (!CLARA_AUTH_ENABLED || !CLARA_ACCOUNT_LINKING_ENABLED) {
+      window.alert(
+        "Account linking is temporarily unavailable. Your current data remains safe on this device."
+      );
+      return;
+    }
+    window.location.hash = "#/login?intent=link-local-vault";
+  };
+
+  const details = [...section.querySelectorAll("button")].find((node) =>
+    String(node.textContent || "").includes("View data details")
+  );
+  section.insertBefore(button, details || null);
+}
+
+export function installLocalVaultSettingsExperience() {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
+  let pending = false;
+  const schedule = () => {
+    if (pending) return;
+    pending = true;
+    window.requestAnimationFrame(() => {
+      pending = false;
+      patch();
+    });
+  };
+  new MutationObserver(schedule).observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+  window.addEventListener("hashchange", schedule);
+  schedule();
+}

--- a/tests/local-vault-account-linking.test.mjs
+++ b/tests/local-vault-account-linking.test.mjs
@@ -1,6 +1,182 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import {
+  linkLocalVaultToAccountWithAdapters,
+  snapshotsMatch,
+} from "../src/lib/accountLinking/linkLocalVaultToAccount.js";
 
-test("local vault linking scaffold", () => {
-  assert.equal(true, true);
+const snapshot = {
+  expenses: {
+    active: 1,
+    deleted: 1,
+    activeIds: ["expense_1"],
+    deletedIds: ["expense_deleted"],
+  },
+  wallets: {
+    active: 1,
+    deleted: 0,
+    activeIds: ["wallet_1"],
+    deletedIds: [],
+  },
+};
+
+function createAdapters(overrides = {}) {
+  let metadata = {
+    linkStatus: "local_only",
+    accountUserId: null,
+    accountEmail: null,
+  };
+  const calls = { linking: 0, linked: 0, failed: 0, dispatched: 0 };
+
+  return {
+    calls,
+    currentMetadata: () => metadata,
+    getActiveVaultId: async () => "local-dev-user",
+    getMetadata: async () => metadata,
+    readSnapshot: async () => structuredClone(snapshot),
+    markLinking: async (patch) => {
+      calls.linking += 1;
+      metadata = { ...metadata, ...patch, linkStatus: "linking" };
+      return metadata;
+    },
+    markLinked: async (patch) => {
+      calls.linked += 1;
+      metadata = { ...metadata, ...patch, linkStatus: "linked" };
+      return metadata;
+    },
+    markFailed: async (patch) => {
+      calls.failed += 1;
+      metadata = { ...metadata, linkStatus: "link_failed", linkError: patch };
+      return metadata;
+    },
+    dispatchLinked: () => {
+      calls.dispatched += 1;
+    },
+    ...overrides,
+  };
+}
+
+test("snapshot comparison preserves active and deleted record IDs", () => {
+  assert.equal(snapshotsMatch(snapshot, structuredClone(snapshot)), true);
+  assert.equal(
+    snapshotsMatch(snapshot, {
+      ...structuredClone(snapshot),
+      expenses: { ...snapshot.expenses, activeIds: [] },
+    }),
+    false
+  );
+});
+
+test("links metadata without changing local records", async () => {
+  const adapters = createAdapters();
+  const result = await linkLocalVaultToAccountWithAdapters(
+    {
+      expectedVaultId: "local-dev-user",
+      accountUserId: "account-123",
+      accountEmail: "max@example.com",
+    },
+    adapters
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.vaultId, "local-dev-user");
+  assert.deepEqual(result.recordCounts, snapshot);
+  assert.deepEqual(adapters.calls, {
+    linking: 1,
+    linked: 1,
+    failed: 0,
+    dispatched: 1,
+  });
+});
+
+test("linking the same account twice is idempotent", async () => {
+  const adapters = createAdapters();
+  await linkLocalVaultToAccountWithAdapters(
+    { accountUserId: "account-123" },
+    adapters
+  );
+  const second = await linkLocalVaultToAccountWithAdapters(
+    { accountUserId: "account-123" },
+    adapters
+  );
+
+  assert.equal(second.idempotent, true);
+  assert.equal(adapters.calls.linked, 1);
+});
+
+test("linking a different account produces a controlled conflict", async () => {
+  const adapters = createAdapters({
+    getMetadata: async () => ({
+      linkStatus: "linked",
+      accountUserId: "first-account",
+    }),
+  });
+
+  await assert.rejects(
+    () =>
+      linkLocalVaultToAccountWithAdapters(
+        { accountUserId: "second-account" },
+        adapters
+      ),
+    (error) => error.code === "VAULT_ACCOUNT_CONFLICT"
+  );
+  assert.equal(adapters.calls.linking, 0);
+});
+
+test("changed active vault is rejected before linking", async () => {
+  const adapters = createAdapters();
+
+  await assert.rejects(
+    () =>
+      linkLocalVaultToAccountWithAdapters(
+        { expectedVaultId: "vault-before", accountUserId: "account-123" },
+        adapters
+      ),
+    (error) => error.code === "VAULT_CHANGED"
+  );
+  assert.equal(adapters.calls.linking, 0);
+});
+
+test("failed verification marks failure without marking linked", async () => {
+  let reads = 0;
+  const adapters = createAdapters({
+    readSnapshot: async () => {
+      reads += 1;
+      if (reads === 1) return structuredClone(snapshot);
+      return {
+        ...structuredClone(snapshot),
+        expenses: {
+          active: 0,
+          deleted: 1,
+          activeIds: [],
+          deletedIds: ["expense_deleted"],
+        },
+      };
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      linkLocalVaultToAccountWithAdapters(
+        { accountUserId: "account-123" },
+        adapters
+      ),
+    (error) => error.code === "VAULT_VERIFICATION_FAILED"
+  );
+  assert.equal(adapters.calls.linked, 0);
+  assert.equal(adapters.calls.failed, 1);
+  assert.equal(adapters.currentMetadata().linkStatus, "link_failed");
+});
+
+test("temporary local identity cannot be linked as an account", async () => {
+  const adapters = createAdapters();
+
+  await assert.rejects(
+    () =>
+      linkLocalVaultToAccountWithAdapters(
+        { accountUserId: "local-dev-user" },
+        adapters
+      ),
+    (error) => error.code === "INVALID_ACCOUNT_ID"
+  );
 });

--- a/tests/local-vault-account-linking.test.mjs
+++ b/tests/local-vault-account-linking.test.mjs
@@ -1,0 +1,6 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("local vault linking scaffold", () => {
+  assert.equal(true, true);
+});

--- a/tests/local-vault-identity.test.mjs
+++ b/tests/local-vault-identity.test.mjs
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  LEGACY_LOCAL_VAULT_ID,
+  isTemporaryLocalAuthUser,
+  resolveLocalVaultId,
+} from "../src/lib/localVaultIdentity.js";
+
+test("preserves the legacy local-dev-user vault when records exist", () => {
+  const vaultId = resolveLocalVaultId({
+    ownerCounts: { [LEGACY_LOCAL_VAULT_ID]: 5, "real-user-id": 2 },
+    createId: () => "vault_new",
+  });
+  assert.equal(vaultId, LEGACY_LOCAL_VAULT_ID);
+});
+
+test("creates a device vault for a fresh installation", () => {
+  const vaultId = resolveLocalVaultId({ ownerCounts: {}, createId: () => "vault_unique" });
+  assert.equal(vaultId, "vault_unique");
+});
+
+test("keeps a persisted vault unchanged across auth identity changes", () => {
+  const beforeLogin = resolveLocalVaultId({ persistedVaultId: "vault_stable" });
+  const afterLogin = resolveLocalVaultId({
+    persistedVaultId: beforeLogin,
+    ownerCounts: { "supabase-user-id": 10 },
+    candidateOwnerIds: ["supabase-user-id"],
+  });
+  const afterLogout = resolveLocalVaultId({ persistedVaultId: afterLogin });
+  assert.equal(beforeLogin, "vault_stable");
+  assert.equal(afterLogin, "vault_stable");
+  assert.equal(afterLogout, "vault_stable");
+});
+
+test("preserves an older authenticated owner when it is the only existing vault", () => {
+  const vaultId = resolveLocalVaultId({
+    ownerCounts: { "existing-supabase-owner": 7 },
+    candidateOwnerIds: ["existing-supabase-owner"],
+    createId: () => "vault_new",
+  });
+  assert.equal(vaultId, "existing-supabase-owner");
+});
+
+test("temporary local identity is not treated as a genuine account", () => {
+  assert.equal(isTemporaryLocalAuthUser({ id: "local-dev-user" }), true);
+  assert.equal(isTemporaryLocalAuthUser({ email: "local@clara.app" }), true);
+  assert.equal(isTemporaryLocalAuthUser({ id: "real-user", email: "max@example.com" }), false);
+});


### PR DESCRIPTION
## Status

This is a **draft / work-in-progress** pull request. Do not merge yet.

The branch currently contains only the local-vault/account-linking foundation and tests scaffold. Existing application flows are not fully integrated yet.

## Goal

Separate these three identities safely:

1. Local vault identity — owns private IndexedDB records
2. Supabase account identity — optional login/account identity
3. Google Play entitlement — Free or Committed access

A login, logout, restart, or failed authentication attempt must never make existing local financial records disappear.

## Already added

- Central feature-flag module
- Stable local-vault identity helpers
- Legacy `local-dev-user` preservation logic
- Local-vault metadata states
- Idempotent account-linking service
- Reactive vault metadata hook
- Local profile-name persistence helper
- Initial vault identity tests
- Linking test scaffold

## Still required before merge

- [ ] Replace auth-derived finance ownership with stable vault ownership
- [ ] Initialize the vault before the app renders
- [ ] Update dashboard cache ownership to use the vault ID
- [ ] Add `/login?intent=link-local-vault`
- [ ] Connect successful Supabase login/signup to the linking service
- [ ] Preserve local mode after logout
- [ ] Update Security & privacy local/linking/linked/error states
- [ ] Remove `local@clara.app` from user-facing account UI
- [ ] Hide Log out in temporary local mode
- [ ] Add complete linking tests
- [ ] Include vault tests in `npm test`
- [ ] Run targeted lint
- [ ] Run `npm test`
- [ ] Run `npm run build`
- [ ] Perform manual zero-data-loss smoke tests

## Zero-data-loss requirements

- Never re-key existing records automatically
- Never change existing record IDs
- Never clear the local vault during login or logout
- Never upload readable private finance data in this change
- Preserve `local-dev-user` when legacy records exist
- Do not enable account linking by default

## Feature flags

- `VITE_CLARA_AUTH_ENABLED=false`
- `VITE_CLARA_ACCOUNT_LINKING_ENABLED=false`
- `VITE_CLARA_LOCAL_MODE_ENABLED=true`

## Review rule

Keep this PR in draft until all integration, automated tests, build checks, and manual data-preservation tests are complete.