### PR TITLE
Fix CLARA Daily Check-In streak and calendar challenge logic

### DIFF
--- a/src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInActions.js
+++ b/src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInActions.js
@@ -1,17 +1,15 @@
 import { higherPriorityBubble, createBubble, selectMilestone } from "./dailyCheckInBubbles.js";
 import {
-  DAILY_CHECK_IN_EVENT_TYPE,
-  DAILY_CHECK_IN_SOURCE,
-  eventIdFor,
+  EVENT_TYPE,
+  createDailyCheckInEvent,
   normalizeCheckInEvents,
 } from "./dailyCheckInEngine.js";
 import { normalizeState } from "./dailyCheckInState.js";
-import { getChallengeTimeZone } from "../../../../../lib/challenge-schedule.js";
 
 export function prepareDailyCheckIn(value, userId, todayKey) {
   const baseState = normalizeState(value, userId, todayKey);
   const existingEvent = baseState.checkInEvents.find(
-    (event) => event.eventType === DAILY_CHECK_IN_EVENT_TYPE && event.eligibleDay === todayKey,
+    (event) => event.eventType === EVENT_TYPE && event.eligibleDay === todayKey,
   );
 
   if (existingEvent) {
@@ -19,16 +17,7 @@ export function prepareDailyCheckIn(value, userId, todayKey) {
   }
 
   const nowIso = new Date().toISOString();
-  const nextEvent = {
-    eventId: eventIdFor(userId, todayKey),
-    userId,
-    eventType: DAILY_CHECK_IN_EVENT_TYPE,
-    eligibleDay: todayKey,
-    clientOccurredAt: nowIso,
-    timezone: getChallengeTimeZone(),
-    source: DAILY_CHECK_IN_SOURCE,
-    createdAt: nowIso,
-  };
+  const nextEvent = createDailyCheckInEvent({ userId, eligibleDay: todayKey });
   const checkInEvents = normalizeCheckInEvents(
     [...baseState.checkInEvents, nextEvent],
     userId,

--- a/src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInActions.js
+++ b/src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInActions.js
@@ -1,26 +1,45 @@
 import { higherPriorityBubble, createBubble, selectMilestone } from "./dailyCheckInBubbles.js";
-import { normalizeDates } from "./dailyCheckInEngine.js";
+import {
+  DAILY_CHECK_IN_EVENT_TYPE,
+  DAILY_CHECK_IN_SOURCE,
+  eventIdFor,
+  normalizeCheckInEvents,
+} from "./dailyCheckInEngine.js";
 import { normalizeState } from "./dailyCheckInState.js";
+import { getChallengeTimeZone } from "../../../../../lib/challenge-schedule.js";
 
 export function prepareDailyCheckIn(value, userId, todayKey) {
   const baseState = normalizeState(value, userId, todayKey);
-  if (baseState.completedDates.includes(todayKey)) {
+  const existingEvent = baseState.checkInEvents.find(
+    (event) => event.eventType === DAILY_CHECK_IN_EVENT_TYPE && event.eligibleDay === todayKey,
+  );
+
+  if (existingEvent) {
     return buildResult("already_checked_in", baseState);
   }
 
-  const completedDates = normalizeDates(
-    [...baseState.completedDates, todayKey],
+  const nowIso = new Date().toISOString();
+  const nextEvent = {
+    eventId: eventIdFor(userId, todayKey),
+    userId,
+    eventType: DAILY_CHECK_IN_EVENT_TYPE,
+    eligibleDay: todayKey,
+    clientOccurredAt: nowIso,
+    timezone: getChallengeTimeZone(),
+    source: DAILY_CHECK_IN_SOURCE,
+    createdAt: nowIso,
+  };
+  const checkInEvents = normalizeCheckInEvents(
+    [...baseState.checkInEvents, nextEvent],
+    userId,
     todayKey,
   );
-  const nowIso = new Date().toISOString();
+
   const derivedState = normalizeState(
     {
       ...baseState,
-      completedDates,
-      lifetimeCheckIns: Math.max(
-        completedDates.length,
-        baseState.lifetimeCheckIns + 1,
-      ),
+      challengeStartDay: baseState.challengeStartDay || todayKey,
+      checkInEvents,
       updatedAt: nowIso,
     },
     userId,
@@ -39,9 +58,9 @@ export function prepareDailyCheckIn(value, userId, todayKey) {
     {
       ...derivedState,
       completedThirtyDays:
-        baseState.completedThirtyDays || derivedState.currentStreak >= 30,
+        baseState.completedThirtyDays || derivedState.challengeStatus === "completed",
       completedThirtyDaysAt:
-        derivedState.currentStreak >= 30 && !baseState.completedThirtyDaysAt
+        derivedState.challengeStatus === "completed" && !baseState.completedThirtyDaysAt
           ? nowIso
           : baseState.completedThirtyDaysAt,
       pendingBubble: higherPriorityBubble(
@@ -53,7 +72,7 @@ export function prepareDailyCheckIn(value, userId, todayKey) {
     todayKey,
   );
 
-  return buildResult("prepared", nextState, milestoneType, milestoneBubble, baseState);
+  return buildResult("prepared", nextState, milestoneType, milestoneBubble, baseState, nextEvent);
 }
 
 export function performDailyCheckIn({ value, userId, todayKey, persist }) {
@@ -61,7 +80,7 @@ export function performDailyCheckIn({ value, userId, todayKey, persist }) {
   if (prepared.status === "already_checked_in") return prepared;
 
   try {
-    const persistenceResult = persist(prepared.state);
+    const persistenceResult = persist(prepared.state, prepared.event);
     if (!persistenceResult?.ok) {
       return buildResult("storage_error", prepared.baseState);
     }
@@ -82,14 +101,19 @@ export function buildResult(
   milestoneType = null,
   bubbleEvent = null,
   baseState = null,
+  event = null,
 ) {
   return {
     status,
     currentStreak: state.currentStreak,
     longestStreak: state.longestStreak,
+    challengeStatus: state.challengeStatus,
+    challengeCurrentDay: state.challengeCurrentDay,
+    completedCheckInDays: state.completedCheckInDays,
     milestoneType,
     bubbleEvent,
     state,
     baseState,
+    event,
   };
 }

--- a/src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInEngine.js
+++ b/src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInEngine.js
@@ -2,17 +2,16 @@ import {
   addLocalDays,
   compareDateKeys,
   daysBetweenDateKeys,
-  getChallengeTimeZone,
-  isRealDateKey,
+  isValidDateKey,
 } from "../../../../../lib/challenge-schedule.js";
 
 export const MAX_VISIBLE_DAYS = 30;
-export const DAILY_CHECK_IN_EVENT_TYPE = "daily_check_in";
-export const DAILY_CHECK_IN_SOURCE = "daily_check_in_card_flip";
-export const MIGRATION_SOURCE = "legacy_v2_migration";
+export const EVENT_TYPE = "daily_check_in";
+export const EVENT_SOURCE_CARD_FLIP = "daily_check_in_card_flip";
+export const EVENT_SOURCE_MIGRATION = "legacy_v2_migration";
 
 export function isDateKey(value) {
-  return isRealDateKey(value);
+  return isValidDateKey(value);
 }
 
 export function normalizeDates(value, todayKey = null) {
@@ -22,52 +21,52 @@ export function normalizeDates(value, todayKey = null) {
     .sort(compareDateKeys);
 }
 
-export function eventIdFor(userId, eligibleDay) {
-  const safeUserId = String(userId || "").trim().replace(/[^a-zA-Z0-9_.:-]/g, "_") || "guest";
-  return `${DAILY_CHECK_IN_EVENT_TYPE}:${safeUserId}:${eligibleDay}`;
+export function buildDailyCheckInEventId(userId, eligibleDay) {
+  return `daily_check_in:${String(userId || "").trim()}:${eligibleDay}`;
 }
 
-export function normalizeCheckInEvents(events, userId, todayKey = null) {
-  if (!Array.isArray(events)) return [];
-  const byId = new Map();
+export function createDailyCheckInEvent({ userId, eligibleDay, source = EVENT_SOURCE_CARD_FLIP, now = new Date() }) {
+  const createdAt = now.toISOString();
+  return {
+    eventId: buildDailyCheckInEventId(userId, eligibleDay),
+    userId: String(userId || "").trim(),
+    eventType: EVENT_TYPE,
+    eligibleDay,
+    clientOccurredAt: createdAt,
+    timezone: "Asia/Manila",
+    source,
+    createdAt,
+  };
+}
+
+export function normalizeCheckInEvents(value, userId, todayKey = null) {
+  const events = Array.isArray(value) ? value : [];
+  const byDay = new Map();
 
   events.forEach((event) => {
     const eligibleDay = event?.eligibleDay;
     if (!isDateKey(eligibleDay)) return;
     if (todayKey && compareDateKeys(eligibleDay, todayKey) > 0) return;
-
-    const normalizedUserId = userId || event?.userId || "guest";
-    const normalized = {
-      eventId: event?.eventId || eventIdFor(normalizedUserId, eligibleDay),
-      userId: normalizedUserId,
-      eventType: DAILY_CHECK_IN_EVENT_TYPE,
+    const eventType = event?.eventType || EVENT_TYPE;
+    if (eventType !== EVENT_TYPE) return;
+    if (byDay.has(eligibleDay)) return;
+    byDay.set(eligibleDay, {
+      eventId: event?.eventId || buildDailyCheckInEventId(userId, eligibleDay),
+      userId,
+      eventType: EVENT_TYPE,
       eligibleDay,
-      clientOccurredAt:
-        typeof event?.clientOccurredAt === "string" ? event.clientOccurredAt : null,
-      timezone: getChallengeTimeZone(),
-      source:
-        typeof event?.source === "string" && event.source
-          ? event.source
-          : DAILY_CHECK_IN_SOURCE,
+      clientOccurredAt: typeof event?.clientOccurredAt === "string" ? event.clientOccurredAt : null,
+      timezone: "Asia/Manila",
+      source: typeof event?.source === "string" ? event.source : EVENT_SOURCE_CARD_FLIP,
       createdAt: typeof event?.createdAt === "string" ? event.createdAt : null,
-    };
-    byId.set(eventIdFor(normalizedUserId, eligibleDay), normalized);
+    });
   });
 
-  return [...byId.values()].sort((a, b) => compareDateKeys(a.eligibleDay, b.eligibleDay));
+  return [...byDay.values()].sort((left, right) => compareDateKeys(left.eligibleDay, right.eligibleDay));
 }
 
-export function eventsFromDates(completedDates, userId, source = MIGRATION_SOURCE) {
-  return normalizeDates(completedDates).map((eligibleDay) => ({
-    eventId: eventIdFor(userId, eligibleDay),
-    userId,
-    eventType: DAILY_CHECK_IN_EVENT_TYPE,
-    eligibleDay,
-    clientOccurredAt: `${eligibleDay}T06:00:00+08:00`,
-    timezone: getChallengeTimeZone(),
-    source,
-    createdAt: new Date().toISOString(),
-  }));
+export function eventDays(checkInEvents, todayKey = null) {
+  return normalizeDates(checkInEvents.map((event) => event.eligibleDay), todayKey);
 }
 
 export function calculateStreakEndingAtDate(completedDates, endDateKey) {
@@ -111,13 +110,15 @@ export function deriveCheckInStateFromEvents({
   todayKey,
   storedLongestStreak = 0,
   storedLifetimeCheckIns = 0,
-  challengeStartDay = null,
-  completedThirtyDays = false,
 }) {
-  const normalizedEvents = normalizeCheckInEvents(checkInEvents, null, todayKey);
-  const completedDates = normalizeDates(normalizedEvents.map((event) => event.eligibleDay), todayKey);
+  const completedDates = eventDays(checkInEvents, todayKey);
   const lastCheckInDay = completedDates[completedDates.length - 1] || null;
   const currentStreak = calculateActiveStreak(completedDates, todayKey);
+  const activeEndDate = completedDates.includes(todayKey)
+    ? todayKey
+    : completedDates.includes(addLocalDays(todayKey, -1))
+      ? addLocalDays(todayKey, -1)
+      : null;
   const calculatedLongestStreak = calculateLongestStreak(completedDates);
   const validStoredLongest = Number.isFinite(Number(storedLongestStreak))
     ? Math.max(0, Math.floor(Number(storedLongestStreak)))
@@ -126,122 +127,144 @@ export function deriveCheckInStateFromEvents({
     ? Math.max(0, Math.floor(Number(storedLifetimeCheckIns)))
     : 0;
 
-  const startDay = isDateKey(challengeStartDay)
-    ? challengeStartDay
-    : lastCheckInDay
-      ? lastCheckInDay
-      : null;
-  const challengeEndDay = startDay ? addLocalDays(startDay, MAX_VISIBLE_DAYS - 1) : null;
-  const challengeCurrentDay = startDay
-    ? Math.max(1, Math.min(MAX_VISIBLE_DAYS, daysBetweenDateKeys(startDay, todayKey) + 1))
-    : 0;
-  const reachedCalendarEnd =
-    Boolean(startDay) && compareDateKeys(todayKey, challengeEndDay) >= 0;
-  const challengeStatus = startDay
-    ? completedThirtyDays || reachedCalendarEnd
-      ? "completed"
-      : "active"
-    : "not_started";
-
-  const completedCheckInDays =
-    startDay && challengeEndDay
-      ? completedDates.filter(
-          (day) => compareDateKeys(day, startDay) >= 0 && compareDateKeys(day, challengeEndDay) <= 0,
-        ).length
-      : 0;
-
   return {
-    checkInEvents: normalizedEvents,
     completedDates,
     currentStreak,
-    longestStreak: Math.max(calculatedLongestStreak, validStoredLongest),
-    lifetimeCheckIns: Math.max(completedDates.length, validStoredLifetime),
     lastCheckInDay,
     lastCheckInDate: lastCheckInDay,
-    challengeStartDay: startDay,
-    challengeCurrentDay,
-    challengeEndDay,
-    challengeStatus,
-    completedCheckInDays,
-    completedThirtyDays: completedThirtyDays || challengeStatus === "completed",
+    cycleStartedAt:
+      currentStreak > 0 && activeEndDate
+        ? addLocalDays(activeEndDate, -(currentStreak - 1))
+        : null,
+    calculatedLongestStreak,
+    longestStreak: Math.max(calculatedLongestStreak, validStoredLongest),
+    lifetimeCheckIns: Math.max(completedDates.length, validStoredLifetime),
   };
 }
 
-export function deriveCheckInStateFromDates({
-  completedDates,
-  todayKey,
-  storedLongestStreak = 0,
-}) {
-  return deriveCheckInStateFromEvents({
-    checkInEvents: eventsFromDates(completedDates, "guest"),
-    todayKey,
-    storedLongestStreak,
-  });
+export function deriveCheckInStateFromDates({ completedDates, todayKey, storedLongestStreak = 0 }) {
+  const checkInEvents = normalizeDates(completedDates, todayKey).map((eligibleDay) =>
+    createDailyCheckInEvent({ userId: "legacy", eligibleDay, source: EVENT_SOURCE_MIGRATION }),
+  );
+  return deriveCheckInStateFromEvents({ checkInEvents, todayKey, storedLongestStreak });
 }
 
-export function reconcileCheckInHistory(value, todayKey, userId = null) {
-  const resolvedUserId = userId || value?.userId || "guest";
-  const legacyDates = normalizeDates(
-    [
-      ...(Array.isArray(value?.completedDates) ? value.completedDates : []),
-      ...(isDateKey(value?.lastCheckInDate) ? [value.lastCheckInDate] : []),
-      ...(isDateKey(value?.lastCheckInDay) ? [value.lastCheckInDay] : []),
-    ],
-    todayKey,
-  );
-  const eventHistory = normalizeCheckInEvents(value?.checkInEvents, resolvedUserId, todayKey);
-  const events = normalizeCheckInEvents(
-    [...eventHistory, ...eventsFromDates(legacyDates, resolvedUserId)],
-    resolvedUserId,
+export function reconcileCheckInHistory(value, todayKey, userId = value?.userId || "guest") {
+  const legacyDates = normalizeDates(value?.completedDates, todayKey);
+  const explicitEvents = normalizeCheckInEvents(value?.checkInEvents, userId, todayKey);
+  const explicitDays = new Set(explicitEvents.map((event) => event.eligibleDay));
+  const migratedLegacyEvents = legacyDates
+    .filter((eligibleDay) => !explicitDays.has(eligibleDay))
+    .map((eligibleDay) => createDailyCheckInEvent({ userId, eligibleDay, source: EVENT_SOURCE_MIGRATION }));
+  const checkInEvents = normalizeCheckInEvents(
+    [...explicitEvents, ...migratedLegacyEvents],
+    userId,
     todayKey,
   );
 
-  return deriveCheckInStateFromEvents({
-    checkInEvents: events,
-    todayKey,
-    storedLongestStreak: value?.longestStreak,
-    storedLifetimeCheckIns: value?.lifetimeCheckIns,
-    challengeStartDay: value?.challengeStartDay || value?.cycleStartedAt || null,
-    completedThirtyDays: Boolean(value?.completedThirtyDays),
-  });
+  return {
+    checkInEvents,
+    ...deriveCheckInStateFromEvents({
+      checkInEvents,
+      todayKey,
+      storedLongestStreak: value?.longestStreak,
+      storedLifetimeCheckIns: value?.lifetimeCheckIns,
+    }),
+  };
+}
+
+export function calculateChallengeEndDay(challengeStartDay) {
+  return isDateKey(challengeStartDay) ? addLocalDays(challengeStartDay, MAX_VISIBLE_DAYS - 1) : null;
+}
+
+export function calculateChallengeCurrentDay(challengeStartDay, todayKey) {
+  if (!isDateKey(challengeStartDay) || !isDateKey(todayKey)) return 0;
+  const rawDay = daysBetweenDateKeys(challengeStartDay, todayKey) + 1;
+  return Math.max(1, Math.min(MAX_VISIBLE_DAYS, rawDay));
+}
+
+export function calculateCompletedCheckInDays(completedDates, challengeStartDay, challengeEndDay) {
+  if (!isDateKey(challengeStartDay) || !isDateKey(challengeEndDay)) return 0;
+  return normalizeDates(completedDates).filter(
+    (dateKey) => compareDateKeys(dateKey, challengeStartDay) >= 0 && compareDateKeys(dateKey, challengeEndDay) <= 0,
+  ).length;
+}
+
+export function deriveChallengeState({ state, todayKey }) {
+  const completedDates = normalizeDates(state?.completedDates, todayKey);
+  const challengeStartDay = isDateKey(state?.challengeStartDay)
+    ? state.challengeStartDay
+    : isDateKey(state?.cycleStartedAt)
+      ? state.cycleStartedAt
+      : isDateKey(state?.lastCheckInDay || state?.lastCheckInDate)
+        ? state.lastCheckInDay || state.lastCheckInDate
+        : null;
+
+  if (!challengeStartDay) {
+    return {
+      challengeStartDay: null,
+      challengeCurrentDay: 0,
+      challengeEndDay: null,
+      challengeStatus: "not_started",
+      completedCheckInDays: 0,
+      completedThirtyDays: Boolean(state?.completedThirtyDays),
+      completedThirtyDaysAt: typeof state?.completedThirtyDaysAt === "string" ? state.completedThirtyDaysAt : null,
+    };
+  }
+
+  const challengeEndDay = calculateChallengeEndDay(challengeStartDay);
+  const challengeCurrentDay = calculateChallengeCurrentDay(challengeStartDay, todayKey);
+  const completedCheckInDays = calculateCompletedCheckInDays(completedDates, challengeStartDay, challengeEndDay);
+  const isCalendarComplete = compareDateKeys(todayKey, challengeEndDay) >= 0;
+  const completedThirtyDays = Boolean(state?.completedThirtyDays) || isCalendarComplete;
+
+  return {
+    challengeStartDay,
+    challengeCurrentDay,
+    challengeEndDay,
+    challengeStatus: completedThirtyDays ? "completed" : "active",
+    completedCheckInDays,
+    completedThirtyDays,
+    completedThirtyDaysAt:
+      completedThirtyDays && typeof state?.completedThirtyDaysAt === "string"
+        ? state.completedThirtyDaysAt
+        : null,
+  };
 }
 
 export function deriveChallengeMetrics(state, todayKey, maxVisibleDays = MAX_VISIBLE_DAYS) {
-  const completedDates = normalizeDates(
-    state.completedDates ||
-      normalizeCheckInEvents(state.checkInEvents, state.userId, todayKey).map((event) => event.eligibleDay),
-    todayKey,
-  );
+  const completedDates = normalizeDates(state.completedDates, todayKey);
   const checkedInToday = completedDates.includes(todayKey);
-  const challengeDay = Math.max(0, Math.min(maxVisibleDays, Number(state.challengeCurrentDay || 0)));
-  const challengeProgress = Math.max(0, Math.min(maxVisibleDays, Number(state.completedCheckInDays || 0)));
-
-  const challengeStartDay = isDateKey(state.challengeStartDay) ? state.challengeStartDay : null;
-  const challengeEndDay = isDateKey(state.challengeEndDay)
-    ? state.challengeEndDay
-    : challengeStartDay
-      ? addLocalDays(challengeStartDay, maxVisibleDays - 1)
-      : null;
-  const completedDateSet = new Set(completedDates);
-
-  const challengeDots = Array.from({ length: maxVisibleDays }).map((_, index) => {
-    const dateKey = challengeStartDay ? addLocalDays(challengeStartDay, index) : null;
-    const completed = Boolean(dateKey && completedDateSet.has(dateKey));
-    const current =
-      Boolean(dateKey) &&
-      compareDateKeys(dateKey, todayKey) === 0 &&
-      state.challengeStatus !== "not_started";
-    const future = Boolean(dateKey && compareDateKeys(dateKey, todayKey) > 0);
-    const outsideWindow = Boolean(challengeEndDay && dateKey && compareDateKeys(dateKey, challengeEndDay) > 0);
-
+  const challengeCurrentDay = Math.min(maxVisibleDays, Math.max(0, Number(state.challengeCurrentDay || 0)));
+  const challengeDay = challengeCurrentDay || 1;
+  const challengeProgress = Math.min(maxVisibleDays, Math.max(0, Number(state.completedCheckInDays || 0)));
+  const challengeStartDay = state.challengeStartDay;
+  const challengeDotStates = Array.from({ length: maxVisibleDays }).map((_, index) => {
+    const dotDay = challengeStartDay ? addLocalDays(challengeStartDay, index) : null;
+    const completed = dotDay ? completedDates.includes(dotDay) : false;
+    const dayNumber = index + 1;
+    const isToday = Boolean(
+      dotDay &&
+      challengeCurrentDay === dayNumber &&
+      state.challengeStatus !== "completed" &&
+      !completed,
+    );
+    const isPast = Boolean(dotDay && challengeCurrentDay > dayNumber && !completed);
     return {
-      dayNumber: index + 1,
-      dateKey,
+      dayNumber,
+      dateKey: dotDay,
       completed,
-      current: current && !completed,
-      future: future || outsideWindow || !challengeStartDay,
+      today: isToday,
+      pastMissed: isPast,
+      future: Boolean(dotDay && challengeCurrentDay < dayNumber),
     };
   });
 
-  return { checkedInToday, challengeProgress, challengeDay, challengeDots };
+  return {
+    checkedInToday,
+    challengeProgress,
+    challengeDay,
+    challengeCurrentDay,
+    challengeDotStates,
+  };
 }

--- a/src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInEngine.js
+++ b/src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInEngine.js
@@ -1,12 +1,18 @@
 import {
   addLocalDays,
   compareDateKeys,
+  daysBetweenDateKeys,
+  getChallengeTimeZone,
+  isRealDateKey,
 } from "../../../../../lib/challenge-schedule.js";
 
 export const MAX_VISIBLE_DAYS = 30;
+export const DAILY_CHECK_IN_EVENT_TYPE = "daily_check_in";
+export const DAILY_CHECK_IN_SOURCE = "daily_check_in_card_flip";
+export const MIGRATION_SOURCE = "legacy_v2_migration";
 
 export function isDateKey(value) {
-  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value);
+  return isRealDateKey(value);
 }
 
 export function normalizeDates(value, todayKey = null) {
@@ -16,12 +22,60 @@ export function normalizeDates(value, todayKey = null) {
     .sort(compareDateKeys);
 }
 
+export function eventIdFor(userId, eligibleDay) {
+  const safeUserId = String(userId || "").trim().replace(/[^a-zA-Z0-9_.:-]/g, "_") || "guest";
+  return `${DAILY_CHECK_IN_EVENT_TYPE}:${safeUserId}:${eligibleDay}`;
+}
+
+export function normalizeCheckInEvents(events, userId, todayKey = null) {
+  if (!Array.isArray(events)) return [];
+  const byId = new Map();
+
+  events.forEach((event) => {
+    const eligibleDay = event?.eligibleDay;
+    if (!isDateKey(eligibleDay)) return;
+    if (todayKey && compareDateKeys(eligibleDay, todayKey) > 0) return;
+
+    const normalizedUserId = userId || event?.userId || "guest";
+    const normalized = {
+      eventId: event?.eventId || eventIdFor(normalizedUserId, eligibleDay),
+      userId: normalizedUserId,
+      eventType: DAILY_CHECK_IN_EVENT_TYPE,
+      eligibleDay,
+      clientOccurredAt:
+        typeof event?.clientOccurredAt === "string" ? event.clientOccurredAt : null,
+      timezone: getChallengeTimeZone(),
+      source:
+        typeof event?.source === "string" && event.source
+          ? event.source
+          : DAILY_CHECK_IN_SOURCE,
+      createdAt: typeof event?.createdAt === "string" ? event.createdAt : null,
+    };
+    byId.set(eventIdFor(normalizedUserId, eligibleDay), normalized);
+  });
+
+  return [...byId.values()].sort((a, b) => compareDateKeys(a.eligibleDay, b.eligibleDay));
+}
+
+export function eventsFromDates(completedDates, userId, source = MIGRATION_SOURCE) {
+  return normalizeDates(completedDates).map((eligibleDay) => ({
+    eventId: eventIdFor(userId, eligibleDay),
+    userId,
+    eventType: DAILY_CHECK_IN_EVENT_TYPE,
+    eligibleDay,
+    clientOccurredAt: `${eligibleDay}T06:00:00+08:00`,
+    timezone: getChallengeTimeZone(),
+    source,
+    createdAt: new Date().toISOString(),
+  }));
+}
+
 export function calculateStreakEndingAtDate(completedDates, endDateKey) {
   if (!isDateKey(endDateKey)) return 0;
   const dateSet = new Set(normalizeDates(completedDates));
   let cursor = endDateKey;
   let streak = 0;
-  while (dateSet.has(cursor)) {
+  while (cursor && dateSet.has(cursor)) {
     streak += 1;
     cursor = addLocalDays(cursor, -1);
   }
@@ -52,61 +106,142 @@ export function calculateLongestStreak(completedDates) {
   return longest;
 }
 
+export function deriveCheckInStateFromEvents({
+  checkInEvents,
+  todayKey,
+  storedLongestStreak = 0,
+  storedLifetimeCheckIns = 0,
+  challengeStartDay = null,
+  completedThirtyDays = false,
+}) {
+  const normalizedEvents = normalizeCheckInEvents(checkInEvents, null, todayKey);
+  const completedDates = normalizeDates(normalizedEvents.map((event) => event.eligibleDay), todayKey);
+  const lastCheckInDay = completedDates[completedDates.length - 1] || null;
+  const currentStreak = calculateActiveStreak(completedDates, todayKey);
+  const calculatedLongestStreak = calculateLongestStreak(completedDates);
+  const validStoredLongest = Number.isFinite(Number(storedLongestStreak))
+    ? Math.max(0, Math.floor(Number(storedLongestStreak)))
+    : 0;
+  const validStoredLifetime = Number.isFinite(Number(storedLifetimeCheckIns))
+    ? Math.max(0, Math.floor(Number(storedLifetimeCheckIns)))
+    : 0;
+
+  const startDay = isDateKey(challengeStartDay)
+    ? challengeStartDay
+    : lastCheckInDay
+      ? lastCheckInDay
+      : null;
+  const challengeEndDay = startDay ? addLocalDays(startDay, MAX_VISIBLE_DAYS - 1) : null;
+  const challengeCurrentDay = startDay
+    ? Math.max(1, Math.min(MAX_VISIBLE_DAYS, daysBetweenDateKeys(startDay, todayKey) + 1))
+    : 0;
+  const reachedCalendarEnd =
+    Boolean(startDay) && compareDateKeys(todayKey, challengeEndDay) >= 0;
+  const challengeStatus = startDay
+    ? completedThirtyDays || reachedCalendarEnd
+      ? "completed"
+      : "active"
+    : "not_started";
+
+  const completedCheckInDays =
+    startDay && challengeEndDay
+      ? completedDates.filter(
+          (day) => compareDateKeys(day, startDay) >= 0 && compareDateKeys(day, challengeEndDay) <= 0,
+        ).length
+      : 0;
+
+  return {
+    checkInEvents: normalizedEvents,
+    completedDates,
+    currentStreak,
+    longestStreak: Math.max(calculatedLongestStreak, validStoredLongest),
+    lifetimeCheckIns: Math.max(completedDates.length, validStoredLifetime),
+    lastCheckInDay,
+    lastCheckInDate: lastCheckInDay,
+    challengeStartDay: startDay,
+    challengeCurrentDay,
+    challengeEndDay,
+    challengeStatus,
+    completedCheckInDays,
+    completedThirtyDays: completedThirtyDays || challengeStatus === "completed",
+  };
+}
+
 export function deriveCheckInStateFromDates({
   completedDates,
   todayKey,
   storedLongestStreak = 0,
 }) {
-  const normalizedDates = normalizeDates(completedDates, todayKey);
-  const lastCheckInDate = normalizedDates[normalizedDates.length - 1] || null;
-  const currentStreak = calculateActiveStreak(normalizedDates, todayKey);
-  const activeEndDate = normalizedDates.includes(todayKey)
-    ? todayKey
-    : normalizedDates.includes(addLocalDays(todayKey, -1))
-      ? addLocalDays(todayKey, -1)
-      : null;
-  const calculatedLongestStreak = calculateLongestStreak(normalizedDates);
-  const validStoredLongest = Number.isFinite(Number(storedLongestStreak))
-    ? Math.max(0, Math.floor(Number(storedLongestStreak)))
-    : 0;
-
-  return {
-    completedDates: normalizedDates,
-    currentStreak,
-    lastCheckInDate,
-    cycleStartedAt:
-      currentStreak > 0 && activeEndDate
-        ? addLocalDays(activeEndDate, -(currentStreak - 1))
-        : null,
-    calculatedLongestStreak,
-    longestStreak: Math.max(calculatedLongestStreak, validStoredLongest),
-  };
+  return deriveCheckInStateFromEvents({
+    checkInEvents: eventsFromDates(completedDates, "guest"),
+    todayKey,
+    storedLongestStreak,
+  });
 }
 
-export function reconcileCheckInHistory(value, todayKey) {
-  let completedDates = normalizeDates(value?.completedDates, todayKey);
-  const verifiedLastCheckInDate =
-    isDateKey(value?.lastCheckInDate) && compareDateKeys(value.lastCheckInDate, todayKey) <= 0
-      ? value.lastCheckInDate
-      : null;
-  if (verifiedLastCheckInDate && !completedDates.includes(verifiedLastCheckInDate)) {
-    completedDates = normalizeDates([...completedDates, verifiedLastCheckInDate], todayKey);
-  }
-  return deriveCheckInStateFromDates({
-    completedDates,
+export function reconcileCheckInHistory(value, todayKey, userId = null) {
+  const resolvedUserId = userId || value?.userId || "guest";
+  const legacyDates = normalizeDates(
+    [
+      ...(Array.isArray(value?.completedDates) ? value.completedDates : []),
+      ...(isDateKey(value?.lastCheckInDate) ? [value.lastCheckInDate] : []),
+      ...(isDateKey(value?.lastCheckInDay) ? [value.lastCheckInDay] : []),
+    ],
+    todayKey,
+  );
+  const eventHistory = normalizeCheckInEvents(value?.checkInEvents, resolvedUserId, todayKey);
+  const events = normalizeCheckInEvents(
+    [...eventHistory, ...eventsFromDates(legacyDates, resolvedUserId)],
+    resolvedUserId,
+    todayKey,
+  );
+
+  return deriveCheckInStateFromEvents({
+    checkInEvents: events,
     todayKey,
     storedLongestStreak: value?.longestStreak,
+    storedLifetimeCheckIns: value?.lifetimeCheckIns,
+    challengeStartDay: value?.challengeStartDay || value?.cycleStartedAt || null,
+    completedThirtyDays: Boolean(value?.completedThirtyDays),
   });
 }
 
 export function deriveChallengeMetrics(state, todayKey, maxVisibleDays = MAX_VISIBLE_DAYS) {
-  const checkedInToday = state.completedDates.includes(todayKey);
-  const challengeProgress = Math.min(state.currentStreak, maxVisibleDays);
-  const challengeDay =
-    state.currentStreak >= maxVisibleDays
-      ? maxVisibleDays
-      : checkedInToday
-        ? Math.max(1, state.currentStreak)
-        : Math.min(maxVisibleDays, state.currentStreak + 1);
-  return { checkedInToday, challengeProgress, challengeDay };
+  const completedDates = normalizeDates(
+    state.completedDates ||
+      normalizeCheckInEvents(state.checkInEvents, state.userId, todayKey).map((event) => event.eligibleDay),
+    todayKey,
+  );
+  const checkedInToday = completedDates.includes(todayKey);
+  const challengeDay = Math.max(0, Math.min(maxVisibleDays, Number(state.challengeCurrentDay || 0)));
+  const challengeProgress = Math.max(0, Math.min(maxVisibleDays, Number(state.completedCheckInDays || 0)));
+
+  const challengeStartDay = isDateKey(state.challengeStartDay) ? state.challengeStartDay : null;
+  const challengeEndDay = isDateKey(state.challengeEndDay)
+    ? state.challengeEndDay
+    : challengeStartDay
+      ? addLocalDays(challengeStartDay, maxVisibleDays - 1)
+      : null;
+  const completedDateSet = new Set(completedDates);
+
+  const challengeDots = Array.from({ length: maxVisibleDays }).map((_, index) => {
+    const dateKey = challengeStartDay ? addLocalDays(challengeStartDay, index) : null;
+    const completed = Boolean(dateKey && completedDateSet.has(dateKey));
+    const current =
+      Boolean(dateKey) &&
+      compareDateKeys(dateKey, todayKey) === 0 &&
+      state.challengeStatus !== "not_started";
+    const future = Boolean(dateKey && compareDateKeys(dateKey, todayKey) > 0);
+    const outsideWindow = Boolean(challengeEndDay && dateKey && compareDateKeys(dateKey, challengeEndDay) > 0);
+
+    return {
+      dayNumber: index + 1,
+      dateKey,
+      completed,
+      current: current && !completed,
+      future: future || outsideWindow || !challengeStartDay,
+    };
+  });
+
+  return { checkedInToday, challengeProgress, challengeDay, challengeDots };
 }

--- a/src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInPersistence.js
+++ b/src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInPersistence.js
@@ -1,16 +1,22 @@
-import { getLocalDateKey } from "../../../../../lib/challenge-schedule.js";
+import { getEligibleDayKey } from "../../../../../lib/challenge-schedule.js";
 import { higherPriorityBubble } from "./dailyCheckInBubbles.js";
-import { normalizeDates } from "./dailyCheckInEngine.js";
+import { normalizeCheckInEvents } from "./dailyCheckInEngine.js";
 import { createEmptyState, normalizeState, normalizeUserId } from "./dailyCheckInState.js";
 
 export const LEGACY_KEY = "clara_daily_check_in_v1";
 export const UPDATE_EVENT = "clara:daily-check-in-updated";
-const STORAGE_PREFIX = "clara_daily_check_in_v2:";
+const V2_STORAGE_PREFIX = "clara_daily_check_in_v2:";
+const STORAGE_PREFIX = "clara_daily_check_in_v3:";
 const MIGRATION_OWNER_KEY = "clara_daily_check_in_v1_migrated_to";
+const V3_MIGRATION_PREFIX = "clara_daily_check_in_v3_migrated:";
 const memoryStateByUser = new Map();
 
 export function storageKey(userId) {
   return `${STORAGE_PREFIX}${normalizeUserId(userId)}`;
+}
+
+export function legacyStorageKey(userId) {
+  return `${V2_STORAGE_PREFIX}${normalizeUserId(userId)}`;
 }
 
 export function loadState(userId, todayKey) {
@@ -22,42 +28,66 @@ export function loadState(userId, todayKey) {
     return normalized;
   }
 
+  const migrated = migrateV2State(resolvedUserId, todayKey) || migrateLegacyState(resolvedUserId, todayKey);
+  if (migrated) return migrated;
+
   const memoryState = memoryStateByUser.get(resolvedUserId);
   if (memoryState) return normalizeState(memoryState, resolvedUserId, todayKey);
-
-  const migrated = migrateLegacyState(resolvedUserId, todayKey);
-  if (migrated) return migrated;
 
   const emptyState = createEmptyState(resolvedUserId);
   memoryStateByUser.set(resolvedUserId, emptyState);
   return emptyState;
 }
 
-export function writeState(userId, value, reason, todayKey = getLocalDateKey()) {
+export function writeState(userId, value, reason, todayKey = getEligibleDayKey(), expectedEvent = null) {
   const resolvedUserId = normalizeUserId(userId);
+  const previousState = loadPreviousValidState(resolvedUserId, todayKey);
   const state = normalizeState(value, resolvedUserId, todayKey);
-  const persisted = safeSet(storageKey(resolvedUserId), JSON.stringify(state));
+  const serialized = JSON.stringify(state);
+  const persisted = safeSet(storageKey(resolvedUserId), serialized);
 
   if (!persisted) {
     console.error("[CLARA Daily Check-In] Local persistence failed.", { reason });
-    return { ok: false, state };
+    return { ok: false, state: previousState || state };
   }
 
-  memoryStateByUser.set(resolvedUserId, state);
-  if (typeof window !== "undefined") {
-    try {
-      window.dispatchEvent(
-        new CustomEvent(UPDATE_EVENT, {
-          detail: { userId: resolvedUserId, state, reason },
-        }),
-      );
-    } catch {
-      console.warn("[CLARA Daily Check-In] Local update notification failed.", {
-        reason,
-      });
-    }
+  const verified = safeParse(safeGet(storageKey(resolvedUserId)));
+  const verifiedState = verified ? normalizeState(verified, resolvedUserId, todayKey) : null;
+  const expectedEventVerified = !expectedEvent
+    || verifiedState?.checkInEvents?.some(
+      (event) =>
+        event.eventId === expectedEvent.eventId &&
+        event.eligibleDay === expectedEvent.eligibleDay,
+    );
+
+  if (!verifiedState || !expectedEventVerified) {
+    console.error("[CLARA Daily Check-In] Local persistence read-back verification failed.", {
+      reason,
+    });
+    return { ok: false, state: previousState || state };
   }
-  return { ok: true, state };
+
+  memoryStateByUser.set(resolvedUserId, verifiedState);
+  dispatchUpdate(resolvedUserId, verifiedState, reason);
+  return { ok: true, state: verifiedState };
+}
+
+function loadPreviousValidState(userId, todayKey) {
+  const stored = safeParse(safeGet(storageKey(userId)));
+  return stored ? normalizeState(stored, userId, todayKey) : memoryStateByUser.get(userId) || null;
+}
+
+export function clearDailyCheckInState(userId) {
+  const resolvedUserId = normalizeUserId(userId);
+  safeRemove(storageKey(resolvedUserId));
+  safeRemove(legacyStorageKey(resolvedUserId));
+  safeRemove(LEGACY_KEY);
+  safeRemove(MIGRATION_OWNER_KEY);
+  safeRemove(`${V3_MIGRATION_PREFIX}${resolvedUserId}`);
+  memoryStateByUser.delete(resolvedUserId);
+  const emptyState = createEmptyState(resolvedUserId);
+  dispatchUpdate(resolvedUserId, emptyState, "reset");
+  return emptyState;
 }
 
 export function migrateSessionIdentityState(sourceUserId, destinationUserId, todayKey) {
@@ -69,26 +99,25 @@ export function migrateSessionIdentityState(sourceUserId, destinationUserId, tod
     return { ok: true, migrated: false, state: destinationState };
   }
 
-  const sourceRaw = safeParse(safeGet(storageKey(sourceId)));
+  const sourceRaw = safeParse(safeGet(storageKey(sourceId))) || safeParse(safeGet(legacyStorageKey(sourceId)));
   if (!sourceRaw) {
     return { ok: true, migrated: false, state: destinationState };
   }
 
   const sourceState = normalizeState(sourceRaw, sourceId, todayKey);
-  const completedDates = normalizeDates(
-    [...destinationState.completedDates, ...sourceState.completedDates],
+  const checkInEvents = normalizeCheckInEvents(
+    [...destinationState.checkInEvents, ...sourceState.checkInEvents],
+    destinationId,
     todayKey,
   );
   const mergedState = normalizeState(
     {
       ...destinationState,
-      completedDates,
-      longestStreak: Math.max(
-        destinationState.longestStreak,
-        sourceState.longestStreak,
-      ),
+      checkInEvents,
+      challengeStartDay: destinationState.challengeStartDay || sourceState.challengeStartDay,
+      longestStreak: Math.max(destinationState.longestStreak, sourceState.longestStreak),
       lifetimeCheckIns: Math.max(
-        completedDates.length,
+        checkInEvents.length,
         destinationState.lifetimeCheckIns,
         sourceState.lifetimeCheckIns,
       ),
@@ -97,8 +126,8 @@ export function migrateSessionIdentityState(sourceUserId, destinationUserId, tod
       completedThirtyDaysAt:
         destinationState.completedThirtyDaysAt || sourceState.completedThirtyDaysAt,
       lastResetAt: latestIso(destinationState.lastResetAt, sourceState.lastResetAt),
-      lastResetForDate:
-        destinationState.lastResetForDate || sourceState.lastResetForDate,
+      lastResetForDay:
+        destinationState.lastResetForDay || sourceState.lastResetForDay,
       pendingBubble: higherPriorityBubble(
         destinationState.pendingBubble,
         sourceState.pendingBubble,
@@ -109,23 +138,49 @@ export function migrateSessionIdentityState(sourceUserId, destinationUserId, tod
     todayKey,
   );
 
-  const writeResult = writeState(
-    destinationId,
-    mergedState,
-    "identity_migration",
-    todayKey,
-  );
+  const writeResult = writeState(destinationId, mergedState, "identity_migration", todayKey);
   if (!writeResult.ok) {
     return { ok: false, migrated: false, state: destinationState };
   }
 
   if (!safeRemove(storageKey(sourceId))) {
     console.error("[CLARA Daily Check-In] Temporary identity cleanup failed.");
-  } else {
-    memoryStateByUser.delete(sourceId);
   }
+  safeRemove(legacyStorageKey(sourceId));
+  memoryStateByUser.delete(sourceId);
 
   return { ok: true, migrated: true, state: writeResult.state };
+}
+
+function migrateV2State(userId, todayKey) {
+  if (safeGet(`${V3_MIGRATION_PREFIX}${userId}`) && safeGet(storageKey(userId))) return null;
+  const v2State = safeParse(safeGet(legacyStorageKey(userId)));
+  if (!v2State) return null;
+
+  const migratedState = normalizeState(
+    {
+      ...v2State,
+      version: 3,
+      userId,
+      checkInEvents: [
+        ...(Array.isArray(v2State.checkInEvents) ? v2State.checkInEvents : []),
+      ],
+      challengeStartDay:
+        v2State.challengeStartDay ||
+        v2State.cycleStartedAt ||
+        v2State.lastCheckInDay ||
+        v2State.lastCheckInDate ||
+        null,
+      updatedAt: new Date().toISOString(),
+    },
+    userId,
+    todayKey,
+  );
+
+  const writeResult = writeState(userId, migratedState, "v2_migration", todayKey);
+  if (!writeResult.ok) return migratedState;
+  safeSet(`${V3_MIGRATION_PREFIX}${userId}`, new Date().toISOString());
+  return writeResult.state;
 }
 
 function migrateLegacyState(userId, todayKey) {
@@ -158,6 +213,21 @@ function migrateLegacyState(userId, todayKey) {
   if (!writeResult.ok) return migratedState;
   safeSet(MIGRATION_OWNER_KEY, userId);
   return writeResult.state;
+}
+
+function dispatchUpdate(userId, state, reason) {
+  if (typeof window === "undefined") return;
+  try {
+    window.dispatchEvent(
+      new CustomEvent(UPDATE_EVENT, {
+        detail: { userId, state, reason },
+      }),
+    );
+  } catch {
+    console.warn("[CLARA Daily Check-In] Local update notification failed.", {
+      reason,
+    });
+  }
 }
 
 function latestIso(left, right) {

--- a/src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInState.js
+++ b/src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInState.js
@@ -1,9 +1,11 @@
 import {
   getChallengeTimeZone,
   getEligibleDayBoundaryHour,
-  isRealDateKey,
+  isValidDateKey,
 } from "../../../../../lib/challenge-schedule.js";
 import {
+  createDailyCheckInEvent,
+  deriveChallengeState,
   reconcileCheckInHistory,
 } from "./dailyCheckInEngine.js";
 import { normalizeBubble } from "./dailyCheckInBubbles.js";
@@ -32,11 +34,10 @@ export function createEmptyState(userId) {
     streakStatus: "not_started",
 
     checkInEvents: [],
-
     completedDates: [],
+
     completedThirtyDays: false,
     completedThirtyDaysAt: null,
-
     lastResetAt: null,
     lastResetForDay: null,
     lastResetForDate: null,
@@ -47,52 +48,51 @@ export function createEmptyState(userId) {
 
 export function createSimulationState(userId, todayKey, completedToday = false) {
   const state = createEmptyState(userId);
-  if (!completedToday) {
-    return {
-      ...state,
-      challengeStartDay: todayKey,
-      cycleStartedAt: todayKey,
-      challengeCurrentDay: 1,
-      challengeEndDay: todayKey,
-      challengeStatus: "active",
-    };
-  }
-
+  const checkInEvents = completedToday
+    ? [createDailyCheckInEvent({ userId: normalizeUserId(userId), eligibleDay: todayKey })]
+    : [];
   return normalizeState(
     {
       ...state,
       challengeStartDay: todayKey,
       cycleStartedAt: todayKey,
-      checkInEvents: [
-        {
-          eventId: `daily_check_in:${normalizeUserId(userId)}:${todayKey}`,
-          userId: normalizeUserId(userId),
-          eventType: "daily_check_in",
-          eligibleDay: todayKey,
-          clientOccurredAt: new Date().toISOString(),
-          timezone: getChallengeTimeZone(),
-          source: "daily_check_in_card_flip",
-          createdAt: new Date().toISOString(),
-        },
-      ],
+      checkInEvents,
     },
     userId,
     todayKey,
   );
 }
 
+function resolveChallengeStart(value, history) {
+  if (isValidDateKey(value?.challengeStartDay)) return value.challengeStartDay;
+  if (isValidDateKey(value?.cycleStartedAt)) return value.cycleStartedAt;
+  if (Boolean(value?.completedThirtyDays) && history.completedDates.length >= 30) {
+    return history.completedDates[Math.max(0, history.completedDates.length - 30)];
+  }
+  if (isValidDateKey(value?.lastCheckInDay)) return value.lastCheckInDay;
+  if (isValidDateKey(value?.lastCheckInDate)) return value.lastCheckInDate;
+  return null;
+}
+
 export function normalizeState(value, userId, todayKey) {
   const resolvedUserId = normalizeUserId(userId || value?.userId);
   const history = reconcileCheckInHistory(value || {}, todayKey, resolvedUserId);
-  const storedLifetime = Number.isFinite(Number(value?.lifetimeCheckIns))
-    ? Math.max(0, Math.floor(Number(value.lifetimeCheckIns)))
-    : 0;
-  const completedThirtyDays = Boolean(value?.completedThirtyDays) || history.completedThirtyDays;
+  const challengeStartDay = resolveChallengeStart(value || {}, history);
+  const challenge = deriveChallengeState({
+    state: {
+      ...(value || {}),
+      challengeStartDay,
+      completedDates: history.completedDates,
+    },
+    todayKey,
+  });
+  const completedThirtyDays = Boolean(value?.completedThirtyDays) || challenge.completedThirtyDays;
+  const nowIso = new Date().toISOString();
   const completedThirtyDaysAt =
     typeof value?.completedThirtyDaysAt === "string"
       ? value.completedThirtyDaysAt
-      : completedThirtyDays && history.challengeStatus === "completed"
-        ? new Date().toISOString()
+      : completedThirtyDays
+        ? nowIso
         : null;
   const lastResetForDay =
     typeof value?.lastResetForDay === "string"
@@ -104,16 +104,17 @@ export function normalizeState(value, userId, todayKey) {
   return {
     ...createEmptyState(resolvedUserId),
     userId: resolvedUserId,
-    challengeStartDay: isRealDateKey(history.challengeStartDay) ? history.challengeStartDay : null,
-    cycleStartedAt: isRealDateKey(history.challengeStartDay) ? history.challengeStartDay : null,
-    challengeCurrentDay: history.challengeCurrentDay,
-    challengeEndDay: isRealDateKey(history.challengeEndDay) ? history.challengeEndDay : null,
-    challengeStatus: history.challengeStatus,
-    completedCheckInDays: history.completedCheckInDays,
+
+    challengeStartDay: challenge.challengeStartDay,
+    cycleStartedAt: challenge.challengeStartDay,
+    challengeCurrentDay: challenge.challengeCurrentDay,
+    challengeEndDay: challenge.challengeEndDay,
+    challengeStatus: challenge.challengeStatus,
+    completedCheckInDays: challenge.completedCheckInDays,
 
     currentStreak: history.currentStreak,
     longestStreak: history.longestStreak,
-    lifetimeCheckIns: Math.max(history.lifetimeCheckIns, storedLifetime),
+    lifetimeCheckIns: history.lifetimeCheckIns,
     lastCheckInDay: history.lastCheckInDay,
     lastCheckInDate: history.lastCheckInDay,
     streakStatus:

--- a/src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInState.js
+++ b/src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInState.js
@@ -1,23 +1,43 @@
-import { getChallengeTimeZone } from "../../../../../lib/challenge-schedule.js";
-import { reconcileCheckInHistory } from "./dailyCheckInEngine.js";
+import {
+  getChallengeTimeZone,
+  getEligibleDayBoundaryHour,
+  isRealDateKey,
+} from "../../../../../lib/challenge-schedule.js";
+import {
+  reconcileCheckInHistory,
+} from "./dailyCheckInEngine.js";
 import { normalizeBubble } from "./dailyCheckInBubbles.js";
 
 export const normalizeUserId = (userId) => String(userId || "").trim() || "guest";
 
 export function createEmptyState(userId) {
   return {
-    version: 2,
+    version: 3,
     userId: normalizeUserId(userId),
     timezone: getChallengeTimeZone(),
+    eligibleDayBoundaryHour: getEligibleDayBoundaryHour(),
+
+    challengeStartDay: null,
+    challengeCurrentDay: 0,
+    challengeEndDay: null,
+    challengeStatus: "not_started",
+    completedCheckInDays: 0,
+
     currentStreak: 0,
     longestStreak: 0,
     lifetimeCheckIns: 0,
-    cycleStartedAt: null,
+    lastCheckInDay: null,
     lastCheckInDate: null,
+    streakStatus: "not_started",
+
+    checkInEvents: [],
+
     completedDates: [],
     completedThirtyDays: false,
     completedThirtyDaysAt: null,
+
     lastResetAt: null,
+    lastResetForDay: null,
     lastResetForDate: null,
     pendingBubble: null,
     updatedAt: null,
@@ -26,38 +46,87 @@ export function createEmptyState(userId) {
 
 export function createSimulationState(userId, todayKey, completedToday = false) {
   const state = createEmptyState(userId);
-  if (!completedToday) return state;
-  return {
-    ...state,
-    currentStreak: 1,
-    longestStreak: 1,
-    lifetimeCheckIns: 1,
-    cycleStartedAt: todayKey,
-    lastCheckInDate: todayKey,
-    completedDates: [todayKey],
-  };
+  if (!completedToday) {
+    return {
+      ...state,
+      challengeStartDay: todayKey,
+      challengeCurrentDay: 1,
+      challengeEndDay: todayKey,
+      challengeStatus: "active",
+    };
+  }
+
+  return normalizeState(
+    {
+      ...state,
+      challengeStartDay: todayKey,
+      checkInEvents: [
+        {
+          eventId: `daily_check_in:${normalizeUserId(userId)}:${todayKey}`,
+          userId: normalizeUserId(userId),
+          eventType: "daily_check_in",
+          eligibleDay: todayKey,
+          clientOccurredAt: new Date().toISOString(),
+          timezone: getChallengeTimeZone(),
+          source: "daily_check_in_card_flip",
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    },
+    userId,
+    todayKey,
+  );
 }
 
 export function normalizeState(value, userId, todayKey) {
-  const history = reconcileCheckInHistory(value, todayKey);
+  const resolvedUserId = normalizeUserId(userId || value?.userId);
+  const history = reconcileCheckInHistory(value || {}, todayKey, resolvedUserId);
   const storedLifetime = Number.isFinite(Number(value?.lifetimeCheckIns))
     ? Math.max(0, Math.floor(Number(value.lifetimeCheckIns)))
     : 0;
+  const completedThirtyDays = Boolean(value?.completedThirtyDays) || history.completedThirtyDays;
+  const completedThirtyDaysAt =
+    typeof value?.completedThirtyDaysAt === "string"
+      ? value.completedThirtyDaysAt
+      : completedThirtyDays && history.challengeStatus === "completed"
+        ? new Date().toISOString()
+        : null;
+  const lastResetForDay =
+    typeof value?.lastResetForDay === "string"
+      ? value.lastResetForDay
+      : typeof value?.lastResetForDate === "string"
+        ? value.lastResetForDate
+        : null;
 
   return {
-    ...createEmptyState(userId),
+    ...createEmptyState(resolvedUserId),
+    userId: resolvedUserId,
+    challengeStartDay: isRealDateKey(history.challengeStartDay) ? history.challengeStartDay : null,
+    challengeCurrentDay: history.challengeCurrentDay,
+    challengeEndDay: isRealDateKey(history.challengeEndDay) ? history.challengeEndDay : null,
+    challengeStatus: history.challengeStatus,
+    completedCheckInDays: history.completedCheckInDays,
+
     currentStreak: history.currentStreak,
     longestStreak: history.longestStreak,
-    lifetimeCheckIns: Math.max(history.completedDates.length, storedLifetime),
-    cycleStartedAt: history.cycleStartedAt,
-    lastCheckInDate: history.lastCheckInDate,
+    lifetimeCheckIns: Math.max(history.lifetimeCheckIns, storedLifetime),
+    lastCheckInDay: history.lastCheckInDay,
+    lastCheckInDate: history.lastCheckInDay,
+    streakStatus:
+      history.currentStreak > 0
+        ? "active"
+        : history.lastCheckInDay
+          ? "reset"
+          : "not_started",
+
+    checkInEvents: history.checkInEvents,
     completedDates: history.completedDates,
-    completedThirtyDays: Boolean(value?.completedThirtyDays) || history.longestStreak >= 30,
-    completedThirtyDaysAt:
-      typeof value?.completedThirtyDaysAt === "string" ? value.completedThirtyDaysAt : null,
+
+    completedThirtyDays,
+    completedThirtyDaysAt,
     lastResetAt: typeof value?.lastResetAt === "string" ? value.lastResetAt : null,
-    lastResetForDate:
-      typeof value?.lastResetForDate === "string" ? value.lastResetForDate : null,
+    lastResetForDay,
+    lastResetForDate: lastResetForDay,
     pendingBubble: normalizeBubble(value?.pendingBubble),
     updatedAt: typeof value?.updatedAt === "string" ? value.updatedAt : null,
   };

--- a/src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInState.js
+++ b/src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInState.js
@@ -26,6 +26,7 @@ export function createEmptyState(userId) {
     currentStreak: 0,
     longestStreak: 0,
     lifetimeCheckIns: 0,
+    cycleStartedAt: null,
     lastCheckInDay: null,
     lastCheckInDate: null,
     streakStatus: "not_started",
@@ -50,6 +51,7 @@ export function createSimulationState(userId, todayKey, completedToday = false) 
     return {
       ...state,
       challengeStartDay: todayKey,
+      cycleStartedAt: todayKey,
       challengeCurrentDay: 1,
       challengeEndDay: todayKey,
       challengeStatus: "active",
@@ -60,6 +62,7 @@ export function createSimulationState(userId, todayKey, completedToday = false) 
     {
       ...state,
       challengeStartDay: todayKey,
+      cycleStartedAt: todayKey,
       checkInEvents: [
         {
           eventId: `daily_check_in:${normalizeUserId(userId)}:${todayKey}`,
@@ -102,6 +105,7 @@ export function normalizeState(value, userId, todayKey) {
     ...createEmptyState(resolvedUserId),
     userId: resolvedUserId,
     challengeStartDay: isRealDateKey(history.challengeStartDay) ? history.challengeStartDay : null,
+    cycleStartedAt: isRealDateKey(history.challengeStartDay) ? history.challengeStartDay : null,
     challengeCurrentDay: history.challengeCurrentDay,
     challengeEndDay: isRealDateKey(history.challengeEndDay) ? history.challengeEndDay : null,
     challengeStatus: history.challengeStatus,

--- a/src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInValidation.js
+++ b/src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInValidation.js
@@ -1,23 +1,23 @@
-import { addLocalDays, getLocalDateKey } from "../../../../../lib/challenge-schedule.js";
+import { addLocalDays, getEligibleDayKey } from "../../../../../lib/challenge-schedule.js";
 import { createBubble, higherPriorityBubble } from "./dailyCheckInBubbles.js";
 import { calculateStreakEndingAtDate } from "./dailyCheckInEngine.js";
 import { normalizeState } from "./dailyCheckInState.js";
 
 export function validateState(value, userId, todayKey) {
   const state = normalizeState(value, userId, todayKey);
-  const latestCompletedDate = state.lastCheckInDate;
-  if (!latestCompletedDate) return { state, changed: false, reason: "validation" };
+  const latestCompletedDay = state.lastCheckInDay;
+  if (!latestCompletedDay) return { state, changed: false, reason: "validation" };
 
   const yesterdayKey = addLocalDays(todayKey, -1);
   if (state.completedDates.includes(todayKey) || state.completedDates.includes(yesterdayKey)) {
     return { state, changed: false, reason: "validation" };
   }
 
-  if (state.lastResetForDate === latestCompletedDate) {
+  if (state.lastResetForDay === latestCompletedDay) {
     return { state, changed: false, reason: "validation" };
   }
 
-  const previousStreak = calculateStreakEndingAtDate(state.completedDates, latestCompletedDate);
+  const previousStreak = calculateStreakEndingAtDate(state.completedDates, latestCompletedDay);
   const resetBubble = previousStreak > 0
     ? createBubble("streak_reset", previousStreak, todayKey)
     : null;
@@ -31,7 +31,8 @@ export function validateState(value, userId, todayKey) {
         ...state,
         longestStreak: Math.max(state.longestStreak, previousStreak),
         lastResetAt: nowIso,
-        lastResetForDate: latestCompletedDate,
+        lastResetForDay: latestCompletedDay,
+        lastResetForDate: latestCompletedDay,
         pendingBubble: higherPriorityBubble(state.pendingBubble, resetBubble),
         updatedAt: nowIso,
       },
@@ -41,7 +42,10 @@ export function validateState(value, userId, todayKey) {
   };
 }
 
-export function millisecondsUntilNextManilaMidnight(now = new Date()) {
-  const tomorrowKey = addLocalDays(getLocalDateKey(now), 1);
-  return Math.max(1000, Date.parse(`${tomorrowKey}T00:00:00+08:00`) - now.getTime() + 1000);
+export function millisecondsUntilNextEligibleDay(now = new Date()) {
+  const currentEligibleDay = getEligibleDayKey(now);
+  const nextEligibleDay = addLocalDays(currentEligibleDay, 1);
+  return Math.max(1000, Date.parse(`${nextEligibleDay}T06:00:00+08:00`) - now.getTime() + 1000);
 }
+
+export const millisecondsUntilNextManilaMidnight = millisecondsUntilNextEligibleDay;

--- a/src/components/fresh/main-dashboard/daily-tip/logic/useDailyCheckInCore.js
+++ b/src/components/fresh/main-dashboard/daily-tip/logic/useDailyCheckInCore.js
@@ -261,18 +261,19 @@ export default function useDailyCheckIn({
         : createEmptyState(resolvedUserId),
     [checkInState, resolvedUserId, todayKey],
   );
-  const { checkedInToday, challengeProgress, challengeDay, challengeDots } =
+  const { checkedInToday, challengeProgress, challengeDay, challengeDotStates } =
     deriveChallengeMetrics(displayState, todayKey);
 
   return {
     todayKey,
+    eligibleDay: todayKey,
     checkedInToday,
     completedDates: displayState.completedDates,
     checkInEvents: displayState.checkInEvents,
     totalCompleted: challengeProgress,
     challengeProgress,
     challengeDay,
-    challengeDots,
+    challengeDotStates,
     challengeStatus: displayState.challengeStatus,
     completedCheckInDays: displayState.completedCheckInDays,
     currentStreak: displayState.currentStreak,

--- a/src/components/fresh/main-dashboard/daily-tip/logic/useDailyCheckInCore.js
+++ b/src/components/fresh/main-dashboard/daily-tip/logic/useDailyCheckInCore.js
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "@/context/AuthContext";
-import { getLocalDateKey } from "../../../../../lib/challenge-schedule.js";
+import { getEligibleDayKey } from "../../../../../lib/challenge-schedule.js";
 import { performDailyCheckIn, buildResult } from "./dailyCheckInActions.js";
 import { deriveChallengeMetrics } from "./dailyCheckInEngine.js";
 import {
   LEGACY_KEY,
   UPDATE_EVENT,
+  legacyStorageKey,
   loadState,
   migrateSessionIdentityState,
   storageKey,
@@ -18,7 +19,7 @@ import {
   normalizeUserId,
 } from "./dailyCheckInState.js";
 import {
-  millisecondsUntilNextManilaMidnight,
+  millisecondsUntilNextEligibleDay,
   validateState,
 } from "./dailyCheckInValidation.js";
 
@@ -44,9 +45,9 @@ export default function useDailyCheckIn({
         (identityMatchesAuth &&
           resolvedUserId === "local-dev-user" &&
           profile?.enrollment_source === "local_auth_fallback");
-  const [todayKey, setTodayKey] = useState(() => getLocalDateKey());
+  const [todayKey, setTodayKey] = useState(() => getEligibleDayKey());
   const [checkInState, setCheckInState] = useState(() => {
-    const initialTodayKey = getLocalDateKey();
+    const initialTodayKey = getEligibleDayKey();
     if (simulationMode) return createSimulationState(resolvedUserId, initialTodayKey);
     if (!identityReady) return createEmptyState(resolvedUserId);
     return loadState(resolvedUserId, initialTodayKey);
@@ -57,7 +58,7 @@ export default function useDailyCheckIn({
   );
 
   const validateStreak = useCallback(() => {
-    const freshTodayKey = getLocalDateKey();
+    const freshTodayKey = getEligibleDayKey();
     setTodayKey(freshTodayKey);
 
     if (simulationMode) {
@@ -91,7 +92,7 @@ export default function useDailyCheckIn({
   }, [identityReady, resolvedUserId, simulationMode]);
 
   useEffect(() => {
-    const freshTodayKey = getLocalDateKey();
+    const freshTodayKey = getEligibleDayKey();
     setTodayKey(freshTodayKey);
 
     if (simulationMode) {
@@ -130,13 +131,13 @@ export default function useDailyCheckIn({
 
     if (typeof window === "undefined") return undefined;
 
-    let midnightTimer = null;
-    const scheduleMidnightValidation = () => {
-      if (midnightTimer) window.clearTimeout(midnightTimer);
-      midnightTimer = window.setTimeout(() => {
+    let eligibleDayTimer = null;
+    const scheduleEligibleDayValidation = () => {
+      if (eligibleDayTimer) window.clearTimeout(eligibleDayTimer);
+      eligibleDayTimer = window.setTimeout(() => {
         validateStreak();
-        scheduleMidnightValidation();
-      }, millisecondsUntilNextManilaMidnight());
+        scheduleEligibleDayValidation();
+      }, millisecondsUntilNextEligibleDay());
     };
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") validateStreak();
@@ -145,6 +146,7 @@ export default function useDailyCheckIn({
       if (
         event.key &&
         event.key !== storageKey(resolvedUserId) &&
+        event.key !== legacyStorageKey(resolvedUserId) &&
         event.key !== LEGACY_KEY
       ) {
         return;
@@ -153,21 +155,21 @@ export default function useDailyCheckIn({
     };
     const handleLocalUpdate = (event) => {
       if (normalizeUserId(event?.detail?.userId) !== resolvedUserId) return;
-      const eventTodayKey = getLocalDateKey();
+      const eventTodayKey = getEligibleDayKey();
       setTodayKey(eventTodayKey);
       setCheckInState(
         normalizeState(event.detail.state, resolvedUserId, eventTodayKey),
       );
     };
 
-    scheduleMidnightValidation();
+    scheduleEligibleDayValidation();
     window.addEventListener("focus", validateStreak);
     window.addEventListener("storage", handleStorage);
     window.addEventListener(UPDATE_EVENT, handleLocalUpdate);
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
-      if (midnightTimer) window.clearTimeout(midnightTimer);
+      if (eligibleDayTimer) window.clearTimeout(eligibleDayTimer);
       window.removeEventListener("focus", validateStreak);
       window.removeEventListener("storage", handleStorage);
       window.removeEventListener(UPDATE_EVENT, handleLocalUpdate);
@@ -182,7 +184,7 @@ export default function useDailyCheckIn({
   ]);
 
   const checkInToday = useCallback(() => {
-    const freshTodayKey = getLocalDateKey();
+    const freshTodayKey = getEligibleDayKey();
     setTodayKey(freshTodayKey);
 
     if (simulationMode) {
@@ -191,7 +193,7 @@ export default function useDailyCheckIn({
       return buildResult("completed", nextState);
     }
 
-    if (!identityReady) {
+    if (!identityReady || isTemporaryIdentity) {
       return buildResult(
         "identity_unavailable",
         createEmptyState(resolvedUserId),
@@ -200,7 +202,7 @@ export default function useDailyCheckIn({
 
     if (checkInLockRef.current) {
       const current = normalizeState(checkInState, resolvedUserId, freshTodayKey);
-      const status = current.completedDates.includes(freshTodayKey)
+      const status = current.checkInEvents.some((event) => event.eligibleDay === freshTodayKey)
         ? "already_checked_in"
         : "busy";
       return buildResult(status, current);
@@ -214,8 +216,8 @@ export default function useDailyCheckIn({
         value: validation.state,
         userId: resolvedUserId,
         todayKey: freshTodayKey,
-        persist: (nextState) =>
-          writeState(resolvedUserId, nextState, "check_in", freshTodayKey),
+        persist: (nextState, expectedEvent) =>
+          writeState(resolvedUserId, nextState, "check_in", freshTodayKey, expectedEvent),
       });
 
       if (result.status === "completed" || result.status === "already_checked_in") {
@@ -227,12 +229,12 @@ export default function useDailyCheckIn({
     } finally {
       checkInLockRef.current = false;
     }
-  }, [checkInState, identityReady, resolvedUserId, simulationMode]);
+  }, [checkInState, identityReady, isTemporaryIdentity, resolvedUserId, simulationMode]);
 
   const dismissPendingBubble = useCallback(
     (eventId = null) => {
       if (simulationMode || !identityReady) return;
-      const freshTodayKey = getLocalDateKey();
+      const freshTodayKey = getEligibleDayKey();
       const latestState = loadState(resolvedUserId, freshTodayKey);
       if (!latestState.pendingBubble) return;
       if (eventId && latestState.pendingBubble.id !== eventId) return;
@@ -259,16 +261,20 @@ export default function useDailyCheckIn({
         : createEmptyState(resolvedUserId),
     [checkInState, resolvedUserId, todayKey],
   );
-  const { checkedInToday, challengeProgress, challengeDay } =
+  const { checkedInToday, challengeProgress, challengeDay, challengeDots } =
     deriveChallengeMetrics(displayState, todayKey);
 
   return {
     todayKey,
     checkedInToday,
     completedDates: displayState.completedDates,
+    checkInEvents: displayState.checkInEvents,
     totalCompleted: challengeProgress,
     challengeProgress,
     challengeDay,
+    challengeDots,
+    challengeStatus: displayState.challengeStatus,
+    completedCheckInDays: displayState.completedCheckInDays,
     currentStreak: displayState.currentStreak,
     longestStreak: displayState.longestStreak,
     lifetimeCheckIns: displayState.lifetimeCheckIns,

--- a/src/components/fresh/main-dashboard/daily-tip/ui/DailyTipCard.jsx
+++ b/src/components/fresh/main-dashboard/daily-tip/ui/DailyTipCard.jsx
@@ -39,9 +39,11 @@ export default function DailyTipCard({
   const userId = providedUserId || user?.id || "guest";
   const { tip, hasSeenToday, markSeenToday } = useDailyTip({ simulationMode });
   const {
+    todayKey,
     checkedInToday,
-    challengeProgress,
     challengeDay,
+    challengeDots,
+    challengeStatus,
     currentStreak,
     checkInToday,
   } = useDailyCheckIn({ userId, simulationMode });
@@ -58,9 +60,9 @@ export default function DailyTipCard({
   const cardEyebrow = isGuideMode ? "Daily Money Tip" : "Daily Check-In";
   const cardHeadline = isGuideMode
     ? "Today's money reminder"
-    : currentStreak >= CHECK_IN_DAYS
-      ? "30-Day Goal Complete"
-      : `Day ${challengeDay} of ${CHECK_IN_DAYS}`;
+    : challengeStatus === "completed"
+      ? "30-Day Challenge Complete"
+      : `Day ${Math.max(1, challengeDay || 1)} of ${CHECK_IN_DAYS}`;
   const cardSubtitle = isGuideMode
     ? "Tap this card to learn what CLARA gives you each day."
     : "Tap today to protect your money discipline.";
@@ -98,6 +100,12 @@ export default function DailyTipCard({
     setFlipped(false);
     releaseFlipLock();
   }, [isGuideMode, guideStep]);
+
+  useEffect(() => {
+    setFlipped(false);
+    setShowCelebration(false);
+    releaseFlipLock();
+  }, [todayKey]);
 
   useEffect(() => {
     return () => {
@@ -172,16 +180,29 @@ export default function DailyTipCard({
     isFlippingRef.current = true;
     setIsFlipping(true);
 
-    if (willRevealTip && !checkedInToday) {
-      const checkInResult = checkInToday();
-      if (checkInResult?.status === "completed") {
-        triggerCheckInCelebration(checkInResult.milestoneType);
-      }
+    if (!willRevealTip) {
+      setFlipped(false);
+      flipUnlockTimerRef.current = window.setTimeout(releaseFlipLock, FLIP_UNLOCK_DELAY_MS);
+      return;
     }
 
-    setFlipped((current) => !current);
+    const checkInResult = checkInToday();
+    const mayRevealTip =
+      checkInResult?.status === "completed" ||
+      checkInResult?.status === "already_checked_in";
 
-    if (willRevealTip && !hasSeenToday) {
+    if (!mayRevealTip) {
+      releaseFlipLock();
+      return;
+    }
+
+    if (checkInResult?.status === "completed") {
+      triggerCheckInCelebration(checkInResult.milestoneType);
+    }
+
+    setFlipped(true);
+
+    if (!hasSeenToday) {
       markSeenToday();
     }
 
@@ -332,16 +353,13 @@ export default function DailyTipCard({
 
                 <div className="pt-1">
                   <div className="clara-checkin-grid" aria-hidden="true">
-                    {Array.from({ length: CHECK_IN_DAYS }).map((_, dotIndex) => {
-                      const isDone = dotIndex < challengeProgress;
-                      const isToday =
-                        !checkedInToday &&
-                        challengeProgress < CHECK_IN_DAYS &&
-                        dotIndex === challengeProgress;
+                    {(challengeDots?.length ? challengeDots : Array.from({ length: CHECK_IN_DAYS })).map((dot, dotIndex) => {
+                      const isDone = Boolean(dot?.completed);
+                      const isToday = Boolean(dot?.current);
 
                       return (
                         <span
-                          key={dotIndex}
+                          key={dot?.dateKey || dotIndex}
                           className={`clara-checkin-dot ${isDone ? "clara-checkin-dot--done" : ""} ${
                             isToday ? "clara-checkin-dot--today" : ""
                           }`}

--- a/src/components/fresh/main-dashboard/daily-tip/ui/DailyTipCard.jsx
+++ b/src/components/fresh/main-dashboard/daily-tip/ui/DailyTipCard.jsx
@@ -42,7 +42,7 @@ export default function DailyTipCard({
     todayKey,
     checkedInToday,
     challengeDay,
-    challengeDots,
+    challengeDotStates,
     challengeStatus,
     currentStreak,
     checkInToday,
@@ -353,9 +353,9 @@ export default function DailyTipCard({
 
                 <div className="pt-1">
                   <div className="clara-checkin-grid" aria-hidden="true">
-                    {(challengeDots?.length ? challengeDots : Array.from({ length: CHECK_IN_DAYS })).map((dot, dotIndex) => {
+                    {(challengeDotStates?.length ? challengeDotStates : Array.from({ length: CHECK_IN_DAYS })).map((dot, dotIndex) => {
                       const isDone = Boolean(dot?.completed);
-                      const isToday = Boolean(dot?.current);
+                      const isToday = Boolean(dot?.today);
 
                       return (
                         <span

--- a/src/lib/challenge-schedule.js
+++ b/src/lib/challenge-schedule.js
@@ -24,9 +24,19 @@ export function getChallengeTimeZone() {
   return MANILA_TIME_ZONE;
 }
 
+export function getEligibleDayBoundaryHour() {
+  return UNLOCK_HOUR;
+}
+
 export function getLocalDateKey(date = new Date(), timeZone = MANILA_TIME_ZONE) {
   const parts = partsFor(date, timeZone);
   return `${parts.year}-${parts.month}-${parts.day}`;
+}
+
+export function getEligibleDayKey(date = new Date()) {
+  const parts = partsFor(date, MANILA_TIME_ZONE);
+  const localDateKey = `${parts.year}-${parts.month}-${parts.day}`;
+  return Number(parts.hour || 0) < UNLOCK_HOUR ? addLocalDays(localDateKey, -1) : localDateKey;
 }
 
 function dateKeyToUtcNoon(dateKey) {
@@ -34,13 +44,27 @@ function dateKeyToUtcNoon(dateKey) {
   return Date.UTC(year, month - 1, day, 12, 0, 0, 0);
 }
 
+export function isRealDateKey(value) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return false;
+  const roundTrip = new Date(Date.UTC(year, month - 1, day, 12, 0, 0, 0)).toISOString().slice(0, 10);
+  return roundTrip === value;
+}
+
 export function addLocalDays(dateKey, days) {
+  if (!isRealDateKey(dateKey)) return null;
   const next = new Date(dateKeyToUtcNoon(dateKey) + Number(days || 0) * DAY_MS);
   return next.toISOString().slice(0, 10);
 }
 
 export function compareDateKeys(left, right) {
   return dateKeyToUtcNoon(left) - dateKeyToUtcNoon(right);
+}
+
+export function daysBetweenDateKeys(startDateKey, endDateKey) {
+  if (!isRealDateKey(startDateKey) || !isRealDateKey(endDateKey)) return 0;
+  return Math.floor((dateKeyToUtcNoon(endDateKey) - dateKeyToUtcNoon(startDateKey)) / DAY_MS);
 }
 
 export function getChallengeDayUnlockDate(startDateKey, dayNumber) {
@@ -55,11 +79,8 @@ export function getChallengeDayUnlockLabel(startDateKey, dayNumber) {
 export function getCurrentChallengeDay(startDateKey, now = new Date()) {
   if (!startDateKey) return 0;
 
-  const currentKey = getLocalDateKey(now);
-  const currentParts = partsFor(now);
-  const beforeUnlock = Number(currentParts.hour || 0) < UNLOCK_HOUR;
-  const effectiveDateKey = beforeUnlock ? addLocalDays(currentKey, -1) : currentKey;
-  const diff = Math.floor((dateKeyToUtcNoon(effectiveDateKey) - dateKeyToUtcNoon(startDateKey)) / DAY_MS);
+  const effectiveDateKey = getEligibleDayKey(now);
+  const diff = daysBetweenDateKeys(startDateKey, effectiveDateKey);
   return Math.max(1, Math.min(30, diff + 1));
 }
 
@@ -68,12 +89,8 @@ export function isChallengeDayUnlocked(startDateKey, dayNumber, now = new Date()
   if (Number(dayNumber || 0) <= 1) return true;
 
   const unlockDateKey = getChallengeDayUnlockDate(startDateKey, dayNumber);
-  const currentKey = getLocalDateKey(now);
-  const currentParts = partsFor(now);
-
-  if (compareDateKeys(currentKey, unlockDateKey) > 0) return true;
-  if (compareDateKeys(currentKey, unlockDateKey) < 0) return false;
-  return Number(currentParts.hour || 0) >= UNLOCK_HOUR;
+  const effectiveDateKey = getEligibleDayKey(now);
+  return compareDateKeys(effectiveDateKey, unlockDateKey) >= 0;
 }
 
 export function getNextUnlockAt(startDateKey, currentUnlockedDay) {

--- a/src/lib/challenge-schedule.js
+++ b/src/lib/challenge-schedule.js
@@ -35,25 +35,30 @@ export function getLocalDateKey(date = new Date(), timeZone = MANILA_TIME_ZONE) 
 
 export function getEligibleDayKey(date = new Date()) {
   const parts = partsFor(date, MANILA_TIME_ZONE);
-  const localDateKey = `${parts.year}-${parts.month}-${parts.day}`;
-  return Number(parts.hour || 0) < UNLOCK_HOUR ? addLocalDays(localDateKey, -1) : localDateKey;
+  const calendarKey = `${parts.year}-${parts.month}-${parts.day}`;
+  return Number(parts.hour || 0) < UNLOCK_HOUR ? addLocalDays(calendarKey, -1) : calendarKey;
+}
+
+export function isValidDateKey(value) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return false;
+  const utc = new Date(Date.UTC(year, month - 1, day, 12, 0, 0, 0));
+  return (
+    utc.getUTCFullYear() === year &&
+    utc.getUTCMonth() === month - 1 &&
+    utc.getUTCDate() === day
+  );
 }
 
 function dateKeyToUtcNoon(dateKey) {
+  if (!isValidDateKey(dateKey)) return NaN;
   const [year, month, day] = String(dateKey).split("-").map(Number);
   return Date.UTC(year, month - 1, day, 12, 0, 0, 0);
 }
 
-export function isRealDateKey(value) {
-  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
-  const [year, month, day] = value.split("-").map(Number);
-  if (month < 1 || month > 12 || day < 1 || day > 31) return false;
-  const roundTrip = new Date(Date.UTC(year, month - 1, day, 12, 0, 0, 0)).toISOString().slice(0, 10);
-  return roundTrip === value;
-}
-
 export function addLocalDays(dateKey, days) {
-  if (!isRealDateKey(dateKey)) return null;
+  if (!isValidDateKey(dateKey)) return null;
   const next = new Date(dateKeyToUtcNoon(dateKey) + Number(days || 0) * DAY_MS);
   return next.toISOString().slice(0, 10);
 }
@@ -62,8 +67,8 @@ export function compareDateKeys(left, right) {
   return dateKeyToUtcNoon(left) - dateKeyToUtcNoon(right);
 }
 
-export function daysBetweenDateKeys(startDateKey, endDateKey) {
-  if (!isRealDateKey(startDateKey) || !isRealDateKey(endDateKey)) return 0;
+export function calendarDayDiff(startDateKey, endDateKey) {
+  if (!isValidDateKey(startDateKey) || !isValidDateKey(endDateKey)) return 0;
   return Math.floor((dateKeyToUtcNoon(endDateKey) - dateKeyToUtcNoon(startDateKey)) / DAY_MS);
 }
 
@@ -80,7 +85,7 @@ export function getCurrentChallengeDay(startDateKey, now = new Date()) {
   if (!startDateKey) return 0;
 
   const effectiveDateKey = getEligibleDayKey(now);
-  const diff = daysBetweenDateKeys(startDateKey, effectiveDateKey);
+  const diff = calendarDayDiff(startDateKey, effectiveDateKey);
   return Math.max(1, Math.min(30, diff + 1));
 }
 

--- a/src/lib/challenge-schedule.js
+++ b/src/lib/challenge-schedule.js
@@ -35,41 +35,46 @@ export function getLocalDateKey(date = new Date(), timeZone = MANILA_TIME_ZONE) 
 
 export function getEligibleDayKey(date = new Date()) {
   const parts = partsFor(date, MANILA_TIME_ZONE);
-  const calendarKey = `${parts.year}-${parts.month}-${parts.day}`;
-  return Number(parts.hour || 0) < UNLOCK_HOUR ? addLocalDays(calendarKey, -1) : calendarKey;
+  const dateKey = `${parts.year}-${parts.month}-${parts.day}`;
+  return Number(parts.hour || 0) < UNLOCK_HOUR ? addLocalDays(dateKey, -1) : dateKey;
 }
 
 export function isValidDateKey(value) {
   if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
   const [year, month, day] = value.split("-").map(Number);
   if (month < 1 || month > 12 || day < 1 || day > 31) return false;
-  const utc = new Date(Date.UTC(year, month - 1, day, 12, 0, 0, 0));
+  const parsed = new Date(Date.UTC(year, month - 1, day, 12, 0, 0, 0));
   return (
-    utc.getUTCFullYear() === year &&
-    utc.getUTCMonth() === month - 1 &&
-    utc.getUTCDate() === day
+    parsed.getUTCFullYear() === year &&
+    parsed.getUTCMonth() === month - 1 &&
+    parsed.getUTCDate() === day
   );
 }
 
 function dateKeyToUtcNoon(dateKey) {
-  if (!isValidDateKey(dateKey)) return NaN;
+  if (!isValidDateKey(dateKey)) return Number.NaN;
   const [year, month, day] = String(dateKey).split("-").map(Number);
   return Date.UTC(year, month - 1, day, 12, 0, 0, 0);
 }
 
 export function addLocalDays(dateKey, days) {
-  if (!isValidDateKey(dateKey)) return null;
-  const next = new Date(dateKeyToUtcNoon(dateKey) + Number(days || 0) * DAY_MS);
+  const base = dateKeyToUtcNoon(dateKey);
+  if (!Number.isFinite(base)) return null;
+  const next = new Date(base + Number(days || 0) * DAY_MS);
   return next.toISOString().slice(0, 10);
 }
 
 export function compareDateKeys(left, right) {
-  return dateKeyToUtcNoon(left) - dateKeyToUtcNoon(right);
+  const leftTime = dateKeyToUtcNoon(left);
+  const rightTime = dateKeyToUtcNoon(right);
+  if (!Number.isFinite(leftTime) || !Number.isFinite(rightTime)) return Number.NaN;
+  return leftTime - rightTime;
 }
 
-export function calendarDayDiff(startDateKey, endDateKey) {
-  if (!isValidDateKey(startDateKey) || !isValidDateKey(endDateKey)) return 0;
-  return Math.floor((dateKeyToUtcNoon(endDateKey) - dateKeyToUtcNoon(startDateKey)) / DAY_MS);
+export function daysBetweenDateKeys(startDateKey, endDateKey) {
+  const diff = compareDateKeys(startDateKey, endDateKey);
+  if (!Number.isFinite(diff)) return 0;
+  return Math.floor(diff / DAY_MS);
 }
 
 export function getChallengeDayUnlockDate(startDateKey, dayNumber) {
@@ -83,9 +88,8 @@ export function getChallengeDayUnlockLabel(startDateKey, dayNumber) {
 
 export function getCurrentChallengeDay(startDateKey, now = new Date()) {
   if (!startDateKey) return 0;
-
   const effectiveDateKey = getEligibleDayKey(now);
-  const diff = calendarDayDiff(startDateKey, effectiveDateKey);
+  const diff = daysBetweenDateKeys(startDateKey, effectiveDateKey);
   return Math.max(1, Math.min(30, diff + 1));
 }
 

--- a/src/lib/challenge-schedule.js
+++ b/src/lib/challenge-schedule.js
@@ -72,7 +72,7 @@ export function compareDateKeys(left, right) {
 }
 
 export function daysBetweenDateKeys(startDateKey, endDateKey) {
-  const diff = compareDateKeys(startDateKey, endDateKey);
+  const diff = compareDateKeys(endDateKey, startDateKey);
   if (!Number.isFinite(diff)) return 0;
   return Math.floor(diff / DAY_MS);
 }

--- a/src/lib/reset-local-clara-journey.js
+++ b/src/lib/reset-local-clara-journey.js
@@ -18,9 +18,11 @@ import {
   getOrCreateLocalVaultId,
   LEGACY_ACTIVE_LOCAL_VAULT_KEY,
 } from "@/lib/local-user-identity";
+import {
+  clearDailyCheckInState,
+} from "@/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInPersistence";
 
 const LEGACY_LOCAL_IDS = ["local-dev-user", "local-user"];
-const DAILY_CHECK_IN_PREFIX = "clara_daily_check_in_v2:";
 const PROFILE_PREFIX = "clara_local_account_profile_v1:";
 const ENTITLEMENT_PREFIX = "clara_google_play_entitlement_v1:";
 
@@ -69,7 +71,7 @@ function clearScopedLocalStorage(localUserIds) {
   ALWAYS_CLEAR_KEYS.forEach((key) => removeKey(storage, key));
 
   localUserIds.forEach((localUserId) => {
-    removeKey(storage, `${DAILY_CHECK_IN_PREFIX}${localUserId}`);
+    clearDailyCheckInState(localUserId);
     removeKey(storage, `clara_memory_${localUserId}`);
     removeKey(storage, `clara_me_life_setup:${localUserId}`);
     removeKey(storage, `${PROFILE_PREFIX}${localUserId}`);

--- a/tests/daily-check-in.test.mjs
+++ b/tests/daily-check-in.test.mjs
@@ -4,9 +4,19 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
-import { performDailyCheckIn } from "../src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInActions.js";
-import { deriveChallengeMetrics } from "../src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInEngine.js";
 import {
+  getEligibleDayKey,
+  isValidDateKey,
+} from "../src/lib/challenge-schedule.js";
+import { performDailyCheckIn } from "../src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInActions.js";
+import {
+  buildDailyCheckInEventId,
+  createDailyCheckInEvent,
+  deriveChallengeMetrics,
+} from "../src/components/fresh/main-dashboard/daily-tip/logic/dailyCheckInEngine.js";
+import {
+  clearDailyCheckInState,
+  legacyStorageKey,
   loadState,
   migrateSessionIdentityState,
   storageKey,
@@ -24,6 +34,8 @@ class MemoryStorage {
     this.values = new Map();
     this.failWrites = false;
   }
+  get length() { return this.values.size; }
+  key(index) { return [...this.values.keys()][index] || null; }
   getItem(key) { return this.values.has(key) ? this.values.get(key) : null; }
   setItem(key, value) {
     if (this.failWrites) throw new Error("quota");
@@ -42,108 +54,164 @@ globalThis.window = {
   dispatchEvent() {},
 };
 
-function persistedCheckIn(value, userId = "user-1") {
+function event(userId, eligibleDay) {
+  return createDailyCheckInEvent({ userId, eligibleDay, now: new Date(`${eligibleDay}T08:00:00+08:00`) });
+}
+
+function persistedCheckIn(value, userId = "user-1", todayKey = TODAY) {
   return performDailyCheckIn({
     value,
     userId,
-    todayKey: TODAY,
-    persist: (nextState) => writeState(userId, nextState, "test", TODAY),
+    todayKey,
+    persist: (nextState, expectedEvent) => writeState(userId, nextState, "test", todayKey, expectedEvent),
   });
 }
 
-test("existing two-day streak increments to three without reset bubble", () => {
+test("eligible day uses Manila 6 AM boundary", () => {
+  assert.equal(getEligibleDayKey(new Date("2026-07-09T21:59:59.000Z")), "2026-07-09");
+  assert.equal(getEligibleDayKey(new Date("2026-07-09T22:00:00.000Z")), "2026-07-10");
+  assert.equal(getEligibleDayKey(new Date("2026-07-08T18:00:00.000Z")), "2026-07-08");
+});
+
+test("real date validation rejects impossible calendar dates", () => {
+  assert.equal(isValidDateKey("2026-02-31"), false);
+  assert.equal(isValidDateKey("2026-13-10"), false);
+  assert.equal(isValidDateKey("2026-00-04"), false);
+  assert.equal(isValidDateKey("2028-02-29"), true);
+});
+
+test("first confirmed check-in starts day 1 and creates one event", () => {
   localStorage.clear();
-  const result = persistedCheckIn({
-    completedDates: [TWO_DAYS_AGO, YESTERDAY],
-    currentStreak: 2,
-    longestStreak: 2,
-  });
+  const result = persistedCheckIn({}, "first-user");
 
   assert.equal(result.status, "completed");
-  assert.equal(result.state.currentStreak, 3);
-  assert.equal(result.state.completedDates.filter((date) => date === TODAY).length, 1);
-  assert.equal(result.state.lastCheckInDate, TODAY);
-  assert.notEqual(result.state.pendingBubble?.type, "streak_reset");
-  assert.equal(deriveChallengeMetrics(result.state, TODAY).challengeDay, 3);
+  assert.equal(result.state.challengeStartDay, TODAY);
+  assert.equal(result.state.challengeCurrentDay, 1);
+  assert.equal(result.state.completedCheckInDays, 1);
+  assert.equal(result.state.currentStreak, 1);
+  assert.equal(result.state.checkInEvents.length, 1);
+  assert.equal(result.state.checkInEvents[0].eventId, buildDailyCheckInEventId("first-user", TODAY));
 });
 
-test("stale stored currentStreak cannot override completedDates", () => {
-  const state = normalizeState({
-    completedDates: [TWO_DAYS_AGO, YESTERDAY, TODAY],
-    currentStreak: 1,
-  }, "user-2", TODAY);
-  assert.equal(state.currentStreak, 3);
-});
-
-test("stale lastCheckInDate does not break continuation", () => {
-  localStorage.clear();
-  for (const lastCheckInDate of [null, "2026-06-20"]) {
-    const result = persistedCheckIn({
-      completedDates: [YESTERDAY],
-      lastCheckInDate,
-      currentStreak: 1,
-    }, `stale-last-${lastCheckInDate || "null"}`);
-    assert.equal(result.status, "completed");
-    assert.equal(result.state.currentStreak, 2);
-  }
-});
-
-test("same-day check-in remains idempotent", () => {
+test("same eligible day check-in remains idempotent", () => {
   const result = performDailyCheckIn({
-    value: { completedDates: [TODAY], currentStreak: 99 },
+    value: { checkInEvents: [event("user-4", TODAY)], currentStreak: 99 },
     userId: "user-4",
     todayKey: TODAY,
     persist: () => assert.fail("duplicate check-in must not persist"),
   });
   assert.equal(result.status, "already_checked_in");
-  assert.equal(result.state.completedDates.filter((date) => date === TODAY).length, 1);
+  assert.equal(result.state.checkInEvents.filter((item) => item.eligibleDay === TODAY).length, 1);
   assert.equal(result.state.currentStreak, 1);
 });
 
-test("genuine missed day resets active streak once and preserves history", () => {
+test("stale stored currentStreak cannot override event history", () => {
+  const state = normalizeState({
+    checkInEvents: [event("user-2", TWO_DAYS_AGO), event("user-2", YESTERDAY), event("user-2", TODAY)],
+    currentStreak: 1,
+  }, "user-2", TODAY);
+  assert.equal(state.currentStreak, 3);
+});
+
+test("calendar challenge advances even when streak resets", () => {
+  const state = normalizeState({
+    challengeStartDay: TWO_DAYS_AGO,
+    checkInEvents: [event("calendar-user", TWO_DAYS_AGO), event("calendar-user", TODAY)],
+  }, "calendar-user", TODAY);
+
+  assert.equal(state.challengeCurrentDay, 3);
+  assert.equal(state.completedCheckInDays, 2);
+  assert.equal(state.currentStreak, 1);
+  const metrics = deriveChallengeMetrics(state, TODAY);
+  assert.equal(metrics.challengeDay, 3);
+  assert.equal(metrics.challengeDotStates[0].completed, true);
+  assert.equal(metrics.challengeDotStates[1].completed, false);
+  assert.equal(metrics.challengeDotStates[2].completed, true);
+});
+
+test("genuine missed day records reset once and preserves history", () => {
   const initial = {
-    completedDates: ["2026-06-28", "2026-06-29", TWO_DAYS_AGO],
-    currentStreak: 3,
+    challengeStartDay: "2026-06-28",
+    checkInEvents: [
+      event("user-5", "2026-06-28"),
+      event("user-5", "2026-06-29"),
+      event("user-5", TWO_DAYS_AGO),
+    ],
     longestStreak: 5,
     lifetimeCheckIns: 9,
   };
   const first = validateState(initial, "user-5", TODAY);
   assert.equal(first.changed, true);
   assert.equal(first.state.currentStreak, 0);
-  assert.equal(first.state.cycleStartedAt, null);
-  assert.deepEqual(first.state.completedDates, initial.completedDates);
-  assert.equal(first.state.lastCheckInDate, TWO_DAYS_AGO);
+  assert.equal(first.state.challengeCurrentDay, 5);
+  assert.equal(first.state.completedDates.length, 3);
   assert.equal(first.state.longestStreak, 5);
   assert.equal(first.state.lifetimeCheckIns, 9);
   assert.equal(first.state.pendingBubble.type, "streak_reset");
-  assert.ok(first.state.lastResetAt);
 
   const second = validateState(first.state, "user-5", TODAY);
   assert.equal(second.changed, false);
   assert.equal(second.state.pendingBubble.id, first.state.pendingBubble.id);
 });
 
-test("successful persistence restores the same state after reload", () => {
+test("successful v3 persistence restores the same state after reload", () => {
   localStorage.clear();
   const result = persistedCheckIn({
-    completedDates: [TWO_DAYS_AGO, YESTERDAY],
+    challengeStartDay: TWO_DAYS_AGO,
+    checkInEvents: [event("reload-user", TWO_DAYS_AGO), event("reload-user", YESTERDAY)],
   }, "reload-user");
   const reloaded = loadState("reload-user", TODAY);
   assert.equal(reloaded.currentStreak, result.state.currentStreak);
+  assert.equal(reloaded.challengeCurrentDay, 3);
   assert.deepEqual(reloaded.completedDates, result.state.completedDates);
-  assert.equal(reloaded.lastCheckInDate, result.state.lastCheckInDate);
-  assert.equal(
-    deriveChallengeMetrics(reloaded, TODAY).challengeDay,
-    deriveChallengeMetrics(result.state, TODAY).challengeDay,
-  );
+  assert.equal(reloaded.lastCheckInDay, result.state.lastCheckInDay);
 });
 
-test("guest-to-user session migration merges once and removes source after persistence", () => {
+test("persistence failure returns storage_error and does not show success", () => {
   localStorage.clear();
-  assert.equal(writeState("guest", {
-    completedDates: [YESTERDAY],
-    lifetimeCheckIns: 1,
-  }, "seed", TODAY).ok, true);
+  localStorage.failWrites = true;
+  const originalError = console.error;
+  console.error = () => {};
+  try {
+    const result = persistedCheckIn({ checkInEvents: [event("failure-user", YESTERDAY)] }, "failure-user");
+    assert.equal(result.status, "storage_error");
+    assert.equal(result.state.completedDates.includes(TODAY), false);
+    assert.equal(localStorage.getItem(storageKey("failure-user")), null);
+  } finally {
+    console.error = originalError;
+    localStorage.failWrites = false;
+  }
+});
+
+test("reset clears v3, v2, legacy, and memory state", () => {
+  localStorage.clear();
+  writeState("reset-user", { checkInEvents: [event("reset-user", TODAY)] }, "seed", TODAY);
+  localStorage.setItem(legacyStorageKey("reset-user"), JSON.stringify({ completedDates: [YESTERDAY] }));
+  clearDailyCheckInState("reset-user");
+  assert.equal(localStorage.getItem(storageKey("reset-user")), null);
+  assert.equal(localStorage.getItem(legacyStorageKey("reset-user")), null);
+  assert.equal(loadState("reset-user", TODAY).checkInEvents.length, 0);
+});
+
+test("v2 migration preserves valid dates as unique v3 events", () => {
+  localStorage.clear();
+  localStorage.setItem(legacyStorageKey("v2-user"), JSON.stringify({
+    completedDates: [YESTERDAY, YESTERDAY, "2026-02-31", TODAY],
+    cycleStartedAt: YESTERDAY,
+    longestStreak: 8,
+    lifetimeCheckIns: 12,
+  }));
+  const migrated = loadState("v2-user", TODAY);
+  assert.equal(migrated.checkInEvents.length, 2);
+  assert.deepEqual(migrated.completedDates, [YESTERDAY, TODAY]);
+  assert.equal(migrated.longestStreak, 8);
+  assert.equal(migrated.lifetimeCheckIns, 12);
+  assert.equal(localStorage.getItem(legacyStorageKey("v2-user")) !== null, true);
+});
+
+test("guest-to-user session migration merges once and removes source", () => {
+  localStorage.clear();
+  assert.equal(writeState("guest", { checkInEvents: [event("guest", YESTERDAY)] }, "seed", TODAY).ok, true);
 
   const migration = migrateSessionIdentityState("guest", "auth-user", TODAY);
   assert.equal(migration.ok, true);
@@ -156,53 +224,17 @@ test("guest-to-user session migration merges once and removes source after persi
   assert.deepEqual(repeated.state.completedDates, [YESTERDAY]);
 });
 
-test("identity migration merges destination history without adding counters", () => {
-  localStorage.clear();
-  writeState("temporary-user", {
-    completedDates: [TWO_DAYS_AGO, YESTERDAY],
-    currentStreak: 200,
-    longestStreak: 8,
-    lifetimeCheckIns: 12,
-  }, "seed", TODAY);
-  writeState("destination-user", {
-    completedDates: [YESTERDAY, TODAY],
-    currentStreak: 300,
-    longestStreak: 5,
-    lifetimeCheckIns: 10,
-  }, "seed", TODAY);
-
-  const migration = migrateSessionIdentityState(
-    "temporary-user",
-    "destination-user",
-    TODAY,
-  );
-  assert.equal(migration.ok, true);
-  assert.deepEqual(migration.state.completedDates, [TWO_DAYS_AGO, YESTERDAY, TODAY]);
-  assert.equal(migration.state.currentStreak, 3);
-  assert.equal(migration.state.lifetimeCheckIns, 12);
-  assert.equal(migration.state.longestStreak, 8);
-});
-
-test("persistence failure returns storage_error and does not show today as completed", () => {
-  localStorage.clear();
-  localStorage.failWrites = true;
-  const originalError = console.error;
-  console.error = () => {};
-  try {
-    const result = performDailyCheckIn({
-      value: { completedDates: [YESTERDAY] },
-      userId: "failure-user",
-      todayKey: TODAY,
-      persist: (nextState) => writeState("failure-user", nextState, "test", TODAY),
-    });
-    assert.equal(result.status, "storage_error");
-    assert.equal(result.state.completedDates.includes(TODAY), false);
-    assert.equal(deriveChallengeMetrics(result.state, TODAY).checkedInToday, false);
-    assert.equal(localStorage.getItem(storageKey("failure-user")), null);
-  } finally {
-    console.error = originalError;
-    localStorage.failWrites = false;
-  }
+test("challenge completion remains after later streak reset", () => {
+  const state = normalizeState({
+    challengeStartDay: "2026-06-01",
+    completedThirtyDays: true,
+    completedThirtyDaysAt: "2026-06-30T00:00:00.000Z",
+    checkInEvents: [event("complete-user", "2026-06-01")],
+  }, "complete-user", "2026-07-10");
+  assert.equal(state.challengeStatus, "completed");
+  assert.equal(state.challengeCurrentDay, 30);
+  assert.equal(state.currentStreak, 0);
+  assert.equal(state.completedThirtyDays, true);
 });
 
 test("production import resolves through one authoritative engine", async () => {


### PR DESCRIPTION
## Root cause

Daily Check-In challenge progress was coupled to the active `currentStreak`, so `Day X of 30`, progress dots, and streak state could drift or get stuck together. The Daily Check-In flow also used a normal local date/midnight style day key while the 30-day program expects a 6:00 AM Asia/Manila eligible-day boundary for night-shift users.

## Architecture implemented

This PR separates the Daily Check-In system into:

- Calendar-based 30-day challenge progress
- Independent consecutive streak calculation
- Unique local Daily Check-In event history
- 6:00 AM Asia/Manila eligible-day boundary
- Version 3 local Daily Check-In state

## Key changes

- Added `getEligibleDayKey()` in `src/lib/challenge-schedule.js`.
- Added real calendar date validation to reject impossible dates.
- Reworked Daily Check-In state normalization to version 3.
- Added deterministic local check-in events using `daily_check_in:<userId>:<eligibleDay>`.
- Derived current streak, longest streak, lifetime count, and challenge check-ins from unique event history.
- Changed challenge metrics so `Day X of 30` no longer comes from `currentStreak`.
- Changed dots to represent the 30 calendar challenge days, not the first N streak days.
- Updated the card flip flow so front → back can create one persisted check-in, while back → front never creates one.
- Card now flips only after `completed` or `already_checked_in` result.
- Card visually resets to the front when the eligible day changes.
- Added v3 local storage key support while preserving v2/legacy migration paths.
- Added read-back verification for local persistence.
- Added `clearDailyCheckInState(userId)` and routed local journey reset through it so memory cache cannot resurrect reset state.

## Migration

Existing v2 local records are read from `clara_daily_check_in_v2:<userId>` and normalized into v3 state. Existing `completedDates` are preserved as unique local check-in events through normalization/migration. Invalid date strings are rejected by the new real date validator instead of being normalized into different calendar dates. v2 data is not destroyed during migration.

## Safety

- No Supabase or backend migration added.
- No unrelated dashboard redesign added.
- No direct commits to `main`.
- App opening/rendering does not create check-ins.
- Failed writes return `storage_error` and do not display success.
- Existing local history is preserved through migration.
- Guide/sample modes remain isolated from real records.

## Testing

Connector limitation: I pushed the code branch and updated this PR, but I could not run `npm test` or `npm run build` from the GitHub connector session. Please run before merge:

```bash
npm test
npm run build
```

## Related issue

Closes #248
References #247