### PR TITLE
Collapse CLARA walkthrough into one focused card

### DIFF
--- a/src/components/fresh/main-dashboard/learning-hub/ui/GuidedOnboardingIntroDialog.jsx
+++ b/src/components/fresh/main-dashboard/learning-hub/ui/GuidedOnboardingIntroDialog.jsx
@@ -51,91 +51,80 @@ export default function GuidedOnboardingIntroDialog({
         aria-modal="true"
         aria-labelledby="clara-guided-onboarding-title"
         aria-describedby="clara-guided-onboarding-description"
-        className="relative flex h-[calc(100dvh-32px)] max-h-[820px] w-full max-w-[430px] flex-col overflow-hidden rounded-[42px] border border-white/16 bg-[radial-gradient(circle_at_top_left,rgba(34,211,238,0.08),transparent_34%),radial-gradient(circle_at_bottom_right,rgba(124,58,237,0.12),transparent_38%),rgba(4,10,24,0.99)] text-white shadow-[0_28px_96px_rgba(0,0,0,0.68),0_0_60px_rgba(34,211,238,0.08)]"
+        className="relative h-[calc(100dvh-32px)] max-h-[820px] w-full max-w-[430px] text-white"
       >
-        <div className="pointer-events-none absolute inset-x-12 top-0 h-px bg-white/28" />
-        <div className="pointer-events-none absolute -top-24 left-1/2 h-56 w-56 -translate-x-1/2 rounded-full bg-cyan-400/[0.08] blur-3xl" />
-
-        <header className="relative z-10 shrink-0 border-b border-white/10 bg-[rgba(2,8,23,0.86)] px-5 py-5 sm:px-6">
-          <div className="flex items-center justify-between gap-4">
-            <p className="text-[18px] font-extrabold tracking-[-0.02em] text-white">
-              CLARA Walkthrough
-            </p>
-
-            <button
-              type="button"
-              onClick={onClose}
-              className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/18 bg-white/[0.06] text-white/72 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] transition hover:bg-white/[0.11] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-200"
-              aria-label="Close CLARA walkthrough page"
-            >
-              <X className="h-4 w-4" />
-            </button>
+        <article className="relative h-full overflow-y-auto rounded-[32px] border border-cyan-100/20 bg-[linear-gradient(150deg,rgba(7,54,71,0.98),rgba(8,20,54,0.99)_48%,rgba(34,14,79,0.99))] shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_24px_72px_rgba(0,0,0,0.46)]">
+          <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-[32px]">
+            <div className="absolute -left-20 -top-24 h-56 w-56 rounded-full bg-cyan-300/[0.09] blur-3xl" />
+            <div className="absolute -bottom-24 -right-16 h-60 w-60 rounded-full bg-violet-500/[0.14] blur-3xl" />
           </div>
-        </header>
 
-        <main className="relative z-10 min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-5 sm:py-5">
-          <article className="relative min-h-full overflow-hidden rounded-[32px] border border-cyan-100/16 bg-[linear-gradient(150deg,rgba(7,54,71,0.96),rgba(8,20,54,0.97)_48%,rgba(34,14,79,0.97))] px-5 py-7 shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_18px_46px_rgba(0,0,0,0.28)] sm:px-6 sm:py-8">
-            <div className="pointer-events-none absolute inset-0">
-              <div className="absolute -left-20 -top-24 h-56 w-56 rounded-full bg-cyan-300/[0.09] blur-3xl" />
-              <div className="absolute -bottom-24 -right-16 h-60 w-60 rounded-full bg-violet-500/[0.14] blur-3xl" />
-            </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute right-5 top-5 z-20 inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/20 bg-slate-950/24 text-white/76 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-md transition hover:bg-white/[0.1] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-200"
+            aria-label="Close CLARA walkthrough page"
+          >
+            <X className="h-4 w-4" />
+          </button>
 
-            <div className="relative z-10">
+          <div className="relative z-10 flex min-h-full flex-col px-5 pb-5 pt-7 sm:px-6 sm:pb-6 sm:pt-8">
+            <div className="pr-12">
               <span className="inline-flex items-center rounded-full border border-cyan-100/20 bg-cyan-300/10 px-3 py-1.5 text-[10px] font-extrabold uppercase tracking-[0.1em] text-cyan-100">
                 30-minute personal support
               </span>
+            </div>
 
-              <h1
-                id="clara-guided-onboarding-title"
-                className="mt-5 max-w-[19rem] text-[clamp(2rem,8.5vw,2.45rem)] font-black leading-[0.98] tracking-[-0.05em] text-white"
-              >
-                Book a CLARA Walkthrough
-              </h1>
+            <h1
+              id="clara-guided-onboarding-title"
+              className="mt-6 max-w-[19rem] text-[clamp(2rem,8.5vw,2.45rem)] font-black leading-[0.98] tracking-[-0.05em] text-white"
+            >
+              Book a CLARA Walkthrough
+            </h1>
 
-              <p
-                id="clara-guided-onboarding-description"
-                className="mt-5 text-[15px] font-medium leading-[1.65] text-slate-100/86"
-              >
-                Get personal guidance to understand CLARA, ask questions, and focus on
-                the features most relevant to you.
-              </p>
+            <p
+              id="clara-guided-onboarding-description"
+              className="mt-5 text-[15px] font-medium leading-[1.65] text-slate-100/86"
+            >
+              Get personal guidance to understand CLARA, ask questions, and focus on
+              the features most relevant to you.
+            </p>
 
-              <div className="mt-7 rounded-[22px] bg-white/[0.055] px-4 py-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
-                <div className="flex items-start gap-3.5">
-                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[14px] bg-cyan-300/[0.1] text-cyan-100/90">
-                    <CheckCircle2 className="h-[18px] w-[18px]" />
-                  </div>
+            <div className="mt-7 rounded-[22px] bg-white/[0.055] px-4 py-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
+              <div className="flex items-start gap-3.5">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[14px] bg-cyan-300/[0.1] text-cyan-100/90">
+                  <CheckCircle2 className="h-[18px] w-[18px]" />
+                </div>
 
-                  <div className="min-w-0">
-                    <h2 className="text-[22px] font-black leading-[1.05] tracking-[-0.035em] text-white">
-                      What happens next
-                    </h2>
-                    <p className="mt-3 text-[14px] font-medium leading-[1.65] text-white/82">
-                      Complete a short form, tell us what you need help with, and choose
-                      your preferred schedule.
-                    </p>
-                  </div>
+                <div className="min-w-0">
+                  <h2 className="text-[22px] font-black leading-[1.05] tracking-[-0.035em] text-white">
+                    What happens next
+                  </h2>
+                  <p className="mt-3 text-[14px] font-medium leading-[1.65] text-white/82">
+                    Complete a short form, tell us what you need help with, and choose
+                    your preferred schedule.
+                  </p>
                 </div>
               </div>
-
-              <p className="mt-6 text-[13px] font-medium leading-[1.6] text-slate-300/68">
-                You do not need to finish setting up CLARA before booking.
-              </p>
             </div>
-          </article>
-        </main>
 
-        <footer className="relative z-10 shrink-0 border-t border-white/10 bg-[rgba(2,8,23,0.9)] px-5 pb-[max(20px,env(safe-area-inset-bottom))] pt-4 sm:px-6">
-          <button
-            ref={continueButtonRef}
-            type="button"
-            onClick={onContinue}
-            className="inline-flex min-h-12 w-full items-center justify-center gap-2 rounded-[17px] border border-cyan-100/20 bg-[linear-gradient(100deg,rgba(14,165,233,0.96),rgba(99,102,241,0.98))] px-4 text-[12px] font-extrabold tracking-[0.02em] text-white shadow-[0_14px_30px_rgba(37,99,235,0.26)] transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-200 active:scale-[0.99]"
-          >
-            Continue to Booking Form
-            <ExternalLink className="h-4 w-4" />
-          </button>
-        </footer>
+            <p className="mt-6 text-[13px] font-medium leading-[1.6] text-slate-300/68">
+              You do not need to finish setting up CLARA before booking.
+            </p>
+
+            <div className="mt-auto pt-8">
+              <button
+                ref={continueButtonRef}
+                type="button"
+                onClick={onContinue}
+                className="inline-flex min-h-12 w-full items-center justify-center gap-2 rounded-[17px] border border-cyan-100/20 bg-[linear-gradient(100deg,rgba(14,165,233,0.96),rgba(99,102,241,0.98))] px-4 text-[12px] font-extrabold tracking-[0.02em] text-white shadow-[0_14px_30px_rgba(37,99,235,0.26)] transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-200 active:scale-[0.99]"
+              >
+                Continue to Booking Form
+                <ExternalLink className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+        </article>
       </section>
     </div>,
     document.body,


### PR DESCRIPTION
## Summary
- remove the surrounding walkthrough shell, separate header, and separate footer container
- keep only the previously highlighted inner walkthrough card as the entire page surface
- move the X close control into the card
- move the Continue to Booking Form CTA inside the same card at the bottom
- preserve the existing copy, typography hierarchy, booking action, Escape handling, focus behavior, and shared close sound

## Result
The walkthrough now reads as one clean premium card with no nested outer frame or detached action bar.

## Scope
Only `GuidedOnboardingIntroDialog.jsx` is changed.