### PR TITLE
Add local CLARA data export download

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ import { applyVisualPerformanceMode } from "@/components/fresh/main-dashboard/pe
 
 const Settings = lazy(() => import("./pages/Settings"));
 const Profile = lazy(() => import("./pages/Profile"));
+const DataExport = lazy(() => import("./pages/DataExport"));
 const Login = lazy(() => import("./pages/Login"));
 const LinkLocalVault = lazy(() => import("./pages/LinkLocalVault"));
 const AppPreview = lazy(() => import("./pages/AppPreview"));
@@ -264,6 +265,7 @@ function AppRoutes() {
                     <Route path="/settings" element={<Settings />} />
                     <Route path="/settings/:section" element={<Settings />} />
                     <Route path="/profile" element={<Profile />} />
+                    <Route path="/data-export" element={<DataExport />} />
                     <Route path="/admin" element={admin(<AdminPanel />)} />
                     <Route path="/admin/coaching" element={admin(<CoachingAdminPage />)} />
                     <Route path="/admin/students/:studentId" element={admin(<StudentProfile />)} />

--- a/src/lib/local-data-export.js
+++ b/src/lib/local-data-export.js
@@ -1,0 +1,269 @@
+const EXPORT_VERSION = 1;
+const CLARA_KEY_PATTERNS = [
+  /^clara/i,
+  /^life_profile/i,
+  /^ai_financial_memory/i,
+  /^money/i,
+  /^wallet/i,
+  /^budget/i,
+  /^expense/i,
+  /^transaction/i,
+  /^savings/i,
+  /^emergency/i,
+  /^daily_tip/i,
+  /^guide/i,
+  /^onboarding/i,
+  /^local_vault/i,
+  /^beta/i,
+];
+
+function isBrowser() {
+  return typeof window !== "undefined" && typeof document !== "undefined";
+}
+
+function shouldIncludeStorageKey(key) {
+  const normalized = String(key || "").trim();
+  if (!normalized) return false;
+  return CLARA_KEY_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function readStorage(storage) {
+  const items = {};
+  const skipped = [];
+
+  if (!storage) {
+    return { items, skipped };
+  }
+
+  for (let index = 0; index < storage.length; index += 1) {
+    const key = storage.key(index);
+    if (!shouldIncludeStorageKey(key)) continue;
+
+    try {
+      items[key] = storage.getItem(key);
+    } catch (error) {
+      skipped.push({ key, reason: error?.message || "Unable to read storage value." });
+    }
+  }
+
+  return { items, skipped };
+}
+
+function readParsedStorage(storage) {
+  const { items, skipped } = readStorage(storage);
+  const parsed = {};
+
+  Object.entries(items).forEach(([key, value]) => {
+    try {
+      parsed[key] = JSON.parse(value);
+    } catch {
+      parsed[key] = value;
+    }
+  });
+
+  return { items, parsed, skipped };
+}
+
+async function readIndexedDbDatabase(databaseInfo) {
+  return new Promise((resolve) => {
+    const databaseName = databaseInfo?.name;
+    if (!databaseName || !window.indexedDB) {
+      resolve(null);
+      return;
+    }
+
+    const request = window.indexedDB.open(databaseName);
+
+    request.onerror = () => {
+      resolve({
+        name: databaseName,
+        version: databaseInfo?.version || null,
+        stores: {},
+        error: request.error?.message || "Unable to open IndexedDB database.",
+      });
+    };
+
+    request.onsuccess = () => {
+      const database = request.result;
+      const storeNames = Array.from(database.objectStoreNames || []);
+      const result = {
+        name: database.name,
+        version: database.version,
+        stores: {},
+      };
+
+      if (storeNames.length === 0) {
+        database.close();
+        resolve(result);
+        return;
+      }
+
+      let remaining = storeNames.length;
+      const finish = () => {
+        remaining -= 1;
+        if (remaining === 0) {
+          database.close();
+          resolve(result);
+        }
+      };
+
+      try {
+        const transaction = database.transaction(storeNames, "readonly");
+
+        storeNames.forEach((storeName) => {
+          try {
+            const store = transaction.objectStore(storeName);
+            const getAllRequest = store.getAll();
+
+            getAllRequest.onsuccess = () => {
+              result.stores[storeName] = getAllRequest.result || [];
+              finish();
+            };
+
+            getAllRequest.onerror = () => {
+              result.stores[storeName] = {
+                error: getAllRequest.error?.message || "Unable to read object store.",
+              };
+              finish();
+            };
+          } catch (error) {
+            result.stores[storeName] = { error: error?.message || "Unable to read object store." };
+            finish();
+          }
+        });
+      } catch (error) {
+        database.close();
+        resolve({
+          ...result,
+          error: error?.message || "Unable to read IndexedDB database.",
+        });
+      }
+    };
+  });
+}
+
+async function readIndexedDbExport() {
+  if (!isBrowser() || !window.indexedDB || typeof window.indexedDB.databases !== "function") {
+    return {
+      supported: false,
+      databases: [],
+      note: "IndexedDB export is not supported by this browser/webview.",
+    };
+  }
+
+  try {
+    const databases = await window.indexedDB.databases();
+    const claraDatabases = (databases || []).filter((database) =>
+      shouldIncludeStorageKey(database?.name || "")
+    );
+
+    const exportedDatabases = await Promise.all(claraDatabases.map(readIndexedDbDatabase));
+
+    return {
+      supported: true,
+      databases: exportedDatabases.filter(Boolean),
+    };
+  } catch (error) {
+    return {
+      supported: true,
+      databases: [],
+      error: error?.message || "Unable to enumerate IndexedDB databases.",
+    };
+  }
+}
+
+function buildFileName() {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  return `clara-local-backup-${timestamp}.json`;
+}
+
+export async function buildClaraLocalDataExport({ user = null, profile = null } = {}) {
+  if (!isBrowser()) {
+    throw new Error("CLARA data export can only run inside the app.");
+  }
+
+  const localStorageExport = readParsedStorage(window.localStorage);
+  const sessionStorageExport = readParsedStorage(window.sessionStorage);
+  const indexedDbExport = await readIndexedDbExport();
+
+  return {
+    app: "CLARA",
+    type: "local-device-transfer-backup",
+    version: EXPORT_VERSION,
+    created_at: new Date().toISOString(),
+    source: {
+      origin: window.location.origin,
+      pathname: window.location.pathname,
+      user_agent: window.navigator?.userAgent || "",
+    },
+    account_hint: user
+      ? {
+          id: user.id || null,
+          email: user.email || null,
+        }
+      : null,
+    profile_hint: profile
+      ? {
+          id: profile.id || null,
+          role: profile.role || null,
+          plan: profile.plan || null,
+          display_name: profile.display_name || profile.full_name || null,
+        }
+      : null,
+    data: {
+      localStorage: localStorageExport.parsed,
+      sessionStorage: sessionStorageExport.parsed,
+      indexedDB: indexedDbExport,
+    },
+    raw: {
+      localStorage: localStorageExport.items,
+      sessionStorage: sessionStorageExport.items,
+    },
+    skipped: {
+      localStorage: localStorageExport.skipped,
+      sessionStorage: sessionStorageExport.skipped,
+    },
+    restore_status: "export-only-v1",
+    restore_note:
+      "This backup is designed for device transfer. Import/restore will be added separately after the export flow is confirmed stable.",
+  };
+}
+
+export async function downloadClaraLocalDataExport(context = {}) {
+  const backup = await buildClaraLocalDataExport(context);
+  const fileName = buildFileName();
+  const blob = new Blob([JSON.stringify(backup, null, 2)], {
+    type: "application/json;charset=utf-8",
+  });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+
+  anchor.href = url;
+  anchor.download = fileName;
+  anchor.rel = "noopener";
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+
+  return {
+    fileName,
+    backup,
+  };
+}
+
+export function countExportedItems(backup) {
+  const localCount = Object.keys(backup?.data?.localStorage || {}).length;
+  const sessionCount = Object.keys(backup?.data?.sessionStorage || {}).length;
+  const indexedDbCount = (backup?.data?.indexedDB?.databases || []).reduce(
+    (total, database) => total + Object.keys(database?.stores || {}).length,
+    0
+  );
+
+  return {
+    localStorage: localCount,
+    sessionStorage: sessionCount,
+    indexedDBStores: indexedDbCount,
+    total: localCount + sessionCount + indexedDbCount,
+  };
+}

--- a/src/pages/DataExport.jsx
+++ b/src/pages/DataExport.jsx
@@ -1,0 +1,192 @@
+import { useState } from "react";
+import { ArrowLeft, CheckCircle2, Database, Download, FileJson, Info, ShieldCheck } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "@/context/AuthContext";
+import { countExportedItems, downloadClaraLocalDataExport } from "@/lib/local-data-export";
+
+export default function DataExport() {
+  const navigate = useNavigate();
+  const { user, profile } = useAuth();
+  const [exporting, setExporting] = useState(false);
+  const [error, setError] = useState("");
+  const [result, setResult] = useState(null);
+
+  const handleDownload = async () => {
+    try {
+      setExporting(true);
+      setError("");
+      const downloadResult = await downloadClaraLocalDataExport({ user, profile });
+      setResult({
+        fileName: downloadResult.fileName,
+        counts: countExportedItems(downloadResult.backup),
+      });
+    } catch (err) {
+      console.error("CLARA data export failed:", err);
+      setError(err?.message || "Unable to download CLARA data right now.");
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#020817] text-white">
+      <div className="mx-auto max-w-md px-4 pb-24 pt-4">
+        <div className="mb-4 flex items-center justify-between">
+          <button type="button" onClick={() => navigate(-1)} className="btn-icon" aria-label="Go back">
+            <ArrowLeft size={18} />
+          </button>
+
+          <div className="text-center">
+            <p className="text-xs tracking-[0.3em] text-emerald-300/70">CLARA TRANSFER</p>
+            <h1 className="text-lg font-bold">Download Data</h1>
+          </div>
+
+          <div className="h-11 w-11" />
+        </div>
+
+        <section className="export-hero">
+          <div className="export-glow export-glow-one" />
+          <div className="export-glow export-glow-two" />
+
+          <div className="relative z-10">
+            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-emerald-300/20 bg-emerald-300/10 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.18em] text-emerald-100">
+              <Database size={12} />
+              Device transfer backup
+            </div>
+
+            <h2 className="text-3xl font-black leading-tight text-white">Make this device’s CLARA data downloadable.</h2>
+            <p className="mt-3 text-sm leading-6 text-slate-300">
+              This creates one JSON backup file from CLARA-related local data on this device. Keep it safe so it can be transferred to another device once the import/restore flow is added.
+            </p>
+
+            <button
+              type="button"
+              onClick={handleDownload}
+              disabled={exporting}
+              className="mt-6 flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-emerald-400 to-cyan-400 px-5 py-4 text-sm font-black text-slate-950 shadow-[0_16px_45px_rgba(16,185,129,0.24)] transition hover:brightness-110 active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <Download size={18} />
+              {exporting ? "Preparing backup..." : "Download CLARA Backup"}
+            </button>
+          </div>
+        </section>
+
+        {error ? (
+          <div className="mt-4 rounded-2xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm leading-6 text-red-200">
+            {error}
+          </div>
+        ) : null}
+
+        {result ? (
+          <div className="mt-4 rounded-2xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-3 text-sm leading-6 text-emerald-100">
+            <div className="mb-2 flex items-center gap-2 font-bold">
+              <CheckCircle2 size={16} />
+              Backup downloaded
+            </div>
+            <p className="break-all text-emerald-50/90">{result.fileName}</p>
+            <p className="mt-2 text-emerald-50/80">
+              Exported {result.counts.total} storage group{result.counts.total === 1 ? "" : "s"} from this device.
+            </p>
+          </div>
+        ) : null}
+
+        <div className="mt-5 space-y-3">
+          <div className="info-card">
+            <FileJson size={18} />
+            <div>
+              <p className="font-semibold text-white">What downloads?</p>
+              <p className="mt-1 text-sm leading-6 text-slate-400">
+                CLARA-related localStorage, sessionStorage, and supported IndexedDB data are packed into one JSON file.
+              </p>
+            </div>
+          </div>
+
+          <div className="info-card">
+            <ShieldCheck size={18} />
+            <div>
+              <p className="font-semibold text-white">Keep it private</p>
+              <p className="mt-1 text-sm leading-6 text-slate-400">
+                The file may contain personal money setup, habits, notes, and local app memory. Do not post or share it publicly.
+              </p>
+            </div>
+          </div>
+
+          <div className="info-card">
+            <Info size={18} />
+            <div>
+              <p className="font-semibold text-white">Export first, import later</p>
+              <p className="mt-1 text-sm leading-6 text-slate-400">
+                This first version only downloads the backup. The upload/import restore system should be built after this file format is confirmed.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <style>{`
+        .btn-icon {
+          height: 44px;
+          width: 44px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          border-radius: 16px;
+          background: rgba(255, 255, 255, 0.05);
+          border: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        .export-hero {
+          position: relative;
+          overflow: hidden;
+          border-radius: 32px;
+          border: 1px solid rgba(110, 231, 183, 0.16);
+          background:
+            radial-gradient(circle at top left, rgba(16, 185, 129, 0.2), transparent 32%),
+            radial-gradient(circle at bottom right, rgba(6, 182, 212, 0.18), transparent 32%),
+            linear-gradient(145deg, rgba(4, 17, 31, 0.96), rgba(2, 8, 23, 0.98));
+          padding: 24px;
+          box-shadow: 0 24px 70px rgba(0, 0, 0, 0.35);
+        }
+
+        .export-glow {
+          position: absolute;
+          border-radius: 999px;
+          filter: blur(30px);
+          opacity: 0.35;
+        }
+
+        .export-glow-one {
+          top: -32px;
+          right: -32px;
+          height: 120px;
+          width: 120px;
+          background: rgba(16, 185, 129, 0.45);
+        }
+
+        .export-glow-two {
+          bottom: -40px;
+          left: -40px;
+          height: 140px;
+          width: 140px;
+          background: rgba(6, 182, 212, 0.35);
+        }
+
+        .info-card {
+          display: flex;
+          align-items: flex-start;
+          gap: 12px;
+          border-radius: 22px;
+          border: 1px solid rgba(255, 255, 255, 0.1);
+          background: rgba(255, 255, 255, 0.05);
+          padding: 16px;
+        }
+
+        .info-card > svg {
+          margin-top: 2px;
+          flex-shrink: 0;
+          color: rgb(110, 231, 183);
+        }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a local CLARA data export helper that collects CLARA-related localStorage/sessionStorage keys and supported IndexedDB stores.
- Adds a `/data-export` page where users can download one JSON backup file for device transfer.
- Wires the new page into the app router.

## Notes
- This is export/download only.
- Import/restore is intentionally left for the next step after the backup format is confirmed stable.
- The generated file may include personal money setup, notes, and local app memory, so the page warns users to keep it private.

## Test plan
- Open `/data-export` while signed in.
- Tap **Download CLARA Backup**.
- Confirm a `clara-local-backup-*.json` file downloads.
- Open the JSON and confirm it contains CLARA-related local data sections: localStorage, sessionStorage, and IndexedDB when supported.