### PR TITLE
Simplify CLARA walkthrough typography

### DIFF
--- a/src/components/fresh/main-dashboard/learning-hub/ui/GuidedOnboardingIntroDialog.jsx
+++ b/src/components/fresh/main-dashboard/learning-hub/ui/GuidedOnboardingIntroDialog.jsx
@@ -56,16 +56,11 @@ export default function GuidedOnboardingIntroDialog({
         <div className="pointer-events-none absolute inset-x-12 top-0 h-px bg-white/28" />
         <div className="pointer-events-none absolute -top-24 left-1/2 h-56 w-56 -translate-x-1/2 rounded-full bg-cyan-400/[0.08] blur-3xl" />
 
-        <header className="relative z-10 shrink-0 border-b border-white/10 bg-[rgba(2,8,23,0.86)] px-5 pb-5 pt-5 sm:px-6">
-          <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0 pt-1">
-              <p className="text-[9px] font-black uppercase tracking-[0.24em] text-white/56">
-                CLARA Personal Support
-              </p>
-              <p className="mt-1 text-[10px] font-black uppercase tracking-[0.18em] text-cyan-100/72">
-                30-Minute Walkthrough
-              </p>
-            </div>
+        <header className="relative z-10 shrink-0 border-b border-white/10 bg-[rgba(2,8,23,0.86)] px-5 py-5 sm:px-6">
+          <div className="flex items-center justify-between gap-4">
+            <p className="text-[18px] font-extrabold tracking-[-0.02em] text-white">
+              CLARA Walkthrough
+            </p>
 
             <button
               type="button"
@@ -79,52 +74,51 @@ export default function GuidedOnboardingIntroDialog({
         </header>
 
         <main className="relative z-10 min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-5 sm:py-5">
-          <article className="relative flex min-h-full flex-col justify-center overflow-hidden rounded-[32px] border border-cyan-100/16 bg-[linear-gradient(150deg,rgba(7,54,71,0.96),rgba(8,20,54,0.97)_48%,rgba(34,14,79,0.97))] px-5 py-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_18px_46px_rgba(0,0,0,0.28)] sm:px-6 sm:py-7">
+          <article className="relative min-h-full overflow-hidden rounded-[32px] border border-cyan-100/16 bg-[linear-gradient(150deg,rgba(7,54,71,0.96),rgba(8,20,54,0.97)_48%,rgba(34,14,79,0.97))] px-5 py-7 shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_18px_46px_rgba(0,0,0,0.28)] sm:px-6 sm:py-8">
             <div className="pointer-events-none absolute inset-0">
               <div className="absolute -left-20 -top-24 h-56 w-56 rounded-full bg-cyan-300/[0.09] blur-3xl" />
               <div className="absolute -bottom-24 -right-16 h-60 w-60 rounded-full bg-violet-500/[0.14] blur-3xl" />
             </div>
 
             <div className="relative z-10">
-              <span className="inline-flex items-center rounded-full border border-cyan-100/20 bg-cyan-300/10 px-3 py-1.5 text-[8px] font-black uppercase tracking-[0.16em] text-cyan-100">
-                30-Minute Personal Support
+              <span className="inline-flex items-center rounded-full border border-cyan-100/20 bg-cyan-300/10 px-3 py-1.5 text-[10px] font-extrabold uppercase tracking-[0.1em] text-cyan-100">
+                30-minute personal support
               </span>
 
               <h1
                 id="clara-guided-onboarding-title"
-                className="mt-5 max-w-[18rem] text-[clamp(1.65rem,7vw,2.1rem)] font-black leading-[0.98] tracking-[-0.045em] text-white"
+                className="mt-5 max-w-[19rem] text-[clamp(2rem,8.5vw,2.45rem)] font-black leading-[0.98] tracking-[-0.05em] text-white"
               >
                 Book a CLARA Walkthrough
               </h1>
 
               <p
                 id="clara-guided-onboarding-description"
-                className="mt-5 text-[12px] font-semibold leading-[1.75] text-slate-100/82"
+                className="mt-5 text-[15px] font-medium leading-[1.65] text-slate-100/86"
               >
-                Get one-on-one guidance from a real person who can help you understand
-                CLARA, answer your questions, and focus on the features most relevant
-                to you.
+                Get personal guidance to understand CLARA, ask questions, and focus on
+                the features most relevant to you.
               </p>
 
-              <div className="mt-6 rounded-[24px] border border-cyan-100/22 bg-slate-950/24 px-4 py-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
+              <div className="mt-7 rounded-[22px] bg-white/[0.055] px-4 py-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
                 <div className="flex items-start gap-3.5">
-                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[14px] border border-cyan-100/18 bg-cyan-300/[0.09] text-cyan-100/90">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[14px] bg-cyan-300/[0.1] text-cyan-100/90">
                     <CheckCircle2 className="h-[18px] w-[18px]" />
                   </div>
 
                   <div className="min-w-0">
-                    <h2 className="text-[clamp(1.15rem,5.5vw,1.45rem)] font-black leading-none tracking-[-0.035em] text-white">
+                    <h2 className="text-[22px] font-black leading-[1.05] tracking-[-0.035em] text-white">
                       What happens next
                     </h2>
-                    <p className="mt-3 text-[11px] font-bold leading-[1.7] text-white/84">
-                      You will continue to a short form where you can share what you
-                      need help with and choose your preferred schedule.
+                    <p className="mt-3 text-[14px] font-medium leading-[1.65] text-white/82">
+                      Complete a short form, tell us what you need help with, and choose
+                      your preferred schedule.
                     </p>
                   </div>
                 </div>
               </div>
 
-              <p className="mt-5 text-[10px] font-semibold leading-relaxed text-slate-300/60">
+              <p className="mt-6 text-[13px] font-medium leading-[1.6] text-slate-300/68">
                 You do not need to finish setting up CLARA before booking.
               </p>
             </div>
@@ -132,25 +126,15 @@ export default function GuidedOnboardingIntroDialog({
         </main>
 
         <footer className="relative z-10 shrink-0 border-t border-white/10 bg-[rgba(2,8,23,0.9)] px-5 pb-[max(20px,env(safe-area-inset-bottom))] pt-4 sm:px-6">
-          <div className="grid gap-2.5">
-            <button
-              ref={continueButtonRef}
-              type="button"
-              onClick={onContinue}
-              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-[17px] border border-cyan-100/20 bg-[linear-gradient(100deg,rgba(14,165,233,0.96),rgba(99,102,241,0.98))] px-4 text-[9px] font-black uppercase tracking-[0.12em] text-white shadow-[0_14px_30px_rgba(37,99,235,0.26)] transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-200 active:scale-[0.99]"
-            >
-              Continue to Booking Form
-              <ExternalLink className="h-3.5 w-3.5" />
-            </button>
-
-            <button
-              type="button"
-              onClick={onClose}
-              className="inline-flex min-h-12 items-center justify-center rounded-[17px] border border-white/[0.09] bg-white/[0.045] px-4 text-[9px] font-black uppercase tracking-[0.12em] text-white/70 transition hover:bg-white/[0.08] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
-            >
-              Not now
-            </button>
-          </div>
+          <button
+            ref={continueButtonRef}
+            type="button"
+            onClick={onContinue}
+            className="inline-flex min-h-12 w-full items-center justify-center gap-2 rounded-[17px] border border-cyan-100/20 bg-[linear-gradient(100deg,rgba(14,165,233,0.96),rgba(99,102,241,0.98))] px-4 text-[12px] font-extrabold tracking-[0.02em] text-white shadow-[0_14px_30px_rgba(37,99,235,0.26)] transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-200 active:scale-[0.99]"
+          >
+            Continue to Booking Form
+            <ExternalLink className="h-4 w-4" />
+          </button>
         </footer>
       </section>
     </div>,


### PR DESCRIPTION
## Summary
- simplify the walkthrough page to one clear header, one badge, one headline, one explanation, one next-step block, and one CTA
- remove the repeated header labels and the redundant Not now button
- increase body, supporting, and CTA text sizes for better mobile readability
- reduce excessive uppercase tracking and replace the nested bordered card with a softer next-step surface
- preserve the full-screen page, booking flow, Escape handling, X close behavior, focus management, and shared close sound

## Typography hierarchy
- header: 18px
- primary headline: responsive 32–39px
- main body: 15px
- next-step heading: 22px
- next-step body: 14px
- support note: 13px
- CTA: 12px

## Scope
Only `GuidedOnboardingIntroDialog.jsx` is changed. No booking URL, Learning Hub, dashboard, sound, or commitment behavior is modified.