### PR TITLE
Balance CLARA walkthrough internal spacing

### DIFF
--- a/src/components/fresh/main-dashboard/learning-hub/ui/GuidedOnboardingIntroDialog.jsx
+++ b/src/components/fresh/main-dashboard/learning-hub/ui/GuidedOnboardingIntroDialog.jsx
@@ -69,59 +69,63 @@ export default function GuidedOnboardingIntroDialog({
           </button>
 
           <div className="relative z-10 flex min-h-full flex-col">
-            <div className="pr-12">
-              <span className="inline-flex w-fit items-center rounded-full border border-cyan-100/20 bg-cyan-300/10 px-3 py-1.5 text-[10px] font-extrabold uppercase tracking-[0.1em] text-cyan-100">
-                30-minute personal support
-              </span>
-            </div>
+            <div>
+              <div className="pr-12">
+                <span className="inline-flex w-fit items-center rounded-full border border-cyan-100/20 bg-cyan-300/10 px-3 py-1.5 text-[10px] font-extrabold uppercase tracking-[0.1em] text-cyan-100">
+                  30-minute personal support
+                </span>
+              </div>
 
-            <h1
-              id="clara-guided-onboarding-title"
-              className="mt-5 max-w-[19rem] text-[clamp(2rem,8.5vw,2.45rem)] font-black leading-[0.98] tracking-[-0.05em] text-white"
-            >
-              Book a CLARA Walkthrough
-            </h1>
+              <h1
+                id="clara-guided-onboarding-title"
+                className="mt-5 max-w-[19rem] text-[clamp(2rem,8.5vw,2.45rem)] font-black leading-[0.98] tracking-[-0.05em] text-white"
+              >
+                Book a CLARA Walkthrough
+              </h1>
 
-            <p
-              id="clara-guided-onboarding-description"
-              className="mt-5 text-[15px] font-medium leading-[1.65] text-slate-100/86"
-            >
-              Get personal guidance to understand CLARA, ask questions, and focus on
-              the features most relevant to you.
-            </p>
+              <p
+                id="clara-guided-onboarding-description"
+                className="mt-5 text-[15px] font-medium leading-[1.65] text-slate-100/86"
+              >
+                Get personal guidance to understand CLARA, ask questions, and focus on
+                the features most relevant to you.
+              </p>
 
-            <div className="mt-7 rounded-[22px] bg-white/[0.055] px-4 py-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
-              <div className="flex items-start gap-3.5">
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[14px] bg-cyan-300/[0.1] text-cyan-100/90">
-                  <CheckCircle2 className="h-[18px] w-[18px]" />
-                </div>
+              <div className="mt-6 rounded-[22px] bg-white/[0.055] px-4 py-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
+                <div className="flex items-start gap-3.5">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[14px] bg-cyan-300/[0.1] text-cyan-100/90">
+                    <CheckCircle2 className="h-[18px] w-[18px]" />
+                  </div>
 
-                <div className="min-w-0">
-                  <h2 className="text-[22px] font-black leading-[1.05] tracking-[-0.035em] text-white">
-                    What happens next
-                  </h2>
-                  <p className="mt-3 text-[14px] font-medium leading-[1.65] text-white/82">
-                    Complete a short form, tell us what you need help with, and choose
-                    your preferred schedule.
-                  </p>
+                  <div className="min-w-0">
+                    <h2 className="text-[22px] font-black leading-[1.05] tracking-[-0.035em] text-white">
+                      What happens next
+                    </h2>
+                    <p className="mt-3 text-[14px] font-medium leading-[1.65] text-white/82">
+                      Complete a short form, tell us what you need help with, and choose
+                      your preferred schedule.
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
 
-            <p className="mt-6 text-[13px] font-medium leading-[1.6] text-slate-300/68">
-              You do not need to finish setting up CLARA before booking.
-            </p>
+            <div className="mt-auto pt-7">
+              <div className="border-t border-white/[0.08] pt-5">
+                <p className="text-[13px] font-medium leading-[1.6] text-slate-300/68">
+                  You do not need to finish setting up CLARA before booking.
+                </p>
 
-            <div className="mt-auto pt-8">
-              <button
-                ref={continueButtonRef}
-                type="button"
-                onClick={onContinue}
-                className="inline-flex min-h-12 w-full items-center justify-center gap-2 rounded-[17px] border border-cyan-100/20 bg-[linear-gradient(100deg,rgba(14,165,233,0.96),rgba(99,102,241,0.98))] px-4 text-[12px] font-extrabold tracking-[0.02em] text-white shadow-[0_14px_30px_rgba(37,99,235,0.26)] transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-200 active:scale-[0.99]"
-              >
-                Continue to Booking Form
-                <ExternalLink className="h-4 w-4" />
-              </button>
+                <button
+                  ref={continueButtonRef}
+                  type="button"
+                  onClick={onContinue}
+                  className="mt-5 inline-flex min-h-12 w-full items-center justify-center gap-2 rounded-[17px] border border-cyan-100/20 bg-[linear-gradient(100deg,rgba(14,165,233,0.96),rgba(99,102,241,0.98))] px-4 text-[12px] font-extrabold tracking-[0.02em] text-white shadow-[0_14px_30px_rgba(37,99,235,0.26)] transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-200 active:scale-[0.99]"
+                >
+                  Continue to Booking Form
+                  <ExternalLink className="h-4 w-4" />
+                </button>
+              </div>
             </div>
           </div>
         </article>


### PR DESCRIPTION
## Summary
- keep the existing card size, container, text, and booking action unchanged
- regroup the reassurance text with the booking CTA so they read as one action area
- remove the awkward empty gap between the reassurance and the button
- add a subtle divider above the action area to create intentional structure without adding more copy
- slightly tighten the spacing above the “What happens next” block

## Result
The page keeps the same amount of content and the same main container, but the vertical rhythm now reads as:
1. introduction
2. next-step explanation
3. reassurance + CTA

## Scope
Only `GuidedOnboardingIntroDialog.jsx` is changed. No text, behavior, sound, booking flow, or card dimensions are changed.