### PR TITLE
Fix Daily Money Tip mobile flip toggle

### DIFF
--- a/src/components/fresh/main-dashboard/daily-tip/ui/daily-tip-premium-flip.css
+++ b/src/components/fresh/main-dashboard/daily-tip/ui/daily-tip-premium-flip.css
@@ -7,6 +7,12 @@
   transform: translateZ(0);
   contain: layout paint;
   isolation: isolate;
+  pointer-events: none;
+}
+
+[data-clara-daily-tip-card="true"] > [role="button"] {
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .clara-daily-tip-scene::before {
@@ -34,6 +40,7 @@
   -webkit-transform-style: preserve-3d;
   transition: transform 620ms cubic-bezier(0.22, 1, 0.36, 1);
   will-change: transform;
+  pointer-events: none;
 }
 
 .clara-daily-tip-flipper--flipped {
@@ -50,24 +57,15 @@
   transform-style: preserve-3d;
   -webkit-transform-style: preserve-3d;
   will-change: transform;
+  pointer-events: none;
 }
 
 .clara-daily-tip-face--front {
   transform: translate3d(0, 0, 1px) rotateY(0deg);
-  pointer-events: auto;
 }
 
 .clara-daily-tip-face--back {
   transform: translate3d(0, 0, 1px) rotateY(180deg);
-  pointer-events: none;
-}
-
-.clara-daily-tip-flipper--flipped .clara-daily-tip-face--front {
-  pointer-events: none;
-}
-
-.clara-daily-tip-flipper--flipped .clara-daily-tip-face--back {
-  pointer-events: auto;
 }
 
 .clara-checkin-grid {


### PR DESCRIPTION
## Summary
- keep the Daily Money Tip interaction target stationary on mobile
- make the 3D scene, flipper, and front/back faces visual-only with `pointer-events: none`
- remove pointer-event ownership switching between transformed faces
- add `touch-action: manipulation` and preserve the transparent mobile tap highlight

## Behavior preserved
- existing `rotateY(0deg)` / `rotateY(180deg)` premium animation
- React flip state and animation lock
- one-time daily check-in behavior
- guide mode, commitment gating, celebration, sound, and desktop keyboard interaction

## Verification
- reviewed the event path so taps now land on the non-rotating outer `role="button"` wrapper
- confirmed the flip-sound listener does not prevent or stop events
- CSS-only surgical change; no check-in or persistence logic changed

Manual mobile-device repetition testing is still recommended after deployment.