### PR TITLE
Smooth one-card mobile swipes in CLARA Guide carousel

### DIFF
--- a/src/components/financial-carousel/FinancialCarousel.jsx
+++ b/src/components/financial-carousel/FinancialCarousel.jsx
@@ -69,28 +69,7 @@ export default function FinancialCarousel(props) {
   });
 
   const items = useMemo(
-    () =>
-      getCarouselData({
-        monthlyBudgetPlan,
-        savingsGoals,
-        totalSavingsSaved,
-        totalSavingsTarget,
-        primarySavingsGoal,
-        wallets,
-        walletMoney,
-        walletPreviewTransactions,
-        survivalExpense,
-        user: userId || userPlan ? { id: userId, plan: userPlan } : null,
-        plan,
-        guardChecked: isGuideMode ? false : guardChecked,
-        loading,
-        profileData,
-        featureFlags,
-        includeLocked,
-        firstPositiveNumber,
-        readStoredSurvivalExpense,
-      }),
-    [
+    () => getCarouselData({
       monthlyBudgetPlan,
       savingsGoals,
       totalSavingsSaved,
@@ -100,45 +79,31 @@ export default function FinancialCarousel(props) {
       walletMoney,
       walletPreviewTransactions,
       survivalExpense,
-      userId,
-      userPlan,
+      user: userId || userPlan ? { id: userId, plan: userPlan } : null,
       plan,
-      guardChecked,
+      guardChecked: isGuideMode ? false : guardChecked,
       loading,
       profileData,
       featureFlags,
       includeLocked,
       firstPositiveNumber,
       readStoredSurvivalExpense,
-      isGuideMode,
-    ]
+    }),
+    [monthlyBudgetPlan, savingsGoals, totalSavingsSaved, totalSavingsTarget, primarySavingsGoal, wallets, walletMoney, walletPreviewTransactions, survivalExpense, userId, userPlan, plan, guardChecked, loading, profileData, featureFlags, includeLocked, firstPositiveNumber, readStoredSurvivalExpense, isGuideMode]
   );
   const defaultIndex = useMemo(() => getDefaultCarouselIndex(items), [items]);
-  const isActiveGuideCarousel =
-    isGuideMode && typeof onGuideCarouselIndexChange === "function";
-  const effectiveGuideMaxStepPerInteraction =
-    isActiveGuideCarousel && !guideCarouselLocked
-      ? Math.max(1, Number(guideMaxStepPerInteraction) || 1)
-      : null;
-  const {
-    carouselRef,
-    activeIndex,
-    scrollToIndex,
-    handleScroll,
-    interactionHandlers,
-  } = useAutoMovingHorizontalCarousel({
+  const isActiveGuideCarousel = isGuideMode && typeof onGuideCarouselIndexChange === "function";
+  const effectiveGuideMaxStepPerInteraction = isActiveGuideCarousel && !guideCarouselLocked
+    ? Math.max(1, Number(guideMaxStepPerInteraction) || 1)
+    : null;
+  const { carouselRef, activeIndex, scrollToIndex, handleScroll, interactionHandlers } = useAutoMovingHorizontalCarousel({
     itemCount: items.length,
     defaultIndex,
-    guideAllowedSwipeDirection: isActiveGuideCarousel
-      ? guideAllowedSwipeDirection
-      : null,
+    guideAllowedSwipeDirection: isActiveGuideCarousel ? guideAllowedSwipeDirection : null,
     guideMaxStepPerInteraction: effectiveGuideMaxStepPerInteraction,
   });
   const guideInteractionHandlers = useGuideMobileSwipeAdapter({
-    enabled:
-      isActiveGuideCarousel &&
-      Number(effectiveGuideMaxStepPerInteraction) > 0 &&
-      !guideCarouselLocked,
+    enabled: isActiveGuideCarousel && Number(effectiveGuideMaxStepPerInteraction) > 0 && !guideCarouselLocked,
     interactionHandlers,
   });
   const expandedCardIndex = useMemo(
@@ -149,39 +114,25 @@ export default function FinancialCarousel(props) {
   const isTerminalGuideLocked = isGuideMode && guideCarouselLocked;
   const isSwipeLocked = isInlineFocusExpanded || isTerminalGuideLocked;
   const isControlledGuideSwipe =
-    isActiveGuideCarousel &&
-    Number(effectiveGuideMaxStepPerInteraction) > 0 &&
-    !isTerminalGuideLocked;
+    isActiveGuideCarousel && Number(effectiveGuideMaxStepPerInteraction) > 0 && !isTerminalGuideLocked;
   const bottomSpacingClass = flushSpacing ? "mb-0" : "mb-5";
-  const productionGuideMatchedClass = isGuideMode
-    ? ""
-    : "clara-production-guide-matched-carousel";
+  const productionGuideMatchedClass = isGuideMode ? "" : "clara-production-guide-matched-carousel";
 
   useEffect(() => {
     if (expandedCardIndex < 0 || typeof window === "undefined") return undefined;
-    const frame = window.requestAnimationFrame(() =>
-      scrollToIndex(expandedCardIndex, "smooth")
-    );
+    const frame = window.requestAnimationFrame(() => scrollToIndex(expandedCardIndex, "smooth"));
     return () => window.cancelAnimationFrame(frame);
   }, [expandedCardIndex, scrollToIndex]);
 
   useEffect(() => {
     if (typeof document === "undefined") return undefined;
     const root = document.documentElement;
-    root.classList.toggle(
-      FINANCIAL_CAROUSEL_FOCUS_CLASS,
-      isInlineFocusExpanded
-    );
+    root.classList.toggle(FINANCIAL_CAROUSEL_FOCUS_CLASS, isInlineFocusExpanded);
     return () => root.classList.remove(FINANCIAL_CAROUSEL_FOCUS_CLASS);
   }, [isInlineFocusExpanded]);
 
   useEffect(() => {
-    if (
-      !isGuideMode ||
-      typeof onGuideCarouselIndexChange !== "function"
-    ) {
-      return undefined;
-    }
+    if (!isGuideMode || typeof onGuideCarouselIndexChange !== "function") return undefined;
 
     const activeItem = items[activeIndex] || null;
 
@@ -201,17 +152,12 @@ export default function FinancialCarousel(props) {
   if (!items.length) return null;
 
   return (
-    <div
-      className={`relative z-20 ${productionGuideMatchedClass} ${bottomSpacingClass} transition-[margin-top] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]`}
-      style={{ marginTop: isInlineFocusExpanded ? EXPANDED_TOP_PULL : 0 }}
-    >
+    <div className={`relative z-20 ${productionGuideMatchedClass} ${bottomSpacingClass} transition-[margin-top] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]`} style={{ marginTop: isInlineFocusExpanded ? EXPANDED_TOP_PULL : 0 }}>
       <style>{FINANCIAL_CAROUSEL_FOCUS_STYLES}</style>
       <CarouselViewport
         carouselRef={carouselRef}
         onScroll={handleScroll}
-        interactionHandlers={
-          isTerminalGuideLocked ? {} : guideInteractionHandlers
-        }
+        interactionHandlers={isTerminalGuideLocked ? {} : guideInteractionHandlers}
         clipClassName={dashboardScale.financeClip || "rounded-[28px]"}
         allowVerticalOverflow={isInlineFocusExpanded}
         isSwipeLocked={isSwipeLocked}
@@ -220,8 +166,7 @@ export default function FinancialCarousel(props) {
         {items.map((item, index) => {
           const isActiveSlide = index === activeIndex;
           const isNearbySlide = Math.abs(index - activeIndex) <= 1;
-          const isInlineExpanded =
-            item.detailKey === expandedFinanceCard && expandedCardIndex >= 0;
+          const isInlineExpanded = item.detailKey === expandedFinanceCard && expandedCardIndex >= 0;
           // Visual performance:
           // Active/expanded cards get full premium visuals.
           // Nearby cards get medium visuals.
@@ -234,53 +179,18 @@ export default function FinancialCarousel(props) {
               : isNearbySlide
                 ? "medium"
                 : "lite";
-          const cardItem =
-            item.type === "investmentFund"
-              ? {
-                  ...item,
-                  data: {
-                    ...item.data,
-                    incomeSources,
-                    incomeData,
-                    refreshData,
-                    isActiveSlide,
-                    isNearbySlide,
-                    performanceMode,
-                  },
-                }
-              : item;
+          const cardItem = item.type === "investmentFund"
+            ? { ...item, data: { ...item.data, incomeSources, incomeData, refreshData, isActiveSlide, isNearbySlide, performanceMode } }
+            : item;
 
           return (
-            <CarouselSlideShell
-              key={cardItem.key}
-              item={cardItem}
-              selectedDashboardTheme={selectedDashboardTheme}
-              dashboardScale={dashboardScale}
-              isExpanded={isInlineExpanded}
-              performanceMode={performanceMode}
-            >
-              <CarouselItemCard
-                {...props}
-                item={cardItem}
-                selectedDashboardTheme={selectedDashboardTheme}
-                expandedFinanceCard={expandedFinanceCard}
-                loading={loading}
-                performanceMode={performanceMode}
-                isActiveSlide={isActiveSlide}
-                isNearbySlide={isNearbySlide}
-              />
+            <CarouselSlideShell key={cardItem.key} item={cardItem} selectedDashboardTheme={selectedDashboardTheme} dashboardScale={dashboardScale} isExpanded={isInlineExpanded} performanceMode={performanceMode}>
+              <CarouselItemCard {...props} item={cardItem} selectedDashboardTheme={selectedDashboardTheme} expandedFinanceCard={expandedFinanceCard} loading={loading} performanceMode={performanceMode} isActiveSlide={isActiveSlide} isNearbySlide={isNearbySlide} />
             </CarouselSlideShell>
           );
         })}
       </CarouselViewport>
-      <CarouselDots
-        items={items}
-        activeIndex={activeIndex}
-        onSelect={isTerminalGuideLocked ? undefined : scrollToIndex}
-        dashboardScale={dashboardScale}
-        selectedDashboardTheme={selectedDashboardTheme}
-        themeInactiveDotClass={themeInactiveDotClass}
-      />
+      <CarouselDots items={items} activeIndex={activeIndex} onSelect={isTerminalGuideLocked ? undefined : scrollToIndex} dashboardScale={dashboardScale} selectedDashboardTheme={selectedDashboardTheme} themeInactiveDotClass={themeInactiveDotClass} />
     </div>
   );
 }

--- a/src/components/financial-carousel/FinancialCarousel.jsx
+++ b/src/components/financial-carousel/FinancialCarousel.jsx
@@ -4,6 +4,7 @@ import CarouselViewport from "./ui/CarouselViewport";
 import CarouselDots from "./ui/CarouselDots";
 import CarouselSlideShell from "./ui/CarouselSlideShell";
 import useAutoMovingHorizontalCarousel from "./logic/useAutoMovingHorizontalCarousel";
+import useGuideMobileSwipeAdapter from "./logic/useGuideMobileSwipeAdapter";
 import { getCarouselData, getDefaultCarouselIndex } from "./logic/FinancialCarouselLogic";
 import {
   EXPANDED_TOP_PULL,
@@ -68,7 +69,28 @@ export default function FinancialCarousel(props) {
   });
 
   const items = useMemo(
-    () => getCarouselData({
+    () =>
+      getCarouselData({
+        monthlyBudgetPlan,
+        savingsGoals,
+        totalSavingsSaved,
+        totalSavingsTarget,
+        primarySavingsGoal,
+        wallets,
+        walletMoney,
+        walletPreviewTransactions,
+        survivalExpense,
+        user: userId || userPlan ? { id: userId, plan: userPlan } : null,
+        plan,
+        guardChecked: isGuideMode ? false : guardChecked,
+        loading,
+        profileData,
+        featureFlags,
+        includeLocked,
+        firstPositiveNumber,
+        readStoredSurvivalExpense,
+      }),
+    [
       monthlyBudgetPlan,
       savingsGoals,
       totalSavingsSaved,
@@ -78,24 +100,46 @@ export default function FinancialCarousel(props) {
       walletMoney,
       walletPreviewTransactions,
       survivalExpense,
-      user: userId || userPlan ? { id: userId, plan: userPlan } : null,
+      userId,
+      userPlan,
       plan,
-      guardChecked: isGuideMode ? false : guardChecked,
+      guardChecked,
       loading,
       profileData,
       featureFlags,
       includeLocked,
       firstPositiveNumber,
       readStoredSurvivalExpense,
-    }),
-    [monthlyBudgetPlan, savingsGoals, totalSavingsSaved, totalSavingsTarget, primarySavingsGoal, wallets, walletMoney, walletPreviewTransactions, survivalExpense, userId, userPlan, plan, guardChecked, loading, profileData, featureFlags, includeLocked, firstPositiveNumber, readStoredSurvivalExpense, isGuideMode]
+      isGuideMode,
+    ]
   );
   const defaultIndex = useMemo(() => getDefaultCarouselIndex(items), [items]);
-  const { carouselRef, activeIndex, scrollToIndex, handleScroll, interactionHandlers } = useAutoMovingHorizontalCarousel({
+  const isActiveGuideCarousel =
+    isGuideMode && typeof onGuideCarouselIndexChange === "function";
+  const effectiveGuideMaxStepPerInteraction =
+    isActiveGuideCarousel && !guideCarouselLocked
+      ? Math.max(1, Number(guideMaxStepPerInteraction) || 1)
+      : null;
+  const {
+    carouselRef,
+    activeIndex,
+    scrollToIndex,
+    handleScroll,
+    interactionHandlers,
+  } = useAutoMovingHorizontalCarousel({
     itemCount: items.length,
     defaultIndex,
-    guideAllowedSwipeDirection: isGuideMode ? guideAllowedSwipeDirection : null,
-    guideMaxStepPerInteraction: isGuideMode ? guideMaxStepPerInteraction : null,
+    guideAllowedSwipeDirection: isActiveGuideCarousel
+      ? guideAllowedSwipeDirection
+      : null,
+    guideMaxStepPerInteraction: effectiveGuideMaxStepPerInteraction,
+  });
+  const guideInteractionHandlers = useGuideMobileSwipeAdapter({
+    enabled:
+      isActiveGuideCarousel &&
+      Number(effectiveGuideMaxStepPerInteraction) > 0 &&
+      !guideCarouselLocked,
+    interactionHandlers,
   });
   const expandedCardIndex = useMemo(
     () => getExpandedCarouselCardIndex(items, expandedFinanceCard),
@@ -105,25 +149,39 @@ export default function FinancialCarousel(props) {
   const isTerminalGuideLocked = isGuideMode && guideCarouselLocked;
   const isSwipeLocked = isInlineFocusExpanded || isTerminalGuideLocked;
   const isControlledGuideSwipe =
-    isGuideMode && Number(guideMaxStepPerInteraction) > 0 && !isTerminalGuideLocked;
+    isActiveGuideCarousel &&
+    Number(effectiveGuideMaxStepPerInteraction) > 0 &&
+    !isTerminalGuideLocked;
   const bottomSpacingClass = flushSpacing ? "mb-0" : "mb-5";
-  const productionGuideMatchedClass = isGuideMode ? "" : "clara-production-guide-matched-carousel";
+  const productionGuideMatchedClass = isGuideMode
+    ? ""
+    : "clara-production-guide-matched-carousel";
 
   useEffect(() => {
     if (expandedCardIndex < 0 || typeof window === "undefined") return undefined;
-    const frame = window.requestAnimationFrame(() => scrollToIndex(expandedCardIndex, "smooth"));
+    const frame = window.requestAnimationFrame(() =>
+      scrollToIndex(expandedCardIndex, "smooth")
+    );
     return () => window.cancelAnimationFrame(frame);
   }, [expandedCardIndex, scrollToIndex]);
 
   useEffect(() => {
     if (typeof document === "undefined") return undefined;
     const root = document.documentElement;
-    root.classList.toggle(FINANCIAL_CAROUSEL_FOCUS_CLASS, isInlineFocusExpanded);
+    root.classList.toggle(
+      FINANCIAL_CAROUSEL_FOCUS_CLASS,
+      isInlineFocusExpanded
+    );
     return () => root.classList.remove(FINANCIAL_CAROUSEL_FOCUS_CLASS);
   }, [isInlineFocusExpanded]);
 
   useEffect(() => {
-    if (!isGuideMode || typeof onGuideCarouselIndexChange !== "function") return undefined;
+    if (
+      !isGuideMode ||
+      typeof onGuideCarouselIndexChange !== "function"
+    ) {
+      return undefined;
+    }
 
     const activeItem = items[activeIndex] || null;
 
@@ -143,12 +201,17 @@ export default function FinancialCarousel(props) {
   if (!items.length) return null;
 
   return (
-    <div className={`relative z-20 ${productionGuideMatchedClass} ${bottomSpacingClass} transition-[margin-top] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]`} style={{ marginTop: isInlineFocusExpanded ? EXPANDED_TOP_PULL : 0 }}>
+    <div
+      className={`relative z-20 ${productionGuideMatchedClass} ${bottomSpacingClass} transition-[margin-top] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]`}
+      style={{ marginTop: isInlineFocusExpanded ? EXPANDED_TOP_PULL : 0 }}
+    >
       <style>{FINANCIAL_CAROUSEL_FOCUS_STYLES}</style>
       <CarouselViewport
         carouselRef={carouselRef}
         onScroll={handleScroll}
-        interactionHandlers={isTerminalGuideLocked ? {} : interactionHandlers}
+        interactionHandlers={
+          isTerminalGuideLocked ? {} : guideInteractionHandlers
+        }
         clipClassName={dashboardScale.financeClip || "rounded-[28px]"}
         allowVerticalOverflow={isInlineFocusExpanded}
         isSwipeLocked={isSwipeLocked}
@@ -157,7 +220,8 @@ export default function FinancialCarousel(props) {
         {items.map((item, index) => {
           const isActiveSlide = index === activeIndex;
           const isNearbySlide = Math.abs(index - activeIndex) <= 1;
-          const isInlineExpanded = item.detailKey === expandedFinanceCard && expandedCardIndex >= 0;
+          const isInlineExpanded =
+            item.detailKey === expandedFinanceCard && expandedCardIndex >= 0;
           // Visual performance:
           // Active/expanded cards get full premium visuals.
           // Nearby cards get medium visuals.
@@ -170,18 +234,53 @@ export default function FinancialCarousel(props) {
               : isNearbySlide
                 ? "medium"
                 : "lite";
-          const cardItem = item.type === "investmentFund"
-            ? { ...item, data: { ...item.data, incomeSources, incomeData, refreshData, isActiveSlide, isNearbySlide, performanceMode } }
-            : item;
+          const cardItem =
+            item.type === "investmentFund"
+              ? {
+                  ...item,
+                  data: {
+                    ...item.data,
+                    incomeSources,
+                    incomeData,
+                    refreshData,
+                    isActiveSlide,
+                    isNearbySlide,
+                    performanceMode,
+                  },
+                }
+              : item;
 
           return (
-            <CarouselSlideShell key={cardItem.key} item={cardItem} selectedDashboardTheme={selectedDashboardTheme} dashboardScale={dashboardScale} isExpanded={isInlineExpanded} performanceMode={performanceMode}>
-              <CarouselItemCard {...props} item={cardItem} selectedDashboardTheme={selectedDashboardTheme} expandedFinanceCard={expandedFinanceCard} loading={loading} performanceMode={performanceMode} isActiveSlide={isActiveSlide} isNearbySlide={isNearbySlide} />
+            <CarouselSlideShell
+              key={cardItem.key}
+              item={cardItem}
+              selectedDashboardTheme={selectedDashboardTheme}
+              dashboardScale={dashboardScale}
+              isExpanded={isInlineExpanded}
+              performanceMode={performanceMode}
+            >
+              <CarouselItemCard
+                {...props}
+                item={cardItem}
+                selectedDashboardTheme={selectedDashboardTheme}
+                expandedFinanceCard={expandedFinanceCard}
+                loading={loading}
+                performanceMode={performanceMode}
+                isActiveSlide={isActiveSlide}
+                isNearbySlide={isNearbySlide}
+              />
             </CarouselSlideShell>
           );
         })}
       </CarouselViewport>
-      <CarouselDots items={items} activeIndex={activeIndex} onSelect={isTerminalGuideLocked ? undefined : scrollToIndex} dashboardScale={dashboardScale} selectedDashboardTheme={selectedDashboardTheme} themeInactiveDotClass={themeInactiveDotClass} />
+      <CarouselDots
+        items={items}
+        activeIndex={activeIndex}
+        onSelect={isTerminalGuideLocked ? undefined : scrollToIndex}
+        dashboardScale={dashboardScale}
+        selectedDashboardTheme={selectedDashboardTheme}
+        themeInactiveDotClass={themeInactiveDotClass}
+      />
     </div>
   );
 }

--- a/src/components/financial-carousel/logic/useGuideMobileSwipeAdapter.js
+++ b/src/components/financial-carousel/logic/useGuideMobileSwipeAdapter.js
@@ -2,13 +2,19 @@ import { useCallback, useMemo, useRef } from "react";
 
 const MOBILE_DRAG_LOCK_THRESHOLD_PX = 4;
 const MOBILE_SWIPE_AXIS_RATIO = 0.8;
+const MOBILE_SWIPE_DISTANCE_MAX_PX = 28;
+const MOBILE_SWIPE_DISTANCE_RATIO = 0.08;
+const MOBILE_SWIPE_VELOCITY_THRESHOLD = 0.18;
 
-// The existing controlled carousel settles at 52px / 0.35px-ms. Only the
-// release coordinate is amplified so the live card still follows the finger
-// at nearly 1:1 while mobile acceptance becomes about 28px / 0.19px-ms.
-const RELEASE_DISTANCE_SCALE = 52 / 28;
+// These mirror the guarded thresholds inside the existing controlled carousel.
+// The adapter only changes Guide Mode input before forwarding it.
 const INTERNAL_DRAG_LOCK_THRESHOLD_PX = 7;
+const INTERNAL_SWIPE_DISTANCE_MAX_PX = 52;
+const INTERNAL_SWIPE_DISTANCE_RATIO = 0.16;
+const INTERNAL_SWIPE_VELOCITY_THRESHOLD = 0.35;
 const LIVE_LOCK_PADDING_PX = 0.25;
+const VELOCITY_TIME_SCALE =
+  MOBILE_SWIPE_VELOCITY_THRESHOLD / INTERNAL_SWIPE_VELOCITY_THRESHOLD;
 
 const INTERACTIVE_TARGET_SELECTOR = [
   "button",
@@ -30,6 +36,7 @@ const createGestureState = () => ({
   pointerId: null,
   startX: 0,
   startY: 0,
+  startTime: 0,
   lastX: 0,
   lastY: 0,
   horizontalIntent: false,
@@ -38,15 +45,30 @@ const createGestureState = () => ({
 
 const isFiniteCoordinate = (value) => Number.isFinite(Number(value));
 
+const getEventTime = (event) => {
+  const value = Number(event?.timeStamp);
+  return Number.isFinite(value) ? value : 0;
+};
+
+const getAdaptedTime = (gesture, event) => {
+  const eventTime = getEventTime(event);
+  const elapsed = Math.max(0, eventTime - gesture.startTime);
+  return gesture.startTime + elapsed * VELOCITY_TIME_SCALE;
+};
+
 const isInteractiveTarget = (target) =>
   Boolean(target?.closest?.(INTERACTIVE_TARGET_SELECTOR));
 
-const createAdaptedPointerEvent = (event, { clientX, clientY }) => {
+const createAdaptedPointerEvent = (
+  event,
+  { clientX, clientY, timeStamp = getEventTime(event) }
+) => {
   const adaptedEvent = Object.create(event);
 
   Object.defineProperties(adaptedEvent, {
     clientX: { configurable: true, enumerable: true, value: clientX },
     clientY: { configurable: true, enumerable: true, value: clientY },
+    timeStamp: { configurable: true, enumerable: true, value: timeStamp },
     currentTarget: {
       configurable: true,
       enumerable: true,
@@ -67,12 +89,24 @@ const createAdaptedPointerEvent = (event, { clientX, clientY }) => {
   return adaptedEvent;
 };
 
+const getMobileDistanceThreshold = (viewportWidth) =>
+  Math.min(
+    MOBILE_SWIPE_DISTANCE_MAX_PX,
+    Math.max(1, viewportWidth) * MOBILE_SWIPE_DISTANCE_RATIO
+  );
+
+const getInternalDistanceThreshold = (viewportWidth) =>
+  Math.min(
+    INTERNAL_SWIPE_DISTANCE_MAX_PX,
+    Math.max(1, viewportWidth) * INTERNAL_SWIPE_DISTANCE_RATIO
+  );
+
 export const GUIDE_MOBILE_SWIPE_SETTINGS = Object.freeze({
   dragLockThresholdPx: MOBILE_DRAG_LOCK_THRESHOLD_PX,
   swipeAxisRatio: MOBILE_SWIPE_AXIS_RATIO,
-  distanceMaxPx: 28,
-  distanceRatioApprox: 0.086,
-  velocityThresholdApprox: 0.19,
+  distanceMaxPx: MOBILE_SWIPE_DISTANCE_MAX_PX,
+  distanceRatio: MOBILE_SWIPE_DISTANCE_RATIO,
+  velocityThreshold: MOBILE_SWIPE_VELOCITY_THRESHOLD,
 });
 
 export default function useGuideMobileSwipeAdapter({
@@ -102,6 +136,7 @@ export default function useGuideMobileSwipeAdapter({
         pointerId: event.pointerId,
         startX,
         startY,
+        startTime: getEventTime(event),
         lastX: startX,
         lastY: startY,
         horizontalIntent: false,
@@ -165,8 +200,12 @@ export default function useGuideMobileSwipeAdapter({
           );
       }
 
-      event.preventDefault?.();
-      event.nativeEvent?.preventDefault?.();
+      try {
+        event.preventDefault?.();
+        event.nativeEvent?.preventDefault?.();
+      } catch {
+        // touch-action: pan-y remains the browser-level vertical scroll guard.
+      }
 
       const liveDeltaX = deltaX + gesture.liveOffsetX;
       const maximumIntentY = Math.abs(liveDeltaX) / 1.1;
@@ -179,6 +218,7 @@ export default function useGuideMobileSwipeAdapter({
         createAdaptedPointerEvent(event, {
           clientX: gesture.startX + liveDeltaX,
           clientY: gesture.startY + liveDeltaY,
+          timeStamp: getAdaptedTime(gesture, event),
         })
       );
     },
@@ -214,8 +254,13 @@ export default function useGuideMobileSwipeAdapter({
         : gesture.lastY;
       const finalX = cancelled ? gesture.lastX : eventX;
       const finalY = cancelled ? gesture.lastY : eventY;
+      const actualDeltaX = finalX - gesture.startX;
+      const actualDeltaY = finalY - gesture.startY;
+      const stillHorizontal =
+        Math.abs(actualDeltaX) >
+        Math.abs(actualDeltaY) * MOBILE_SWIPE_AXIS_RATIO;
 
-      if (!gesture.horizontalIntent) {
+      if (!gesture.horizontalIntent || (cancelled && !stillHorizontal)) {
         const handler = cancelled
           ? interactionHandlers.onPointerCancel
           : interactionHandlers.onPointerUp;
@@ -230,16 +275,22 @@ export default function useGuideMobileSwipeAdapter({
         return;
       }
 
-      const releaseDeltaX =
-        (finalX - gesture.startX) * RELEASE_DISTANCE_SCALE;
+      const viewportWidth = Number(event.currentTarget?.clientWidth) || 1;
+      const passedDistance =
+        Math.abs(actualDeltaX) >= getMobileDistanceThreshold(viewportWidth);
+      const releaseDeltaX = passedDistance
+        ? Math.sign(actualDeltaX || 1) *
+          (getInternalDistanceThreshold(viewportWidth) + LIVE_LOCK_PADDING_PX)
+        : actualDeltaX + gesture.liveOffsetX;
 
-      // Treat a cancelled horizontal drag like a release, using the last real
-      // coordinates. This avoids throwing away a valid swipe when mobile
-      // Safari/Chrome cancels pointer capture during a completed gesture.
+      // A cancelled horizontal gesture is evaluated like a release using its
+      // latest real coordinates. Vertical cancellations still use the original
+      // cancellation path and snap safely to the starting card.
       interactionHandlers.onPointerUp?.(
         createAdaptedPointerEvent(event, {
           clientX: gesture.startX + releaseDeltaX,
           clientY: gesture.startY,
+          timeStamp: getAdaptedTime(gesture, event),
         })
       );
 

--- a/src/components/financial-carousel/logic/useGuideMobileSwipeAdapter.js
+++ b/src/components/financial-carousel/logic/useGuideMobileSwipeAdapter.js
@@ -1,0 +1,268 @@
+import { useCallback, useMemo, useRef } from "react";
+
+const MOBILE_DRAG_LOCK_THRESHOLD_PX = 4;
+const MOBILE_SWIPE_AXIS_RATIO = 0.8;
+
+// The existing controlled carousel settles at 52px / 0.35px-ms. Only the
+// release coordinate is amplified so the live card still follows the finger
+// at nearly 1:1 while mobile acceptance becomes about 28px / 0.19px-ms.
+const RELEASE_DISTANCE_SCALE = 52 / 28;
+const INTERNAL_DRAG_LOCK_THRESHOLD_PX = 7;
+const LIVE_LOCK_PADDING_PX = 0.25;
+
+const INTERACTIVE_TARGET_SELECTOR = [
+  "button",
+  "a",
+  "input",
+  "textarea",
+  "select",
+  "option",
+  "label",
+  "[role='button']",
+  "[contenteditable='true']",
+  "[data-clara-finance-expand-toggle='true']",
+  "[data-clara-carousel-swipe-ignore='true']",
+].join(",");
+
+const createGestureState = () => ({
+  active: false,
+  ignored: false,
+  pointerId: null,
+  startX: 0,
+  startY: 0,
+  lastX: 0,
+  lastY: 0,
+  horizontalIntent: false,
+  liveOffsetX: 0,
+});
+
+const isFiniteCoordinate = (value) => Number.isFinite(Number(value));
+
+const isInteractiveTarget = (target) =>
+  Boolean(target?.closest?.(INTERACTIVE_TARGET_SELECTOR));
+
+const createAdaptedPointerEvent = (event, { clientX, clientY }) => {
+  const adaptedEvent = Object.create(event);
+
+  Object.defineProperties(adaptedEvent, {
+    clientX: { configurable: true, enumerable: true, value: clientX },
+    clientY: { configurable: true, enumerable: true, value: clientY },
+    currentTarget: {
+      configurable: true,
+      enumerable: true,
+      value: event.currentTarget,
+    },
+    target: {
+      configurable: true,
+      enumerable: true,
+      value: event.target,
+    },
+    nativeEvent: {
+      configurable: true,
+      enumerable: true,
+      value: event.nativeEvent,
+    },
+  });
+
+  return adaptedEvent;
+};
+
+export const GUIDE_MOBILE_SWIPE_SETTINGS = Object.freeze({
+  dragLockThresholdPx: MOBILE_DRAG_LOCK_THRESHOLD_PX,
+  swipeAxisRatio: MOBILE_SWIPE_AXIS_RATIO,
+  distanceMaxPx: 28,
+  distanceRatioApprox: 0.086,
+  velocityThresholdApprox: 0.19,
+});
+
+export default function useGuideMobileSwipeAdapter({
+  enabled = false,
+  interactionHandlers = {},
+} = {}) {
+  const gestureRef = useRef(createGestureState());
+
+  const resetGesture = useCallback(() => {
+    gestureRef.current = createGestureState();
+  }, []);
+
+  const handlePointerDown = useCallback(
+    (event) => {
+      if (!enabled) {
+        interactionHandlers.onPointerDown?.(event);
+        return;
+      }
+
+      const ignored = isInteractiveTarget(event.target);
+      const startX = Number(event.clientX) || 0;
+      const startY = Number(event.clientY) || 0;
+
+      gestureRef.current = {
+        active: !ignored,
+        ignored,
+        pointerId: event.pointerId,
+        startX,
+        startY,
+        lastX: startX,
+        lastY: startY,
+        horizontalIntent: false,
+        liveOffsetX: 0,
+      };
+
+      if (!ignored) {
+        interactionHandlers.onPointerDown?.(event);
+      }
+    },
+    [enabled, interactionHandlers]
+  );
+
+  const handlePointerMove = useCallback(
+    (event) => {
+      if (!enabled) {
+        interactionHandlers.onPointerMove?.(event);
+        return;
+      }
+
+      const gesture = gestureRef.current;
+
+      if (
+        !gesture.active ||
+        gesture.ignored ||
+        gesture.pointerId !== event.pointerId
+      ) {
+        return;
+      }
+
+      const currentX = isFiniteCoordinate(event.clientX)
+        ? Number(event.clientX)
+        : gesture.lastX;
+      const currentY = isFiniteCoordinate(event.clientY)
+        ? Number(event.clientY)
+        : gesture.lastY;
+      const deltaX = currentX - gesture.startX;
+      const deltaY = currentY - gesture.startY;
+
+      gesture.lastX = currentX;
+      gesture.lastY = currentY;
+
+      if (!gesture.horizontalIntent) {
+        const passedLockThreshold =
+          Math.abs(deltaX) >= MOBILE_DRAG_LOCK_THRESHOLD_PX;
+        const hasHorizontalIntent =
+          Math.abs(deltaX) > Math.abs(deltaY) * MOBILE_SWIPE_AXIS_RATIO;
+
+        if (!passedLockThreshold || !hasHorizontalIntent) {
+          return;
+        }
+
+        gesture.horizontalIntent = true;
+        gesture.liveOffsetX =
+          Math.sign(deltaX || 1) *
+          Math.max(
+            0,
+            INTERNAL_DRAG_LOCK_THRESHOLD_PX +
+              LIVE_LOCK_PADDING_PX -
+              Math.abs(deltaX)
+          );
+      }
+
+      event.preventDefault?.();
+      event.nativeEvent?.preventDefault?.();
+
+      const liveDeltaX = deltaX + gesture.liveOffsetX;
+      const maximumIntentY = Math.abs(liveDeltaX) / 1.1;
+      const liveDeltaY = Math.max(
+        -maximumIntentY,
+        Math.min(maximumIntentY, deltaY)
+      );
+
+      interactionHandlers.onPointerMove?.(
+        createAdaptedPointerEvent(event, {
+          clientX: gesture.startX + liveDeltaX,
+          clientY: gesture.startY + liveDeltaY,
+        })
+      );
+    },
+    [enabled, interactionHandlers]
+  );
+
+  const finishPointer = useCallback(
+    (event, cancelled) => {
+      if (!enabled) {
+        const handler = cancelled
+          ? interactionHandlers.onPointerCancel
+          : interactionHandlers.onPointerUp;
+        handler?.(event);
+        return;
+      }
+
+      const gesture = gestureRef.current;
+
+      if (gesture.pointerId !== event.pointerId) {
+        return;
+      }
+
+      if (gesture.ignored || !gesture.active) {
+        resetGesture();
+        return;
+      }
+
+      const eventX = isFiniteCoordinate(event.clientX)
+        ? Number(event.clientX)
+        : gesture.lastX;
+      const eventY = isFiniteCoordinate(event.clientY)
+        ? Number(event.clientY)
+        : gesture.lastY;
+      const finalX = cancelled ? gesture.lastX : eventX;
+      const finalY = cancelled ? gesture.lastY : eventY;
+
+      if (!gesture.horizontalIntent) {
+        const handler = cancelled
+          ? interactionHandlers.onPointerCancel
+          : interactionHandlers.onPointerUp;
+
+        handler?.(
+          createAdaptedPointerEvent(event, {
+            clientX: finalX,
+            clientY: finalY,
+          })
+        );
+        resetGesture();
+        return;
+      }
+
+      const releaseDeltaX =
+        (finalX - gesture.startX) * RELEASE_DISTANCE_SCALE;
+
+      // Treat a cancelled horizontal drag like a release, using the last real
+      // coordinates. This avoids throwing away a valid swipe when mobile
+      // Safari/Chrome cancels pointer capture during a completed gesture.
+      interactionHandlers.onPointerUp?.(
+        createAdaptedPointerEvent(event, {
+          clientX: gesture.startX + releaseDeltaX,
+          clientY: gesture.startY,
+        })
+      );
+
+      resetGesture();
+    },
+    [enabled, interactionHandlers, resetGesture]
+  );
+
+  return useMemo(() => {
+    if (!enabled) return interactionHandlers;
+
+    return {
+      ...interactionHandlers,
+      onPointerDown: handlePointerDown,
+      onPointerMove: handlePointerMove,
+      onPointerUp: (event) => finishPointer(event, false),
+      onPointerCancel: (event) => finishPointer(event, true),
+    };
+  }, [
+    enabled,
+    finishPointer,
+    handlePointerDown,
+    handlePointerMove,
+    interactionHandlers,
+  ]);
+}


### PR DESCRIPTION
## Summary
- makes the active Guide Mode finance carousel use controlled one-card movement during both directional training and card explanations
- lowers effective mobile gesture thresholds to 4px intent lock, 0.8 horizontal-axis ratio, 28px/8% distance, and 0.18px/ms velocity
- keeps live card movement nearly 1:1 with the finger instead of accelerating the drag
- evaluates qualified horizontal `pointercancel` events as releases while vertical cancellations still snap back
- ignores swipe capture when a gesture begins on buttons, links, inputs, and other interactive card controls
- preserves the final Debt / Obligations lock and NEXT-only continuation

## One-card protection
The existing controlled carousel still owns clamping and settling. `guideMaxStepPerInteraction` is forced to `1` only while the finance carousel is the active Guide target, so every gesture can resolve only to the current or immediately adjacent card. Direction guards and terminal locking remain unchanged.

## Scope
Changed only:
- `src/components/financial-carousel/FinancialCarousel.jsx`
- `src/components/financial-carousel/logic/useGuideMobileSwipeAdapter.js`

No finance calculations, data persistence, Supabase, routing, membership, billing, Guide copy/order, card styling, bubble styling, dashboard layout, or non-Guide carousel behavior were changed.

## Validation targets
- Android Chrome and iPhone/WebKit portrait widths around 360–390px
- short flicks, slow drags, rapid repeated swipes
- diagonal horizontal gestures versus vertical page scrolling
- pointer cancellation
- first/last carousel boundaries
- card buttons and expand controls
- terminal Debt / Obligations lock