### PR TITLE
Fix CLARA walkthrough Google Form handoff on mobile

### DIFF
--- a/src/components/fresh/main-dashboard/learning-hub/LearningHub.jsx
+++ b/src/components/fresh/main-dashboard/learning-hub/LearningHub.jsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { Capacitor } from "@capacitor/core";
 import { CalendarClock, ScrollText } from "lucide-react";
 import DailyTipCard from "../daily-tip";
 import ClaraGuideLearningHubInlineBubble from "../guide/ClaraGuideLearningHubInlineBubble";
@@ -48,6 +49,35 @@ function restoreDashboardScrollPosition(scroller, scrollTop) {
       restore();
     });
   });
+}
+
+function openWelcomeSessionForm(url) {
+  const safeUrl = String(url || "").trim();
+  if (!safeUrl || typeof window === "undefined") return false;
+
+  if (Capacitor.isNativePlatform()) {
+    // Capacitor Android hands external top-level navigations to ACTION_VIEW,
+    // which opens the device browser instead of relying on unsupported popups.
+    window.location.assign(safeUrl);
+    return true;
+  }
+
+  try {
+    const popup = window.open(safeUrl, "_blank");
+    if (popup) {
+      try {
+        popup.opener = null;
+      } catch {
+        // The new tab is already isolated by the browser when opener is unavailable.
+      }
+      return true;
+    }
+  } catch {
+    // Fall through to a same-tab navigation when the browser blocks popups.
+  }
+
+  window.location.assign(safeUrl);
+  return true;
 }
 
 function ClaraGuideButton({ hasNewGuide = false, onClick }) {
@@ -226,9 +256,7 @@ export default function LearningHub({
   };
 
   const handleOpenGuidedOnboardingForm = () => {
-    if (!WELCOME_SESSION_FORM_URL || typeof window === "undefined") return;
-
-    window.open(WELCOME_SESSION_FORM_URL, "_blank", "noopener,noreferrer");
+    if (!openWelcomeSessionForm(WELCOME_SESSION_FORM_URL)) return;
     closeGuidedOnboardingIntro({ restoreFocus: false });
   };
 


### PR DESCRIPTION
## Problem
The booking button was correctly wired, but it relied only on `window.open(..., "_blank")`. In the Capacitor Android WebView, popup-style navigation can be ignored, so tapping **Reserve My Free Session** appeared to do nothing.

## Fix
- detect the native Capacitor runtime
- on native mobile, use a top-level external navigation so Capacitor hands the Google Form URL to Android's browser intent
- on normal web browsers, continue opening a new tab
- add a fallback to same-tab navigation when a browser blocks the popup
- close the walkthrough only after a navigation path has been started

## Preserved
- existing Google Form URL and environment override
- walkthrough layout and copy
- close behavior, sound, Guide Mode, Learning Hub, and booking state

## Scope
Only `LearningHub.jsx` is changed. No new native plugin or dependency is required.