### PR TITLE
Add bubble pulse and Learning Hub sound to onboarding trigger

### DIFF
--- a/src/guided-onboarding-bubble.css
+++ b/src/guided-onboarding-bubble.css
@@ -1,0 +1,67 @@
+button[data-clara-guided-onboarding-button="true"] {
+  isolation: isolate;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+button[data-clara-guided-onboarding-button="true"]::before,
+button[data-clara-guided-onboarding-button="true"]::after {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  inset: -5px;
+  z-index: 0;
+  border-radius: 999px;
+  border: 1px solid rgba(103, 232, 249, 0.34);
+  opacity: 0;
+  transform: scale(0.72);
+  animation: clara-guided-onboarding-bubble 2.2s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+}
+
+button[data-clara-guided-onboarding-button="true"]::after {
+  inset: -9px;
+  border-color: rgba(129, 140, 248, 0.26);
+  animation-delay: 1.1s;
+}
+
+button[data-clara-guided-onboarding-button="true"]:active::before,
+button[data-clara-guided-onboarding-button="true"][aria-expanded="true"]::before {
+  border-color: rgba(167, 243, 208, 0.56);
+  box-shadow: 0 0 22px rgba(45, 212, 191, 0.24);
+}
+
+@keyframes clara-guided-onboarding-bubble {
+  0% {
+    opacity: 0;
+    transform: scale(0.72);
+  }
+
+  18% {
+    opacity: 0.7;
+  }
+
+  72%,
+  100% {
+    opacity: 0;
+    transform: scale(1.42);
+  }
+}
+
+.clara-performance-mode button[data-clara-guided-onboarding-button="true"]::before,
+.clara-performance-mode button[data-clara-guided-onboarding-button="true"]::after {
+  animation-name: clara-guided-onboarding-bubble !important;
+  animation-duration: 2.2s !important;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1) !important;
+  animation-iteration-count: infinite !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  button[data-clara-guided-onboarding-button="true"]::before,
+  button[data-clara-guided-onboarding-button="true"]::after,
+  .clara-performance-mode button[data-clara-guided-onboarding-button="true"]::before,
+  .clara-performance-mode button[data-clara-guided-onboarding-button="true"]::after {
+    animation: none !important;
+    opacity: 0.28;
+    transform: scale(1);
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -33,6 +33,7 @@ import "./guide-mode-schedule.css";
 import "./guide-mode-intro-cleanup.css";
 import "./welcome-session-calendar-status.css";
 import "./budget-manager-layout-fix.css";
+import "./guided-onboarding-bubble.css";
 
 window.CLARA_BILLING = window.CLARA_BILLING || {};
 

--- a/src/runtime/installLearningHubOpenSound.js
+++ b/src/runtime/installLearningHubOpenSound.js
@@ -8,6 +8,7 @@ const LEARNING_HUB_TOGGLE_SELECTOR = [
   'button[aria-label="Collapse Learning Hub."]',
   "button[data-clara-pressure-signal]",
   'button[aria-label="Open CLARA Guide Mode"]',
+  'button[data-clara-guided-onboarding-button="true"]',
   "button.clara-guide-next-button",
   "button.clara-guide-carousel-next-button",
   "button.clara-guide-orb-next",


### PR DESCRIPTION
## Summary
- add a soft two-ring bubble pulse around the 30-minute guided onboarding button beside Learning Hub
- preserve the existing compact circular button, badge, layout, and dialog behavior
- reuse the existing Learning Hub toggle sound and light haptic for pointer and keyboard activation
- prevent the generic click sound from stacking on top of the reused Learning Hub sound
- preserve the pulse in CLARA performance mode while respecting reduced-motion preferences

## Scope
Only the guided onboarding trigger visual effect, shared sound selector, and stylesheet import are changed. Learning Hub behavior, Daily Check-In, dashboard layout, booking dialog, and other buttons are unchanged.

## Verification
- the existing `data-clara-guided-onboarding-button="true"` attribute drives both the bubble CSS and shared sound trigger
- no event propagation or default browser behavior is blocked
- Enter and Space use the same Learning Hub sound path through the existing runtime listener